### PR TITLE
types: Really bump version

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-types"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bitcoin",
  "serde",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-types"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bitcoin",
  "serde",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -22,7 +22,7 @@ client-sync = ["jsonrpc"]
 
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false, features = ["std", "serde"] }
-types = { package = "corepc-types", version = "0.6.0", default-features = false, features = [] }
+types = { package = "corepc-types", version = "0.6.1", default-features = false, features = [] }
 log = "0.4"
 serde = { version = "1.0.103", default-features = false, features = [ "derive", "alloc" ] }
 serde_json = { version = "1.0.117" }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-types"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/corepc"


### PR DESCRIPTION
I just did a patch to bump the version of `node` and `types` but only added the changelog for `types` and forgot to actually bump the version - face palm.

Bump the version to 0.6.1 ready for release. Explicitly depend on the new version. Update the lock files.