### PR TITLE
types: Update status for `getblockstats`

### DIFF
--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -25,7 +25,7 @@
 //! | getblockfrompeer                   | todo            |
 //! | getblockhash                       | done            |
 //! | getblockheader                     | done            |
-//! | getblockstats                      | done (untested) |
+//! | getblockstats                      | done            |
 //! | getchaintips                       | done            |
 //! | getchaintxstats                    | done            |
 //! | getdeploymentinfo                  | todo            |

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -26,7 +26,7 @@
 //! | getblockfrompeer                   | todo            |
 //! | getblockhash                       | done            |
 //! | getblockheader                     | done            |
-//! | getblockstats                      | done (untested) |
+//! | getblockstats                      | done            |
 //! | getchainstates                     | todo            |
 //! | getchaintips                       | done            |
 //! | getchaintxstats                    | done            |

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -26,7 +26,7 @@
 //! | getblockfrompeer                   | todo            |
 //! | getblockhash                       | done            |
 //! | getblockheader                     | done            |
-//! | getblockstats                      | done (untested) |
+//! | getblockstats                      | done            |
 //! | getchainstates                     | todo            |
 //! | getchaintips                       | done            |
 //! | getchaintxstats                    | done            |

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -26,7 +26,7 @@
 //! | getblockfrompeer                   | todo            |
 //! | getblockhash                       | done            |
 //! | getblockheader                     | done            |
-//! | getblockstats                      | done (untested) |
+//! | getblockstats                      | done            |
 //! | getchainstates                     | todo            |
 //! | getchaintips                       | done            |
 //! | getchaintxstats                    | done            |


### PR DESCRIPTION
Recently we added tests for `getblockstats` but forgot to update the status.

There is still some confusion in my mind as what should be done about versions 19-24. Currently the method is untested and not working for these versions but we still re-export the `GetBlockStats` type and the method exists in `bitcoincli help getblockstats`.