### PR TITLE
Verify integration tests using output of test file

### DIFF
--- a/types/src/v17/mod.rs
+++ b/types/src/v17/mod.rs
@@ -62,7 +62,7 @@
 //!
 //! | JSON-PRC Method Name               | Status          |
 //! |:-----------------------------------|:---------------:|
-//! | generate                           | done            |
+//! | generate                           | done (untested) |
 //! | generatetoaddress                  | done            |
 //!
 //! </details>
@@ -143,7 +143,7 @@
 //! |:-----------------------------------|:---------------:|
 //! | abandontransaction                 | omitted         |
 //! | abortrescan                        | omitted         |
-//! | addmultisigaddress                 | done            |
+//! | addmultisigaddress                 | done (untested) |
 //! | backupwallet                       | omitted         |
 //! | bumpfee                            | done            |
 //! | createwallet                       | done            |
@@ -154,7 +154,7 @@
 //! | getaccountaddress                  | omitted         |
 //! | getaddressbyaccount                | omitted         |
 //! | getaddressesbylabel                | done            |
-//! | getaddressinfo                     | done            |
+//! | getaddressinfo                     | done (untested) |
 //! | getbalance                         | done            |
 //! | getnewaddress                      | done            |
 //! | getrawchangeaddress                | done            |

--- a/types/src/v18/mod.rs
+++ b/types/src/v18/mod.rs
@@ -28,7 +28,7 @@
 //! | getblockcount                      | done            |
 //! | getblockhash                       | done            |
 //! | getblockheader                     | done            |
-//! | getblockstats                      | done            |
+//! | getblockstats                      | done (untested) |
 //! | getchaintips                       | done            |
 //! | getchaintxstats                    | done            |
 //! | getdifficulty                      | done            |
@@ -68,7 +68,7 @@
 //!
 //! | JSON-PRC Method Name               | Status          |
 //! |:-----------------------------------|:---------------:|
-//! | generate                           | done            |
+//! | generate                           | done (untested) |
 //! | generatetoaddress                  | done            |
 //!
 //! </details>
@@ -126,7 +126,7 @@
 //! | fundrawtransaction                 | todo            |
 //! | getrawtransaction                  | todo            |
 //! | joinpsbts                          | todo            |
-//! | sendrawtransaction                 | done            |
+//! | sendrawtransaction                 | done (untested) |
 //! | signrawtransactionwithkey          | todo            |
 //! | testmempoolaccept                  | todo            |
 //! | utxoupdatepsbt                     | todo            |
@@ -155,7 +155,7 @@
 //! |:-----------------------------------|:---------------:|
 //! | abandontransaction                 | omitted         |
 //! | abortrescan                        | omitted         |
-//! | addmultisigaddress                 | done            |
+//! | addmultisigaddress                 | done (untested) |
 //! | backupwallet                       | omitted         |
 //! | bumpfee                            | done            |
 //! | createwallet                       | done            |
@@ -163,7 +163,7 @@
 //! | dumpwallet                         | done            |
 //! | encryptwallet                      | omitted         |
 //! | getaddressesbylabel                | done            |
-//! | getaddressinfo                     | done            |
+//! | getaddressinfo                     | done (untested) |
 //! | getbalance                         | done            |
 //! | getnewaddress                      | done            |
 //! | getrawchangeaddress                | done            |


### PR DESCRIPTION
Currently the verify integration test code is broken because it greps for test names not bothering that some may be feature gated.

Instead of grepping for integration tests by name instead accept an option that includes a file that is the output from running the integration tests and then grep that file.
