### PR TITLE
client: Enable `std` feature in `types` crate

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -22,7 +22,7 @@ client-sync = ["jsonrpc"]
 
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false, features = ["std", "serde"] }
-types = { package = "corepc-types", version = "0.6.0", default-features = false, features = [] }
+types = { package = "corepc-types", version = "0.6.0", default-features = false, features = ["std"] }
 log = "0.4"
 serde = { version = "1.0.103", default-features = false, features = [ "derive", "alloc" ] }
 serde_json = { version = "1.0.117" }


### PR DESCRIPTION
The `client` is std only but we don't enable the `std` feature in `types` - this is a bug.

Fix: #97