### PR TITLE
Add `std` feature

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -120,7 +120,6 @@ name = "corepc-types"
 version = "0.5.0"
 dependencies = [
  "bitcoin",
- "bitcoin-internals",
  "serde",
  "serde_json",
 ]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -120,7 +120,6 @@ name = "corepc-types"
 version = "0.5.0"
 dependencies = [
  "bitcoin",
- "bitcoin-internals",
  "serde",
  "serde_json",
 ]

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -14,11 +14,10 @@ exclude = ["tests", "contrib"]
 
 [features]
 default = ["std"]
-std = ["bitcoin/std", "internals/std"]
+std = ["bitcoin/std"]
 
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false, features = ["serde", "base64"] }
-internals = { package = "bitcoin-internals", version = "0.3.0", default-features = false, features = ["alloc"]}
 serde = { version = "1.0.103", default-features = false, features = [ "derive", "alloc" ] }
 serde_json = { version = "1.0.117" }
 

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -13,11 +13,12 @@ rust-version = "1.63.0"
 exclude = ["tests", "contrib"]
 
 [features]
-default = []
+default = ["std"]
+std = ["bitcoin/std", "internals/std"]
 
 [dependencies]
-bitcoin = { version = "0.32.0", default-features = false, features = ["std", "serde", "base64"] }
-internals = { package = "bitcoin-internals", version = "0.3.0", default-features = false,  features = ["std"] }
+bitcoin = { version = "0.32.0", default-features = false, features = ["serde", "base64"] }
+internals = { package = "bitcoin-internals", version = "0.3.0", default-features = false, features = ["alloc"]}
 serde = { version = "1.0.103", default-features = false, features = [ "derive", "alloc" ] }
 serde_json = { version = "1.0.117" }
 

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: CC0-1.0
+
+/// Formats error.
+///
+/// If `std` feature is OFF appends error source (delimited by `: `). We do this because
+/// `e.source()` is only available in std builds, without this macro the error source is lost for
+/// no-std builds.
+macro_rules! write_err {
+    ($writer:expr, $string:literal $(, $args:expr)*; $source:expr) => {
+        {
+            #[cfg(feature = "std")]
+            {
+                let _ = &$source;   // Prevents clippy warnings.
+                write!($writer, $string $(, $args)*)
+            }
+            #[cfg(not(feature = "std"))]
+            {
+                write!($writer, concat!($string, ": {}") $(, $args)*, $source)
+            }
+        }
+    }
+}
+pub(crate) use write_err;

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -27,6 +27,7 @@ pub mod v26;
 pub mod v27;
 pub mod v28;
 
+mod error;
 // JSON types that model _all_ `bitcoind` versions.
 pub mod model;
 

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -9,6 +9,8 @@
 /// Re-export the `rust-bitcoin` crate.
 pub extern crate bitcoin;
 
+extern crate alloc;
+
 // TODO: Consider updating https://en.bitcoin.it/wiki/API_reference_%28JSON-RPC%29 when this is complete.
 
 // JSON types, for each specific version of `bitcoind`.
@@ -28,7 +30,7 @@ pub mod v28;
 // JSON types that model _all_ `bitcoind` versions.
 pub mod model;
 
-use std::fmt;
+use core::fmt;
 
 use bitcoin::amount::ParseAmountError;
 use bitcoin::{Amount, FeeRate};
@@ -75,6 +77,7 @@ impl fmt::Display for NumericError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for NumericError {}
 
 /// Converts `fee_rate` in BTC/kB to `FeeRate`.

--- a/types/src/model/blockchain.rs
+++ b/types/src/model/blockchain.rs
@@ -5,7 +5,7 @@
 //! These structs model the types returned by the JSON-RPC API but have concrete types
 //! and are not specific to a specific version of Bitcoin Core.
 
