### PR TITLE
Release tracking PR: `node` and `types` both to `v0.6.1`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-node"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-node"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -51,7 +51,7 @@ TODO = []                       # This is a dirty hack while writing the tests.
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false, features = ["std", "serde"] }
 client = { package = "corepc-client", version = "0.6.0", default-features = false, features = ["client-sync"] }
-node = { package = "corepc-node", version = "0.6.0", default-features = false, features = ["download"] }
+node = { package = "corepc-node", version = "0.6.1", default-features = false, features = ["download"] }
 rand = "0.8.5"
 env_logger = "0.9.0"
 

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.6.1 - 2025-03-11
+
+- Fix the docs.rs build [#92](https://github.com/rust-bitcoin/corepc/pull/92)
+
 # 0.6.0 - 2025-03-07
 
 - Remove `default` feature [#45](https://github.com/rust-bitcoin/corepc/pull/45)

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-node"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Riccardo Casatta <riccardo@casatta.it>", "Tobin C. Harding <me@tobin.cc>"]
 license = "MIT"
 repository = "https://github.com/rust-bitcoin/corepc"

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.6.1 - 2025-03-11
+
+- Add missing transaction categories [#91](https://github.com/rust-bitcoin/corepc/pull/91)
+
 # 0.6.0 - 2025-03-07
 
 - Add `std` feature [#44](https://github.com/rust-bitcoin/corepc/pull/44)


### PR DESCRIPTION
We would like to do a point release of `node` and `type`s.
    
- `node`: to fix the docs.rs build
- `types`: to get the bug fix to transaction categories
    
To each crate add a changelog entry, bump the version, and update the  lock files.
