### PR TITLE
verify: Include trailing semicolon

### DIFF
--- a/verify/src/lib.rs
+++ b/verify/src/lib.rs
@@ -179,7 +179,7 @@ pub fn grep_for_re_export(path: &Path, s: &str) -> Result<bool> {
         .with_context(|| format!("Failed to grep for string in {}", path.display()))?;
     let reader = io::BufReader::new(file);
 
-    let s = format!("{}[,}}]", &s);
+    let s = format!("{}[,}};]", &s);
     let re = Regex::new(&s)?;
 
     for line in reader.lines() {


### PR DESCRIPTION
We have a bunch of false positives when verifying types in the version they are defined because the re-export is of form:

```rust
pub use self::control::Logging;
```

Add a semicolon to the regex.