### PR TITLE
Release tracking PR: `v0.6.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -153,7 +153,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "corepc-client"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bitcoin",
  "corepc-types",
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-node"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-types"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bitcoin",
  "serde",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -153,7 +153,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "corepc-client"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bitcoin",
  "corepc-types",
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-node"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-types"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bitcoin",
  "serde",

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.6.0 - 2025-03-07
+
+- Expose all methods from `blockchain` section [#79](https://github.com/rust-bitcoin/corepc/pull/79)
+- Fix bugs in tx out proof methods
+- Improve docs
+- Reduce number of Core minor versions supported
+
 # 0.5.0 - 2024-12-16
 
 - Add support for Bitcoin Core v27.2

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-client"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/corepc"
@@ -22,7 +22,7 @@ client-sync = ["jsonrpc"]
 
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false, features = ["std", "serde"] }
-types = { package = "corepc-types", version = "0.5.0", default-features = false, features = [] }
+types = { package = "corepc-types", version = "0.6.0", default-features = false, features = [] }
 log = "0.4"
 serde = { version = "1.0.103", default-features = false, features = [ "derive", "alloc" ] }
 serde_json = { version = "1.0.117" }

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -50,8 +50,8 @@ TODO = []                       # This is a dirty hack while writing the tests.
 
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false, features = ["std", "serde"] }
-client = { package = "corepc-client", version = "0.5.0", default-features = false, features = ["client-sync"] }
-node = { package = "corepc-node", version = "0.5.0", default-features = false, features = ["download"] }
+client = { package = "corepc-client", version = "0.6.0", default-features = false, features = ["client-sync"] }
+node = { package = "corepc-node", version = "0.6.0", default-features = false, features = ["download"] }
 rand = "0.8.5"
 env_logger = "0.9.0"
 

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.6.0 - 2025-03-07
+
+- Remove `default` feature [#45](https://github.com/rust-bitcoin/corepc/pull/45)
+- Reduce number of supported minor versions [#27](https://github.com/rust-bitcoin/corepc/pull/27)
+- Enable running multiple Core v28 nodes [#46](https://github.com/rust-bitcoin/corepc/pull/46)
+
 # 0.5.0 - 2024-12-16
 
 - Rename `BitcoinD` to `Node`

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-node"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Riccardo Casatta <riccardo@casatta.it>", "Tobin C. Harding <me@tobin.cc>"]
 license = "MIT"
 repository = "https://github.com/rust-bitcoin/corepc"
@@ -13,7 +13,7 @@ rust-version = "1.63.0"
 exclude = ["tests", "contrib"]
 
 [dependencies]
-corepc-client = { version = "0.5.0", features = ["client-sync"] }
+corepc-client = { version = "0.6.0", features = ["client-sync"] }
 log = { version = "0.4", default-features = false }
 which = { version = "3.1.1", default-features = false }
 anyhow = { version = "1.0.66", default-features = false, features = ["std"] }

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.6.0 - 2025-03-07
+
+- Add `std` feature [#44](https://github.com/rust-bitcoin/corepc/pull/44)
+- Reduce number of supported minor versions [#27](https://github.com/rust-bitcoin/corepc/pull/27)
+- Update the version specific docs for Core versions 19 - 28
+   - [#55](https://github.com/rust-bitcoin/corepc/pull/55)
+   - [#64](https://github.com/rust-bitcoin/corepc/pull/64)
+
 # 0.5.0 - 2024-12-16
 
 - Flesh out v17 and v18

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-types"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/corepc"

--- a/verify/README.md
+++ b/verify/README.md
@@ -1,0 +1,15 @@
+# Verify
+
+TL;DR: `cargo run -- --help`
+
+This crate provides a tool to help verify the rest of the repository.
+Specifically the Single Source Of Truth for a specific Core version is
+the version module in `types` e.g., `types/src/v17/mod.rs`.
+
+Verification is warranted because there are many pieces involved and
+during development much cut'n'paste. We want to catch our mistakes and
+have some confidence that our claims are valid.
+
+Please see `types/README.md` for more information.
+
+


### PR DESCRIPTION
In preparation for release of all three crates add changelog entries, bump the version number, and update the lock files.

Patch 2 closes #69