### PR TITLE
Remove minor numbers from docs

### DIFF
--- a/client/src/client_sync/v17/blockchain.rs
+++ b/client/src/client_sync/v17/blockchain.rs
@@ -3,7 +3,7 @@
 //! Macros for implementing JSON-RPC methods on a client.
 //!
 //! Specifically this is methods found under the `== Blockchain ==` section of the
-//! API docs of `bitcoind v0.17.1`.
+//! API docs of Bitcoin Core `v0.17`.
 //!
 //! All macros require `Client` to be in scope.
 //!

--- a/client/src/client_sync/v17/control.rs
+++ b/client/src/client_sync/v17/control.rs
@@ -3,7 +3,7 @@
 //! Macros for implementing JSON-RPC methods on a client.
 //!
 //! Specifically this is methods found under the `== Control ==` section of the
-//! API docs of `bitcoind v0.17.1`.
+//! API docs of Bitcoin Core `v0.17`.
 //!
 //! All macros require `Client` to be in scope.
 //!

--- a/client/src/client_sync/v17/generating.rs
+++ b/client/src/client_sync/v17/generating.rs
@@ -3,7 +3,7 @@
 //! Macros for implementing JSON-RPC methods on a client.
 //!
 //! Specifically this is methods found under the `== Generating ==` section of the
-//! API docs of `bitcoind v0.17.1`.
+//! API docs of Bitcoin Core `v0.17`.
 //!
 //! All macros require `Client` to be in scope.
 //!

--- a/client/src/client_sync/v17/mod.rs
+++ b/client/src/client_sync/v17/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! A JSON-RPC client for testing against Bitcoin Core `v0.17.1`.
+//! A JSON-RPC client for testing against Bitcoin Core `v0.17`.
 //!
 //! We ignore option arguments unless they effect the shape of the returned JSON data.
 

--- a/client/src/client_sync/v17/network.rs
+++ b/client/src/client_sync/v17/network.rs
@@ -5,7 +5,7 @@
 //! Requires `Client` to be in scope.
 //!
 //! Specifically this is methods found under the `== Network ==` section of the
-//! API docs of `bitcoind v0.17.1`.
+//! API docs of Bitcoin Core `v0.17`.
 //!
 //! See, or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
 

--- a/client/src/client_sync/v17/raw_transactions.rs
+++ b/client/src/client_sync/v17/raw_transactions.rs
@@ -3,7 +3,7 @@
 //! Macros for implementing JSON-RPC methods on a client.
 //!
 //! Specifically this is methods found under the `== Rawtransactions ==` section of the
-//! API docs of `bitcoind v0.17.1`.
+//! API docs of Bitcoin Core `v0.17`.
 //!
 //! All macros require `Client` to be in scope.
 //!

--- a/client/src/client_sync/v17/wallet.rs
+++ b/client/src/client_sync/v17/wallet.rs
@@ -3,7 +3,7 @@
 //! Macros for implementing JSON-RPC methods on a client.
 //!
 //! Specifically this is methods found under the `== Wallet ==` section of the
-//! API docs of `bitcoind v0.17.1`.
+//! API docs of Bitcoin Core `v0.17`.
 //!
 //! All macros require `Client` to be in scope.
 //!

--- a/client/src/client_sync/v18.rs
+++ b/client/src/client_sync/v18.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! A JSON-RPC client for testing against Bitcoin Core `v0.18.1`.
+//! A JSON-RPC client for testing against Bitcoin Core `v0.18`.
 //!
 //! We ignore option arguments unless they effect the shape of the returned JSON data.
 

--- a/client/src/client_sync/v19/mod.rs
+++ b/client/src/client_sync/v19/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! A JSON-RPC client for testing against Bitcoin Core `v0.19.1`.
+//! A JSON-RPC client for testing against Bitcoin Core `v0.19`.
 //!
 //! We ignore option arguments unless they effect the shape of the returned JSON data.
 

--- a/client/src/client_sync/v19/wallet.rs
+++ b/client/src/client_sync/v19/wallet.rs
@@ -3,7 +3,7 @@
 //! Macros for implementing JSON-RPC methods on a client.
 //!
 //! Specifically this is methods found under the `== Wallet ==` section of the
-//! API docs of `bitcoind v0.19.1`.
+//! API docs of Bitcoin Core `v0.19`.
 //!
 //! All macros require `Client` to be in scope.
 //!

--- a/client/src/client_sync/v20.rs
+++ b/client/src/client_sync/v20.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! A JSON-RPC client for testing against Bitcoin Core `v0.20.2`.
+//! A JSON-RPC client for testing against Bitcoin Core `v0.20`.
 //!
 //! We ignore option arguments unless they effect the shape of the returned JSON data.
 

--- a/client/src/client_sync/v21.rs
+++ b/client/src/client_sync/v21.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! A JSON-RPC client for testing against Bitcoin Core `v0.21.2`.
+//! A JSON-RPC client for testing against Bitcoin Core `v0.21`.
 //!
 //! We ignore option arguments unless they effect the shape of the returned JSON data.
 

