### PR TITLE
Add support for Bitcoin Core v27.2

### DIFF
--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2021"
 # Enable the same feature in `node` and the version feature here.
 # All minor releases (but only the latest patch release).
 28_0 = ["v28", "node/28_0"]
+27_2 = ["v27", "node/27_2"]
 27_1 = ["v27", "node/27_1"]
 27_0 = ["v27", "node/27_0"]
 26_2 = ["v26", "node/26_2"]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -45,7 +45,8 @@ default = ["28_0"]
 download = ["bitcoin_hashes", "flate2", "tar", "minreq", "zip"]
 
 # We support all minor releases (but only the latest patch release).
-28_0 = ["download", "27_1"]
+28_0 = ["download", "27_2"]
+27_2 = ["download", "27_1"]
 27_1 = ["download", "27_0"]
 27_0 = ["download", "26_2"]
 26_2 = ["download", "26_1"]

--- a/node/src/client_versions.rs
+++ b/node/src/client_versions.rs
@@ -10,7 +10,11 @@
 #[allow(unused_imports)] // Not all users need the json types.
 pub use corepc_client::{client_sync::v28::{Client, AddressType}, types::v28 as types};
 
-#[cfg(all(feature = "27_1", not(feature = "28_0")))]
+#[cfg(all(feature = "27_2", not(feature = "28_0")))]
+#[allow(unused_imports)] // Not all users need the json types.
+pub use corepc_client::{client_sync::v27::{Client, AddressType}, types::v27 as types};
+
+#[cfg(all(feature = "27_1", not(feature = "27_2")))]
 #[allow(unused_imports)] // Not all users need the json types.
 pub use corepc_client::{client_sync::v27::{Client, AddressType}, types::v27 as types};
 

--- a/node/src/versions.rs
+++ b/node/src/versions.rs
@@ -1,7 +1,10 @@
 #[cfg(feature = "28_0")]
 pub const VERSION: &str = "28.0";
 
-#[cfg(all(feature = "27_1", not(feature = "28_0")))]
+#[cfg(all(feature = "27_2", not(feature = "28_0")))]
+pub const VERSION: &str = "27.1";
+
+#[cfg(all(feature = "27_1", not(feature = "27_2")))]
 pub const VERSION: &str = "27.1";
 
 #[cfg(all(feature = "27_0", not(feature = "27_1")))]


### PR DESCRIPTION
Add support for minor release of v27. Nothing much to do except update all the manifest infrastructure and add the version-specific re-exports from `client`.

Close: #3