-use std::collections::BTreeMap;
+use alloc::collections::BTreeMap;
 
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::{

--- a/types/src/model/raw_transactions.rs
+++ b/types/src/model/raw_transactions.rs
@@ -5,7 +5,7 @@
 //! These structs model the types returned by the JSON-RPC API but have concrete types
 //! and are not specific to a specific version of Bitcoin Core.
 
-use std::collections::BTreeMap;
+use alloc::collections::BTreeMap;
 
 use bitcoin::{Amount, FeeRate, Txid, Wtxid};
 use serde::{Deserialize, Serialize};

--- a/types/src/model/wallet.rs
+++ b/types/src/model/wallet.rs
@@ -5,7 +5,7 @@
 //! These structs model the types returned by the JSON-RPC API but have concrete types
 //! and are not specific to a specific version of Bitcoin Core.
 
-use std::collections::BTreeMap;
+use alloc::collections::BTreeMap;
 
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::hashes::hash160;

--- a/types/src/v17/blockchain/error.rs
+++ b/types/src/v17/blockchain/error.rs
@@ -6,8 +6,8 @@ use bitcoin::amount::{self, ParseAmountError};
 use bitcoin::consensus::encode;
 use bitcoin::error::UnprefixedHexError;
 use bitcoin::{address, hex, network};
-use internals::write_err;
 
+use crate::error::write_err;
 use crate::NumericError;
 
 /// Error when converting a `GetBlockVerbosityOne` type into the model type.

--- a/types/src/v17/blockchain/error.rs
+++ b/types/src/v17/blockchain/error.rs
@@ -47,6 +47,7 @@ impl fmt::Display for GetBlockVerbosityOneError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for GetBlockVerbosityOneError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use GetBlockVerbosityOneError::*;
@@ -94,6 +95,7 @@ impl fmt::Display for GetBlockchainInfoError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for GetBlockchainInfoError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use GetBlockchainInfoError::*;
@@ -131,6 +133,7 @@ impl fmt::Display for GetBlockHeaderError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for GetBlockHeaderError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use GetBlockHeaderError::*;
@@ -179,6 +182,7 @@ impl fmt::Display for GetBlockHeaderVerboseError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for GetBlockHeaderVerboseError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use GetBlockHeaderVerboseError::*;
@@ -219,6 +223,7 @@ impl fmt::Display for GetBlockStatsError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for GetBlockStatsError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use GetBlockStatsError::*;
@@ -254,6 +259,7 @@ impl fmt::Display for ChainTipsError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for ChainTipsError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use ChainTipsError::*;
@@ -290,6 +296,7 @@ impl fmt::Display for GetChainTxStatsError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for GetChainTxStatsError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use GetChainTxStatsError::*;
@@ -325,6 +332,7 @@ impl fmt::Display for MapMempoolEntryError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for MapMempoolEntryError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use MapMempoolEntryError as E;
@@ -369,6 +377,7 @@ impl fmt::Display for MempoolEntryError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for MempoolEntryError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use MempoolEntryError as E;
@@ -409,6 +418,7 @@ impl fmt::Display for MempoolEntryFeesError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for MempoolEntryFeesError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use MempoolEntryFeesError as E;
@@ -442,6 +452,7 @@ impl fmt::Display for GetMempoolInfoError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for GetMempoolInfoError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use GetMempoolInfoError as E;
@@ -491,6 +502,7 @@ impl fmt::Display for GetTxOutError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for GetTxOutError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use GetTxOutError::*;
@@ -532,6 +544,7 @@ impl fmt::Display for GetTxOutSetInfoError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for GetTxOutSetInfoError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use GetTxOutSetInfoError::*;

--- a/types/src/v17/blockchain/mod.rs
+++ b/types/src/v17/blockchain/mod.rs
@@ -7,7 +7,7 @@
 mod error;
 mod into;
 
-use std::collections::BTreeMap;
+use alloc::collections::BTreeMap;
 
 use bitcoin::hex::FromHex;
 use bitcoin::{Address, Amount, FeeRate, Network, ScriptBuf, TxMerkleNode, TxOut, Wtxid};

--- a/types/src/v17/control.rs
+++ b/types/src/v17/control.rs
@@ -4,7 +4,7 @@
 //!
 //! Types for methods found under the `== Control ==` section of the API docs.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 // This just mimics the map returned by my instance of Core `v0.17`, I don't know how
 // to handle other map values or if they exist?
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-pub struct GetMemoryInfoStats(pub HashMap<String, Locked>);
+pub struct GetMemoryInfoStats(pub BTreeMap<String, Locked>);
 
 /// Information about locked memory manager.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]

--- a/types/src/v17/control.rs
+++ b/types/src/v17/control.rs
@@ -4,7 +4,7 @@
 //!
 //! Types for methods found under the `== Control ==` section of the API docs.
 
-use std::collections::BTreeMap;
+use alloc::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 

--- a/types/src/v17/network/error.rs
+++ b/types/src/v17/network/error.rs
@@ -3,7 +3,8 @@
 use core::fmt;
 
 use bitcoin::amount::ParseAmountError;
-use internals::write_err;
+
+use crate::error::write_err;
 
 /// Error when converting a `GetTransaction` type into the model type.
 #[derive(Debug)]

--- a/types/src/v17/network/error.rs
+++ b/types/src/v17/network/error.rs
@@ -26,6 +26,7 @@ impl fmt::Display for GetNetworkInfoError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for GetNetworkInfoError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use GetNetworkInfoError as E;

--- a/types/src/v17/network/mod.rs
+++ b/types/src/v17/network/mod.rs
@@ -9,7 +9,7 @@
 mod error;
 mod into;
 
-use std::collections::BTreeMap;
+use alloc::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 

--- a/types/src/v17/wallet/error.rs
+++ b/types/src/v17/wallet/error.rs
@@ -6,8 +6,8 @@ use bitcoin::amount::ParseAmountError;
 use bitcoin::consensus::encode;
 use bitcoin::psbt::PsbtParseError;
 use bitcoin::{address, bip32, hex, key, witness_program, witness_version};
-use internals::write_err;
 
+use crate::error::write_err;
 use crate::NumericError;
 
 /// Error when converting a `AddMultisigAddress` type into the model type.

--- a/types/src/v17/wallet/error.rs
+++ b/types/src/v17/wallet/error.rs
@@ -31,6 +31,7 @@ impl fmt::Display for AddMultisigAddressError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for AddMultisigAddressError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use AddMultisigAddressError::*;
@@ -66,6 +67,7 @@ impl fmt::Display for BumpFeeError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for BumpFeeError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use BumpFeeError as E;
@@ -135,6 +137,7 @@ impl fmt::Display for GetAddressInfoError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for GetAddressInfoError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use GetAddressInfoError as E;
@@ -209,6 +212,7 @@ impl fmt::Display for GetAddressInfoEmbeddedError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for GetAddressInfoEmbeddedError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use GetAddressInfoEmbeddedError as E;
@@ -267,6 +271,7 @@ impl fmt::Display for GetTransactionError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for GetTransactionError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use GetTransactionError as E;
@@ -310,6 +315,7 @@ impl fmt::Display for GetTransactionDetailError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for GetTransactionDetailError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use GetTransactionDetailError as E;
@@ -356,6 +362,7 @@ impl fmt::Display for GetWalletInfoError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for GetWalletInfoError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use GetWalletInfoError::*;
@@ -395,6 +402,7 @@ impl fmt::Display for ListAddressGroupingsError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for ListAddressGroupingsError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use ListAddressGroupingsError::*;
@@ -426,6 +434,7 @@ impl fmt::Display for ListLockUnspentItemError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for ListLockUnspentItemError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use ListLockUnspentItemError::*;
@@ -465,6 +474,7 @@ impl fmt::Display for ListReceivedByAddressError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for ListReceivedByAddressError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use ListReceivedByAddressError::*;
@@ -501,6 +511,7 @@ impl fmt::Display for ListSinceBlockError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for ListSinceBlockError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use ListSinceBlockError::*;
@@ -545,6 +556,7 @@ impl fmt::Display for ListSinceBlockTransactionError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for ListSinceBlockTransactionError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use ListSinceBlockTransactionError as E;
@@ -596,6 +608,7 @@ impl fmt::Display for ListTransactionsItemError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for ListTransactionsItemError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use ListTransactionsItemError as E;
@@ -652,6 +665,7 @@ impl fmt::Display for ListUnspentItemError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for ListUnspentItemError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use ListUnspentItemError as E;
@@ -693,6 +707,7 @@ impl fmt::Display for SignRawTransactionWithWalletError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for SignRawTransactionWithWalletError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use SignRawTransactionWithWalletError as E;
@@ -727,6 +742,7 @@ impl fmt::Display for SignErrorDataError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for SignErrorDataError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use SignErrorDataError as E;
@@ -766,6 +782,7 @@ impl fmt::Display for WalletCreateFundedPsbtError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for WalletCreateFundedPsbtError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use WalletCreateFundedPsbtError as E;

--- a/types/src/v17/wallet/mod.rs
+++ b/types/src/v17/wallet/mod.rs
@@ -7,7 +7,7 @@
 mod error;
 mod into;
 
-use std::collections::BTreeMap;
+use alloc::collections::BTreeMap;
 
 use bitcoin::amount::ParseAmountError;
 use bitcoin::key::{self, PrivateKey};

--- a/types/src/v19/blockchain.rs
+++ b/types/src/v19/blockchain.rs
@@ -9,9 +9,9 @@ use core::fmt;
 
 use bitcoin::error::UnprefixedHexError;
 use bitcoin::{hex, network, BlockHash, Network, Work};
-use internals::write_err;
 use serde::{Deserialize, Serialize};
 
+use crate::error::write_err;
 use crate::{model, NumericError};
 
 /// Result of JSON-RPC method `getblockchaininfo`.

--- a/types/src/v19/blockchain.rs
+++ b/types/src/v19/blockchain.rs
@@ -4,8 +4,8 @@
 //!
 //! Types for methods found under the `== Blockchain ==` section of the API docs.
 
+use alloc::collections::BTreeMap;
 use core::fmt;
-use std::collections::BTreeMap;
 
 use bitcoin::error::UnprefixedHexError;
 use bitcoin::{hex, network, BlockHash, Network, Work};
@@ -202,6 +202,7 @@ impl fmt::Display for GetBlockchainInfoError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for GetBlockchainInfoError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use GetBlockchainInfoError::*;

--- a/types/src/v28/blockchain.rs
+++ b/types/src/v28/blockchain.rs
@@ -4,7 +4,7 @@
 //!
 //! Types for methods found under the `== Blockchain ==` section of the API docs.
 
-use std::collections::BTreeMap;
+use alloc::collections::BTreeMap;
 
 use bitcoin::{BlockHash, Network, Work};
 use serde::{Deserialize, Serialize};

--- a/types/src/v28/raw_transactions/error.rs
+++ b/types/src/v28/raw_transactions/error.rs
@@ -34,6 +34,7 @@ impl fmt::Display for SubmitPackageError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for SubmitPackageError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use SubmitPackageError as E;
@@ -73,6 +74,7 @@ impl fmt::Display for SubmitPackageTxResultError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for SubmitPackageTxResultError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use SubmitPackageTxResultError as E;
@@ -114,6 +116,7 @@ impl fmt::Display for SubmitPackageTxResultFeesError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for SubmitPackageTxResultFeesError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use SubmitPackageTxResultFeesError as E;

--- a/types/src/v28/raw_transactions/error.rs
+++ b/types/src/v28/raw_transactions/error.rs
@@ -4,8 +4,8 @@ use core::fmt;
 
 use bitcoin::amount::ParseAmountError;
 use bitcoin::hex::HexToArrayError;
-use internals::write_err;
 
+use crate::error::write_err;
 use crate::NumericError;
 
 /// Error when converting a `SubmitPackage` type into the model type.

--- a/types/src/v28/raw_transactions/mod.rs
+++ b/types/src/v28/raw_transactions/mod.rs
@@ -7,7 +7,7 @@
 mod error;
 mod into;
 
-use std::collections::BTreeMap;
+use alloc::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
`master` is currently broken because the linter is warning because of a `std` feature (which is coming from our usage of `internals::write_err`).

We can fix this breakage after observing that calling macros from other crates is error prone. Lets copy the macro. On the way add a `std` feature and stop using `HashMap`.

This also allows the removal of the `internals` dependency. Sexy PR right here.

Close: #12