### PR TITLE
node: Use latest version in docs build

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -67,5 +67,5 @@ doc = [] # used only for documentation building
 
 
 [package.metadata.docs.rs]
-features = ["download", "doc", "26_2"]
+features = ["download", "doc", "28_0"]
 rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
I don't think this actually makes any difference but it saves me doing it again later.