### PR TITLE
Refactor `getblockstats` tests and enable for v18

### DIFF
--- a/integration_test/src/lib.rs
+++ b/integration_test/src/lib.rs
@@ -25,6 +25,13 @@ pub trait NodeExt {
         Self::new(conf, None)
     }
 
+    /// Returns a handle to a `bitcoind` instance with "default" wallet loaded and `-txindex` enabled.
+    fn new_with_default_wallet_txindex() -> Node {
+        let mut conf = node::Conf::default();
+        conf.args.push("-txindex");
+        Self::new(conf, None)
+    }
+
     /// Returns a handle to a `bitcoind` instance with `wallet` loaded.
     fn new_with_wallet(wallet: String) -> Node {
         let conf = node::Conf::default();

--- a/integration_test/tests/blockchain.rs
+++ b/integration_test/tests/blockchain.rs
@@ -70,55 +70,41 @@ fn get_block_header_verbose() { // verbose = true
     assert!(json.into_model().is_ok());
 }
 
-#[cfg(not(any(feature = "v18", feature = "v19", feature = "v20", feature = "v21", feature = "v22", feature = "v23", feature = "v24")))]
+#[cfg(not(any(feature = "v19", feature = "v20", feature = "v21", feature = "v22", feature = "v23", feature = "v24")))]
 // `getblockstats` used to not work on the genesis block as it doesn't have undo data saved to disk
 // (see https://github.com/bitcoin/bitcoin/pull/19888). We therefore only run tests for versions
 // allowing to.
 #[test]
 fn get_block_stats() {
-    get_block_stats_by_height();
-    get_block_stats_by_hash();
+    // Version 18 cannot getblockstats if -txindex is not enabled.
+    #[cfg(not(feature = "v18"))]
+    getblockstats();
+
+    // All non-feature gated versions including 18 can getblockstats if -txindex is enabled.
+    getblockstats_txindex();
 }
 
 #[cfg(not(any(feature = "v18", feature = "v19", feature = "v20", feature = "v21", feature = "v22", feature = "v23", feature = "v24")))]
-// `getblockstats` used to not work on the genesis block as it doesn't have undo data saved to disk
-// (see https://github.com/bitcoin/bitcoin/pull/19888). We therefore only run tests for versions
-// allowing to.
-fn get_block_stats_by_height() {
-    let node = Node::new_no_wallet();
-    let json = node.client.get_block_stats_by_height(0).expect("getblockstats");
+fn getblockstats() {
+    let node = Node::new_with_default_wallet();
+    node.mine_a_block();
+
+    let json = node.client.get_block_stats_by_height(1).expect("getblockstats");
     assert!(json.into_model().is_ok());
-}
 
-#[cfg(not(any(feature = "v18", feature = "v19", feature = "v20", feature = "v21", feature = "v22", feature = "v23", feature = "v24")))]
-// `getblockstats` used to not work on the genesis block as it doesn't have undo data saved to disk
-// (see https://github.com/bitcoin/bitcoin/pull/19888). We therefore only run tests for versions
-// allowing to.
-fn get_block_stats_by_hash() { // verbose = true
-    let node = Node::new_no_wallet();
     let block_hash = best_block_hash();
     let json = node.client.get_block_stats_by_block_hash(&block_hash).expect("getblockstats");
     assert!(json.into_model().is_ok());
 }
 
 #[cfg(not(any(feature = "v19", feature = "v20", feature = "v21", feature = "v22", feature = "v23", feature = "v24")))]
-// `getblockstats` used to not work on the genesis block as it doesn't have undo data saved to disk
-// (see https://github.com/bitcoin/bitcoin/pull/19888). We therefore only run tests for versions
-// allowing to.
-#[test]
-fn get_block_stats_by_height_txindex() {
-    let node = Node::new_no_wallet_txindex();
-    let json = node.client.get_block_stats_by_height(0).expect("getblockstats");
-    assert!(json.into_model().is_ok());
-}
+fn getblockstats_txindex() {
+    let node = Node::new_with_default_wallet_txindex();
+    node.mine_a_block();
 
-#[cfg(not(any(feature = "v19", feature = "v20", feature = "v21", feature = "v22", feature = "v23", feature = "v24")))]
-// `getblockstats` used to not work on the genesis block as it doesn't have undo data saved to disk
-// (see https://github.com/bitcoin/bitcoin/pull/19888). We therefore only run tests for versions
-// allowing to.
-#[test]
-fn get_block_stats_by_hash_txindex() { // verbose = true
-    let node = Node::new_no_wallet_txindex();
+    let json = node.client.get_block_stats_by_height(1).expect("getblockstats");
+    assert!(json.into_model().is_ok());
+
     let block_hash = best_block_hash();
     let json = node.client.get_block_stats_by_block_hash(&block_hash).expect("getblockstats");
     assert!(json.into_model().is_ok());

--- a/types/src/v18/mod.rs
+++ b/types/src/v18/mod.rs
@@ -28,7 +28,7 @@
 //! | getblockcount                      | done            |
 //! | getblockhash                       | done            |
 //! | getblockheader                     | done            |
-//! | getblockstats                      | done (untested) |
+//! | getblockstats                      | done            |
 //! | getchaintips                       | done            |
 //! | getchaintxstats                    | done            |
 //! | getdifficulty                      | done            |


### PR DESCRIPTION
The `getblockstats` method works for some versions of Core and not others.

- Refactor the tests to try and make it more clear exactly when the method is tested.
- Enable testing for `v18` with and without `-txindex` for versions that support it.
- Enable testing of `v18` with `-txindex`
- Update the rustdocs in `types` to show that its tested for `v18`.
- Mine a block before getting the stats, no real reason but just because the comments mention the genesis block.

FTR I'm not totally across exactly why this works for v17 and v18 and then not until v25 again.