--- a/client/src/client_sync/v22/wallet.rs
+++ b/client/src/client_sync/v22/wallet.rs
@@ -3,7 +3,7 @@
 //! Macros for implementing JSON-RPC methods on a client.
 //!
 //! Specifically this is methods found under the `== Wallet ==` section of the
-//! API docs of `bitcoind v22.1`.
+//! API docs of Bitcoin Core `v22`.
 //!
 //! All macros require `Client` to be in scope.
 //!

--- a/client/src/client_sync/v28/raw_transactions.rs
+++ b/client/src/client_sync/v28/raw_transactions.rs
@@ -3,7 +3,7 @@
 //! Macros for implementing JSON-RPC methods on a client.
 //!
 //! Specifically this is methods found under the `== Rawtransactions ==` section of the
-//! API docs of `bitcoind v28.0`.
+//! API docs of Bitcoin Core `v28`.
 //!
 //! All macros require `Client` to be in scope.
 //!

--- a/contrib/extract.pl
+++ b/contrib/extract.pl
@@ -11,7 +11,7 @@ use Getopt::Long qw(:config no_auto_abbrev);
 my $SCRIPT = $0;
 
 # The Bitcoin Core version we are working with.
-my $CORE_VERSION = "0.17.1";
+my $CORE_VERSION = "0.17";
 # The file holding output of `bitcoin-cli --help`.
 my $RPC_HELP_FILE = "types/src/v17/rpc-api.txt";
 

--- a/types/src/v17/blockchain/mod.rs
+++ b/types/src/v17/blockchain/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! The JSON-RPC API for Bitcoin Core v0.17.1 - blockchain.
+//! The JSON-RPC API for Bitcoin Core `v0.17` - blockchain.
 //!
 //! Types for methods found under the `== Blockchain ==` section of the API docs.
 

--- a/types/src/v17/control.rs
+++ b/types/src/v17/control.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! The JSON-RPC API for Bitcoin Core v0.17.1 - control.
+//! The JSON-RPC API for Bitcoin Core `v0.17` - control.
 //!
 //! Types for methods found under the `== Control ==` section of the API docs.
 
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 /// > 1. "mode" determines what kind of information is returned. This argument is optional, the default mode is "stats".
 /// >   - "stats" returns general statistics about memory usage in the daemon.
 /// >   - "mallocinfo" returns an XML string describing low-level heap state (only available if compiled with glibc 2.10+).
-// This just mimics the map returned by my instance of Core v0.17.1, I don't know how
+// This just mimics the map returned by my instance of Core `v0.17`, I don't know how
 // to handle other map values or if they exist?
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct GetMemoryInfoStats(pub HashMap<String, Locked>);

--- a/types/src/v17/generating.rs
+++ b/types/src/v17/generating.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! The JSON-RPC API for Bitcoin Core v0.17.1 - generating.
+//! The JSON-RPC API for Bitcoin Core `v0.17` - generating.
 //!
 //! Types for methods found under the `== Generating ==` section of the API docs.
 

--- a/types/src/v17/mining.rs
+++ b/types/src/v17/mining.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! The JSON-RPC API for Bitcoin Core v0.17.1 - mining.
+//! The JSON-RPC API for Bitcoin Core `v0.17` - mining.
 //!
 //! Types for methods found under the `== Mining ==` section of the API docs.

--- a/types/src/v17/mod.rs
+++ b/types/src/v17/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! # JSON-RPC types for Bitcoin Core `v0.17.1`
+//! # JSON-RPC types for Bitcoin Core `v0.17`.
 //!
 //! These structs are shaped for the JSON data returned by the JSON-RPC API. They use stdlib types
 //! (or custom types) and where necessary implement an `into_model` function to convert the type to

--- a/types/src/v17/network/mod.rs
+++ b/types/src/v17/network/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! The JSON-RPC API for Bitcoin Core v0.17.1 - network.
+//! The JSON-RPC API for Bitcoin Core `v0.17` - network.
 //!
 //! Types for methods found under the `== Network ==` section of the API docs.
 //!

--- a/types/src/v17/raw_transactions.rs
+++ b/types/src/v17/raw_transactions.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! The JSON-RPC API for Bitcoin Core v0.17.1 - raw transactions.
+//! The JSON-RPC API for Bitcoin Core `v0.17` - raw transactions.
 //!
 //! Types for methods found under the `== Rawtransactions ==` section of the API docs.
 

--- a/types/src/v17/util.rs
+++ b/types/src/v17/util.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! The JSON-RPC API for Bitcoin Core v0.17.1 - util.
+//! The JSON-RPC API for Bitcoin Core `v0.17` - util.
 //!
 //! Types for methods found under the `== Util ==` section of the API docs.

--- a/types/src/v17/wallet/mod.rs
+++ b/types/src/v17/wallet/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! The JSON-RPC API for Bitcoin Core v0.17.1 - wallet.
+//! The JSON-RPC API for Bitcoin Core `v0.17` - wallet.
 //!
 //! Types for methods found under the `== Wallet ==` section of the API docs.
 

