### PR TITLE
backport: node: Fix the rustdocs build

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -65,5 +65,5 @@ download = ["anyhow", "bitcoin_hashes", "flate2", "tar", "minreq", "zip"]
 0_17_1 = []
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["28_0"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/node/README.md
+++ b/node/README.md
@@ -30,7 +30,7 @@ if let Ok(exe_path) = corepc_node::exe_path() {
 ```
 
 Startup options could be configured via the [`Conf`] struct using [`Node::with_conf`] or
-[`Node::from_downloaded_with_conf`]
+`Node::from_downloaded_with_conf`
 
 ## Features
 

--- a/node/build.rs
+++ b/node/build.rs
@@ -1,12 +1,11 @@
 fn main() { download::start().unwrap(); }
 
-#[cfg(not(feature = "download"))]
+#[cfg(any(docsrs, not(feature = "download")))]
 mod download {
     pub(crate) fn start() -> Result<(), ()> { Ok(()) }
 }
 
 #[cfg(feature = "download")]
-#[cfg(not(docsrs))]
 mod download {
     use std::fs::File;
     use std::io::{self, BufRead, BufReader, Cursor, Read};


### PR DESCRIPTION
This is a backport of the single patch in #90

Currently the docs.rs build is not working. From the log it can be seen that the build is trying to download a bitcoind binary. I cannot see why this is happening, it does not happen locally. Anyway we can just change the docs build to use `28_0` instead of all features and this bypasses the problem.

While we are at it, change the feature gating in `build.rs` on the `download` module because it still seems wrong. Phew logically combining negative truth values is hard to reason about.