### PR TITLE
Release tracking PR: Bump versions to 0.5.0

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -105,7 +105,7 @@ checksum = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
 
 [[package]]
 name = "corepc-client"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bitcoin",
  "corepc-types",
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-types"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bitcoin",
  "bitcoin-internals",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -105,7 +105,7 @@ checksum = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
 
 [[package]]
 name = "corepc-client"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bitcoin",
  "corepc-types",
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-types"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bitcoin",
  "bitcoin-internals",

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.5.0 - 2024-12-16
+
+- Add support for Bitcoin Core v27.2
+- Add a bunch more methods to the `Client`
+- Flesh out v17 and v18
+
 # 0.4.0 - 2024-11-14
 
 - Add support for Bitcoin Core v28

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-client"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/corepc"
@@ -22,7 +22,7 @@ client-sync = ["jsonrpc"]
 
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false, features = ["std", "serde"] }
-types = { package = "corepc-types", version = "0.4.0", default-features = false, features = [] }
+types = { package = "corepc-types", version = "0.5.0", default-features = false, features = [] }
 log = "0.4"
 serde = { version = "1.0.103", default-features = false, features = [ "derive", "alloc" ] }
 serde_json = { version = "1.0.117" }

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -50,8 +50,8 @@ TODO = []                       # This is a dirty hack while writing the tests.
 
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false, features = ["std", "serde"] }
-client = { package = "corepc-client", version = "0.4.0", default-features = false, features = ["client-sync"] }
-node = { package = "corepc-node", version = "0.4.0", default-features = false, features = [] }
+client = { package = "corepc-client", version = "0.5.0", default-features = false, features = ["client-sync"] }
+node = { package = "corepc-node", version = "0.5.0", default-features = false, features = [] }
 rand = "0.8.5"
 env_logger = "0.9.0"
 

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.5.0 - 2024-12-16
+
+- Rename `BitcoinD` to `Node`
+- Add support for Bitcoin Core v27.2
+
 # 0.4.0 - 2024-11-14
 
 - Add support for Bitcoin Core v28

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-node"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Riccardo Casatta <riccardo@casatta.it>", "Tobin C. Harding <me@tobin.cc>"]
 license = "MIT"
 repository = "https://github.com/rust-bitcoin/corepc"
@@ -13,7 +13,7 @@ rust-version = "1.63.0"
 exclude = ["tests", "contrib"]
 
 [dependencies]
-corepc-client = { version = "0.4", features = ["client-sync"] }
+corepc-client = { version = "0.5.0", features = ["client-sync"] }
 log = "0.4"
 which = "4.2.5"
 anyhow = "1.0.66"

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -1,7 +1,7 @@
-# Unreleased
+# 0.5.0 - 2024-12-16
 
-- Flesh out v17 and v18.
-- Rename `corepc-node::BitcoinD` to `Node`.
+- Flesh out v17 and v18
+- Re-write docs and verify correctness of status claims
 
 # 0.4.0 - 2024-11-14
 

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-types"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/corepc"


### PR DESCRIPTION
In preparation for releasing all three crates bump the version, add a changlog entry, and update the lock files.

For the record this release of `types` will include fleshed out support in `types` for v17 and v18.
