### PR TITLE
Add support for `invalidateblock`

### DIFF
--- a/client/src/client_sync/v17/generating.rs
+++ b/client/src/client_sync/v17/generating.rs
@@ -36,3 +36,15 @@ macro_rules! impl_client_v17__generate {
         }
     };
 }
+
+/// Implements Bitcoin Core JSON-RPC API method `invalidateblock`
+#[macro_export]
+macro_rules! impl_client_v17__invalidateblock {
+    () => {
+        impl Client {
+            pub fn invalidate_block(&self, hash: BlockHash) -> Result<()> {
+                self.call("invalidateblock", &[into_json(hash)?])
+            }
+        }
+    };
+}

--- a/client/src/client_sync/v17/mod.rs
+++ b/client/src/client_sync/v17/mod.rs
@@ -85,6 +85,7 @@ crate::impl_client_v17__uptime!();
 // == Generating ==
 crate::impl_client_v17__generatetoaddress!();
 crate::impl_client_v17__generate!();
+crate::impl_client_v17__invalidateblock!();
 
 // == Network ==
 crate::impl_client_v17__getaddednodeinfo!();

--- a/client/src/client_sync/v18.rs
+++ b/client/src/client_sync/v18.rs
@@ -48,6 +48,7 @@ crate::impl_client_v17__uptime!();
 // == Generating ==
 crate::impl_client_v17__generatetoaddress!();
 crate::impl_client_v17__generate!();
+crate::impl_client_v17__invalidateblock!();
 
 // == Network ==
 crate::impl_client_v17__getaddednodeinfo!();

--- a/client/src/client_sync/v19/mod.rs
+++ b/client/src/client_sync/v19/mod.rs
@@ -25,6 +25,7 @@ crate::impl_client_v17__stop!();
 
 // == Generating ==
 crate::impl_client_v17__generatetoaddress!();
+crate::impl_client_v17__invalidateblock!();
 
 // == Network ==
 crate::impl_client_v17__getnetworkinfo!();

--- a/client/src/client_sync/v20.rs
+++ b/client/src/client_sync/v20.rs
@@ -26,6 +26,7 @@ crate::impl_client_v17__stop!();
 
 // == Generating ==
 crate::impl_client_v17__generatetoaddress!();
+crate::impl_client_v17__invalidateblock!();
 
 // == Network ==
 crate::impl_client_v17__getnetworkinfo!();

--- a/client/src/client_sync/v21.rs
+++ b/client/src/client_sync/v21.rs
@@ -25,6 +25,7 @@ crate::impl_client_v17__stop!();
 
 // == Generating ==
 crate::impl_client_v17__generatetoaddress!();
+crate::impl_client_v17__invalidateblock!();
 
 // == Network ==
 crate::impl_client_v17__getnetworkinfo!();

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -25,6 +25,7 @@ crate::impl_client_v17__stop!();
 
 // == Generating ==
 crate::impl_client_v17__generatetoaddress!();
+crate::impl_client_v17__invalidateblock!();
 
 // == Network ==
 crate::impl_client_v17__getnetworkinfo!();

--- a/client/src/client_sync/v23.rs
+++ b/client/src/client_sync/v23.rs
@@ -24,6 +24,7 @@ crate::impl_client_v17__stop!();
 
 // == Generating ==
 crate::impl_client_v17__generatetoaddress!();
+crate::impl_client_v17__invalidateblock!();
 
 // == Network ==
 crate::impl_client_v17__getnetworkinfo!();

--- a/client/src/client_sync/v24.rs
+++ b/client/src/client_sync/v24.rs
@@ -26,6 +26,7 @@ crate::impl_client_v17__stop!();
 
 // == Generating ==
 crate::impl_client_v17__generatetoaddress!();
+crate::impl_client_v17__invalidateblock!();
 
 // == Network ==
 crate::impl_client_v17__getnetworkinfo!();

--- a/client/src/client_sync/v25.rs
+++ b/client/src/client_sync/v25.rs
@@ -26,6 +26,7 @@ crate::impl_client_v17__stop!();
 
 // == Generating ==
 crate::impl_client_v17__generatetoaddress!();
+crate::impl_client_v17__invalidateblock!();
 
 // == Network ==
 crate::impl_client_v17__getnetworkinfo!();

--- a/client/src/client_sync/v26.rs
+++ b/client/src/client_sync/v26.rs
@@ -26,6 +26,7 @@ crate::impl_client_v17__stop!();
 
 // == Generating ==
 crate::impl_client_v17__generatetoaddress!();
+crate::impl_client_v17__invalidateblock!();
 
 // == Network ==
 crate::impl_client_v17__getnetworkinfo!();

--- a/client/src/client_sync/v27.rs
+++ b/client/src/client_sync/v27.rs
@@ -26,6 +26,7 @@ crate::impl_client_v17__stop!();
 
 // == Generating ==
 crate::impl_client_v17__generatetoaddress!();
+crate::impl_client_v17__invalidateblock!();
 
 // == Network ==
 crate::impl_client_v17__getnetworkinfo!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -28,6 +28,7 @@ crate::impl_client_v17__stop!();
 
 // == Generating ==
 crate::impl_client_v17__generatetoaddress!();
+crate::impl_client_v17__invalidateblock!();
 
 // == Network ==
 crate::impl_client_v17__getnetworkinfo!();

--- a/integration_test/tests/generating.rs
+++ b/integration_test/tests/generating.rs
@@ -14,6 +14,23 @@ fn generate_to_address() {
     json.into_model().unwrap();
 }
 
+#[test]
+fn invalidate_block() {
+    const NBLOCKS: usize = 1;
+
+    let node = Node::new_with_default_wallet();
+    let address = node.client.new_address().expect("failed to get new address");
+    let old_best_block = node.client.get_best_block_hash().expect("getbestblockhash").into_model().unwrap().0;
+    node.client.generate_to_address(NBLOCKS, &address).expect("generatetoaddress").into_model().unwrap();
+
+    let new_best_block = node.client.get_best_block_hash().expect("getbestblockhash").into_model().unwrap().0;
+    assert_ne!(old_best_block, new_best_block);
+
+    node.client.invalidate_block(new_best_block).expect("invalidateblock");
+    let best_block = node.client.get_best_block_hash().expect("getbestblockhash").into_model().unwrap().0;
+    assert_eq!(old_best_block, best_block);
+}
+
 // #[test]
 // #[cfg(not(feature = "v19"))]
 // fn generate() {


### PR DESCRIPTION
Fixes #67.

While this is RPC call is not listed as part of the official RPC API, we add support here as it can be crucial for regtest testing (e.g. writing reorg tests).