### PR TITLE
Add missing transaction categories

### DIFF
--- a/types/src/model/wallet.rs
+++ b/types/src/model/wallet.rs
@@ -27,10 +27,16 @@ pub enum AddressPurpose {
 /// The category of a transaction.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 pub enum TransactionCategory {
-    /// Transaction is a send.
+    /// Transactions sent.
     Send,
-    /// Transactions is a receive.
+    /// Non-coinbase transactions received.
     Receive,
+    /// Coinbase transactions received with more than 100 confirmations.
+    Generate,
+    /// Coinbase transactions received with 100 or fewer confirmations.
+    Immature,
+    /// Orphaned coinbase transactions received.
+    Orphan,
 }
 
 /// Whether this transaction can be RBF'ed.

--- a/types/src/v17/wallet/into.rs
+++ b/types/src/v17/wallet/into.rs
@@ -37,6 +37,9 @@ impl TransactionCategory {
         match self {
             V::Send => M::Send,
             V::Receive => M::Receive,
+            V::Generate => M::Generate,
+            V::Immature => M::Immature,
+            V::Orphan => M::Orphan,
         }
     }
 }

--- a/types/src/v17/wallet/mod.rs
+++ b/types/src/v17/wallet/mod.rs
@@ -38,10 +38,16 @@ pub enum AddressPurpose {
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum TransactionCategory {
-    /// Transaction is a send.
+    /// Transactions sent.
     Send,
-    /// Transactions is a receive.
+    /// Non-coinbase transactions received.
     Receive,
+    /// Coinbase transactions received with more than 100 confirmations.
+    Generate,
+    /// Coinbase transactions received with 100 or fewer confirmations.
+    Immature,
+    /// Orphaned coinbase transactions received.
+    Orphan,
 }
 
 /// Whether this transaction can be RBF'ed.


### PR DESCRIPTION
Contrary to Bitcoin Core's v17 docs, there are *five* transaction categories that might be returned as part of a response to `listtransactions`, `listsinceblock`, or `gettransaction`. While Core fixed this omission in the docs in https://github.com/bitcoin/bitcoin/pull/14653, we didn't account for them in the respective model's `enum`, leading to calls to `get_transaction` randomly failing with the rather obscure error message:
```
Err(JsonRpc(Json(Error("unknown variant `generate`, expected `send` or `receive`", line: 1, column: 682))))
```

Here, we fix this omission and add the missing categories. Note that while the doc fix https://github.com/bitcoin/bitcoin/pull/14653 was shipped as part of `v18`, the categories are pre-existing, which is why we simply fix the `v17` and `model` variants in-place here.

@tcharding This might warrant a patch release, IMO?