--- a/types/src/v17/zmq.rs
+++ b/types/src/v17/zmq.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! The JSON-RPC API for Bitcoin Core v0.17.1 - zmq.
+//! The JSON-RPC API for Bitcoin Core `v0.17` - zmq.
 //!
 //! Types for methods found under the `== Zmq ==` section of the API docs.
 

--- a/types/src/v18/mod.rs
+++ b/types/src/v18/mod.rs
@@ -8,7 +8,7 @@
 // differences.
 // - Double check that nothing marked `x` has a feature gated test (i.e. ensure tested).
 
-//! # JSON-RPC types for Bitcoin Core `v0.18.1`
+//! # JSON-RPC types for Bitcoin Core `v0.18`
 //!
 //! These structs are shaped for the JSON data returned by the JSON-RPC API. They use stdlib types
 //! (or custom types) and where necessary implement an `into_model` function to convert the type to

--- a/types/src/v19/blockchain.rs
+++ b/types/src/v19/blockchain.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! The JSON-RPC API for Bitcoin Core v0.19.1 - blockchain.
+//! The JSON-RPC API for Bitcoin Core `v0.19` - blockchain.
 //!
 //! Types for methods found under the `== Blockchain ==` section of the API docs.
 

--- a/types/src/v19/mod.rs
+++ b/types/src/v19/mod.rs
@@ -3,7 +3,7 @@
 //! Structs with standard types.
 //!
 //! These structs model the types returned by the JSON-RPC API and use stdlib types (or custom
-//! types) and are specific to a specific to Bitcoin Core `v0.19.1`.
+//! types) and are specific to a specific to Bitcoin Core `v0.19`.
 //!
 //! **== Blockchain ==**
 //! - [x] `getbestblockhash`

--- a/types/src/v19/wallet.rs
+++ b/types/src/v19/wallet.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! The JSON-RPC API for Bitcoin Core v0.19.1 - wallet.
+//! The JSON-RPC API for Bitcoin Core `v0.19` - wallet.
 //!
 //! Types for methods found under the `== Wallet ==` section of the API docs.
 

--- a/types/src/v20/mod.rs
+++ b/types/src/v20/mod.rs
@@ -3,7 +3,7 @@
 //! Structs with standard types.
 //!
 //! These structs model the types returned by the JSON-RPC API and use stdlib types (or custom
-//! types) and are specific to a specific to Bitcoin Core `v0.20.2`.
+//! types) and are specific to a specific to Bitcoin Core `v0.20`.
 //!
 //! **== Blockchain ==**
 //! - [x] `getbestblockhash`

--- a/types/src/v21/mod.rs
+++ b/types/src/v21/mod.rs
@@ -3,7 +3,7 @@
 //! Structs with standard types.
 //!
 //! These structs model the types returned by the JSON-RPC API and use stdlib types (or custom
-//! types) and are specific to a specific to Bitcoin Core `v0.21.2`.
+//! types) and are specific to a specific to Bitcoin Core `v0.21`.
 //!
 //! **== Blockchain ==**
 //! - [x] `getbestblockhash`

--- a/types/src/v21/wallet.rs
+++ b/types/src/v21/wallet.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! The JSON-RPC API for Bitcoin Core v0.21 - wallet.
+//! The JSON-RPC API for Bitcoin Core `v0.21` - wallet.
 //!
 //! Types for methods found under the `== Wallet ==` section of the API docs.
 

--- a/types/src/v25/wallet.rs
+++ b/types/src/v25/wallet.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! The JSON-RPC API for Bitcoin Core v25 - wallet.
+//! The JSON-RPC API for Bitcoin Core `v25` - wallet.
 //!
 //! Types for methods found under the `== Wallet ==` section of the API docs.
 

--- a/types/src/v28/blockchain.rs
+++ b/types/src/v28/blockchain.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! The JSON-RPC API for Bitcoin Core v28.0 - blockchain.
+//! The JSON-RPC API for Bitcoin Core `v28` - blockchain.
 //!
 //! Types for methods found under the `== Blockchain ==` section of the API docs.
 

--- a/types/src/v28/network.rs
+++ b/types/src/v28/network.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! The JSON-RPC API for Bitcoin Core v28.0 - network.
+//! The JSON-RPC API for Bitcoin Core `v28` - network.
 //!
 //! Types for methods found under the `== Network ==` section of the API docs.
 use serde::{Deserialize, Serialize};

--- a/types/src/v28/raw_transactions/mod.rs
+++ b/types/src/v28/raw_transactions/mod.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! The JSON-RPC API for Bitcoin Core v28.0 - raw transactions.
+//! The JSON-RPC API for Bitcoin Core `v28` - raw transactions.
 //!
 //! Types for methods found under the `== Rawtransactions ==` section of the API docs.
 


### PR DESCRIPTION
In an effort to make the crate more maintainable remove the minor version number from doc strings. While we are at it be consistent about usage of backticks.

Close: #10