### PR TITLE
Rename script to use dash

### DIFF
--- a/contrib/run-bitcoind.sh
+++ b/contrib/run-bitcoind.sh
@@ -15,7 +15,7 @@ usage() {
     cat <<EOF
 Usage:
 
-    ./run_bitcoind.sh [COMMAND]
+    ./run-bitcoind.sh [COMMAND]
 
 COMMAND
    - all                      Start all known bitcoind versions.
@@ -215,7 +215,7 @@ run_bitcoind() {
 }
 
 say() {
-    echo "run_bitcoind: $1"
+    echo "run-bitcoind: $1"
 }
 
 err() {


### PR DESCRIPTION
Currently we have one script that uses dashes and one using underscores. Dashes or underscores it doesn't matter, just use one.

Use dashes because it makes me feel like a lisp hacker.