### PR TITLE
Use `SignedAmount` when converting `gettransaction` amount to model 

### DIFF
--- a/types/src/model/wallet.rs
+++ b/types/src/model/wallet.rs
@@ -277,7 +277,7 @@ pub struct GetReceivedByAddress(pub Amount);
 pub struct GetTransaction {
     /// The transaction amount.
     #[serde(default, with = "bitcoin::amount::serde::as_btc")]
-    pub amount: Amount,
+    pub amount: SignedAmount,
     /// The amount of the fee.
     ///
     /// This is negative and only available for the 'send' category of transactions.

--- a/types/src/v17/wallet/into.rs
+++ b/types/src/v17/wallet/into.rs
@@ -325,7 +325,7 @@ impl GetTransaction {
     pub fn into_model(self) -> Result<model::GetTransaction, GetTransactionError> {
         use GetTransactionError as E;
 
-        let amount = Amount::from_btc(self.amount).map_err(E::Amount)?;
+        let amount = SignedAmount::from_btc(self.amount).map_err(E::Amount)?;
         let fee = self.fee.map(|fee| SignedAmount::from_btc(fee).map_err(E::Fee)).transpose()?;
 
         let block_hash =

--- a/types/src/v17/wallet/mod.rs
+++ b/types/src/v17/wallet/mod.rs
@@ -21,7 +21,7 @@ pub use self::error::*;
 //
 // The following structs are very similar but have slightly different fields and docs.
 // - GetTransaction
-// - ListSinceLastBlockTransaction
+// - ListSinceBlockTransaction
 // - ListTransactionsItem
 
 /// Returned as part of `getaddressesbylabel` and `getaddressinfo`


### PR DESCRIPTION
Fix a code comment mistake then change the `model` for `GetTransaction` to use a signed amount.

This is a bug fix.

Close: #80