### PR TITLE
client: Bump version to 0.6.1

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -153,7 +153,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "corepc-client"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bitcoin",
  "corepc-types",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -153,7 +153,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "corepc-client"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bitcoin",
  "corepc-types",

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.6.1 - 2025-13-13
+
+- Enable `std` feature in `types` crate [#98](https://github.com/rust-bitcoin/corepc/pull/98)
+
 # 0.6.0 - 2025-03-07
 
 - Expose all methods from `blockchain` section [#79](https://github.com/rust-bitcoin/corepc/pull/79)

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-client"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/corepc"

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -50,7 +50,7 @@ TODO = []                       # This is a dirty hack while writing the tests.
 
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false, features = ["std", "serde"] }
-client = { package = "corepc-client", version = "0.6.0", default-features = false, features = ["client-sync"] }
+client = { package = "corepc-client", version = "0.6.1", default-features = false, features = ["client-sync"] }
 node = { package = "corepc-node", version = "0.6.1", default-features = false, features = ["download"] }
 rand = "0.8.5"
 env_logger = "0.9.0"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.63.0"
 exclude = ["tests", "contrib"]
 
 [dependencies]
-corepc-client = { version = "0.6.0", features = ["client-sync"] }
+corepc-client = { version = "0.6.1", features = ["client-sync"] }
 log = { version = "0.4", default-features = false }
 which = { version = "3.1.1", default-features = false }
 anyhow = { version = "1.0.66", default-features = false, features = ["std"] }


### PR DESCRIPTION
In preparation for release bump the version, add a changelog entry, and update the lock files.