### PR TITLE
Update to base64 0.22.1

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -32,15 +32,15 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bech32"
@@ -282,7 +282,7 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 name = "jsonrpc"
 version = "0.18.0"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.22.1",
  "minreq",
  "serde",
  "serde_json",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -32,15 +32,15 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bech32"
@@ -282,7 +282,7 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 name = "jsonrpc"
 version = "0.18.0"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.22.1",
  "minreq",
  "serde",
  "serde_json",

--- a/jsonrpc/Cargo.toml
+++ b/jsonrpc/Cargo.toml
@@ -33,7 +33,7 @@ proxy = ["socks"]
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = [ "raw_value" ] }
 
-base64 = { version = "0.13.0", optional = true }
+base64 = { version = "0.22.1", optional = true }
 minreq = { version = "2.7.0", features = ["json-using-serde"], optional = true }
 socks = { version = "0.3.4", optional = true}
 

--- a/jsonrpc/src/http/minreq_http.rs
+++ b/jsonrpc/src/http/minreq_http.rs
@@ -13,6 +13,9 @@ use std::{error, fmt};
 use crate::client::Transport;
 use crate::{Request, Response};
 
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine;
+
 const DEFAULT_URL: &str = "http://localhost";
 const DEFAULT_PORT: u16 = 8332; // the default RPC port for bitcoind.
 #[cfg(not(jsonrpc_fuzz))]
@@ -123,7 +126,7 @@ impl Builder {
         if let Some(ref pass) = pass {
             s.push_str(pass.as_ref());
         }
-        self.tp.basic_auth = Some(format!("Basic {}", &base64::encode(s.as_bytes())));
+        self.tp.basic_auth = Some(format!("Basic {}", &BASE64.encode(s.as_bytes())));
         self
     }
 
@@ -144,7 +147,7 @@ impl Builder {
     /// let client = MinreqHttpTransport::builder().cookie_auth(cookie);
     /// ```
     pub fn cookie_auth<S: AsRef<str>>(mut self, cookie: S) -> Self {
-        self.tp.basic_auth = Some(format!("Basic {}", &base64::encode(cookie.as_ref().as_bytes())));
+        self.tp.basic_auth = Some(format!("Basic {}", &BASE64.encode(cookie.as_ref().as_bytes())));
         self
     }
 

--- a/jsonrpc/src/http/simple_http.rs
+++ b/jsonrpc/src/http/simple_http.rs
@@ -14,6 +14,9 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
 use std::{error, fmt, io, net, num};
 
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine;
+
 #[cfg(feature = "proxy")]
 use socks::Socks5Stream;
 
@@ -377,13 +380,13 @@ impl Builder {
         if let Some(ref pass) = pass {
             auth.push_str(pass.as_ref());
         }
-        self.tp.basic_auth = Some(format!("Basic {}", &base64::encode(auth.as_bytes())));
+        self.tp.basic_auth = Some(format!("Basic {}", &BASE64.encode(auth.as_bytes())));
         self
     }
 
     /// Adds authentication information to the transport using a cookie string ('user:pass').
     pub fn cookie_auth<S: AsRef<str>>(mut self, cookie: S) -> Self {
-        self.tp.basic_auth = Some(format!("Basic {}", &base64::encode(cookie.as_ref().as_bytes())));
+        self.tp.basic_auth = Some(format!("Basic {}", &BASE64.encode(cookie.as_ref().as_bytes())));
         self
     }
 


### PR DESCRIPTION
This is just simple dependency update to avoid people having duplicate (old) versions of base64 in their dependency tree if they use this crate.