### PR TITLE
Fix to download the correct binary for Apple silicon Macs

### DIFF
--- a/node/build.rs
+++ b/node/build.rs
@@ -22,13 +22,18 @@ mod download {
 
     include!("src/versions.rs");
 
-    #[cfg(all(target_os = "macos", any(target_arch = "x86_64", target_arch = "aarch64"),))]
+    #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
     fn download_filename() -> String {
         if cfg!(not(feature = "23_2")) {
             format!("bitcoin-{}-osx64.tar.gz", &VERSION)
         } else {
             format!("bitcoin-{}-x86_64-apple-darwin.tar.gz", &VERSION)
         }
+    }
+
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    fn download_filename() -> String {
+        format!("bitcoin-{}-arm64-apple-darwin.tar.gz", &VERSION)
     }
 
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]


### PR DESCRIPTION
Previously, using the (node) crate with the `from_downloaded()` trait would fail on apple silicon with `bad CPU type in executable`

Part of the update includes some code-signing, this is necessary for unsigned binaries (like bitcoind) to run on Arm Macs:
https://github.com/bitcoin/bitcoin/pull/26694#issuecomment-1348887186