### PR TITLE
Fix up `verify v17`

### DIFF
--- a/client/src/client_sync/v17/wallet.rs
+++ b/client/src/client_sync/v17/wallet.rs
@@ -191,8 +191,11 @@ macro_rules! impl_client_v17__getrawchangeaddress {
 macro_rules! impl_client_v17__getreceivedbyaddress {
     () => {
         impl Client {
-            pub fn get_received_by_address(&self) -> Result<GetReceivedByAddress> {
-                self.call("getreceivedbyaddress", &[])
+            pub fn get_received_by_address(
+                &self,
+                address: &Address<NetworkChecked>,
+            ) -> Result<GetReceivedByAddress> {
+                self.call("getreceivedbyaddress", &[address.to_string().into()])
             }
         }
     };
@@ -406,7 +409,7 @@ macro_rules! impl_client_v17__sendtoaddress {
 macro_rules! impl_client_v17__signmessage {
     () => {
         impl Client {
-            pub fn sign_message(&self, address: Address, message: &str) -> Result<SignMessage> {
+            pub fn sign_message(&self, address: &Address, message: &str) -> Result<SignMessage> {
                 self.call("signmessage", &[into_json(address)?, into_json(message)?])
             }
         }

--- a/integration_test/tests/raw_transactions.rs
+++ b/integration_test/tests/raw_transactions.rs
@@ -6,10 +6,7 @@ use integration_test::{Node, NodeExt as _};
 
 #[test]
 #[cfg(feature = "TODO")]
-fn send_raw_transaction() {
-    let _node = Node::new_no_wallet();
-    todo!()
-}
+fn send_raw_transaction() { todo!() }
 
 #[test]
 #[cfg(feature = "v28")]

--- a/integration_test/tests/raw_transactions.rs
+++ b/integration_test/tests/raw_transactions.rs
@@ -2,6 +2,7 @@
 
 //! Tests for methods found under the `== Rawtransactions ==` section of the API docs.
 
+#[cfg(feature = "v28")]
 use integration_test::{Node, NodeExt as _};
 
 #[test]

--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -136,11 +136,24 @@ fn get_raw_change_address() {
 }
 
 #[test]
-#[cfg(feature = "TODO")]
 fn get_received_by_address() {
+    let amount = Amount::from_sat(10_000);
+
     let node = Node::new_with_default_wallet();
-    let json = node.client.get_received_by_address().expect("getreceivedbyaddress");
-    assert!(json.into_model().is_ok());
+    node.fund_wallet();
+    let address = node.client.new_address().expect("failed to create new address");
+
+    let _txid = node
+        .client
+        .send_to_address(&address, amount)
+        .expect("sendtoaddress")
+        .txid()
+        .unwrap();
+    node.mine_a_block();
+
+    let json = node.client.get_received_by_address(&address).expect("getreceivedbyaddress");
+    let model = json.into_model().expect("into_model failed");
+    assert_eq!(model.0, amount);
 }
 
 #[test]

--- a/types/src/v17/mod.rs
+++ b/types/src/v17/mod.rs
@@ -159,7 +159,7 @@
 //! | getnewaddress                      | done            |
 //! | getrawchangeaddress                | done            |
 //! | getreceivedbyaccount               | omitted         |
-//! | getreceivedbyaddress               | done (untested) |
+//! | getreceivedbyaddress               | done            |
 //! | gettransaction                     | done            |
 //! | getunconfirmedbalance              | done (untested) |
 //! | getwalletinfo                      | done (untested) |

--- a/types/src/v18/mod.rs
+++ b/types/src/v18/mod.rs
@@ -1,12 +1,9 @@
 // SPDX-License-Identifier: CC0-1.0
 
-// This module is currently just copy of v17. As such it introduces the following TODOs:
+// TODO: Work out how to solve the problem that the docs on the re-exported types are for v17.
 //
-// - Check all items marked with `-` still should be omitted (currently just copied from v17).
-// - Work out how to solve the problem that the docs on the re-exported types are for v17. We
-// probably have to write a script to pull the v18 docs and check them against the v17 docs for
-// differences.
-// - Double check that nothing marked `x` has a feature gated test (i.e. ensure tested).
+// We probably need to write a script to pull the v18 docs from Core (code base or RPC call) and
+// check them against the v17 docs for differences.
 
 //! # JSON-RPC types for Bitcoin Core `v0.18.1`
 //!


### PR DESCRIPTION
There are a couple of problems highlighted when one runs `verify v17` - fix them. Includes fix the client and integration test around the `getreceivedbyaddresses` method.