### PR TITLE
Test `getblockstats` for all versions

### DIFF
--- a/integration_test/tests/blockchain.rs
+++ b/integration_test/tests/blockchain.rs
@@ -4,12 +4,6 @@
 
 use integration_test::{Node, NodeExt as _};
 
-// FIXME: Do we need this?
-fn best_block_hash() -> bitcoin::BlockHash {
-    let node = Node::new_no_wallet();
-    node.client.best_block_hash().expect("best_block_hash failed")
-}
-
 #[test]
 fn get_blockchain_info() {
     let node = Node::new_no_wallet();
@@ -27,7 +21,7 @@ fn get_best_block_hash() {
 #[test]
 fn get_block() {
     let node = Node::new_no_wallet();
-    let block_hash = best_block_hash();
+    let block_hash = node.client.best_block_hash().expect("best_block_hash failed");
 
     let json = node.client.get_block_verbose_zero(block_hash).expect("getblock verbose=0");
     assert!(json.into_model().is_ok());
@@ -57,7 +51,7 @@ fn get_block_hash() {
 #[test]
 fn get_block_header() { // verbose = false
     let node = Node::new_no_wallet();
-    let block_hash = best_block_hash();
+    let block_hash = node.client.best_block_hash().expect("best_block_hash failed");
     let json = node.client.get_block_header(&block_hash).expect("getblockheader");
     assert!(json.into_model().is_ok());
 }
@@ -65,7 +59,7 @@ fn get_block_header() { // verbose = false
 #[test]
 fn get_block_header_verbose() { // verbose = true
     let node = Node::new_no_wallet();
-    let block_hash = best_block_hash();
+    let block_hash = node.client.best_block_hash().expect("best_block_hash failed");
     let json = node.client.get_block_header_verbose(&block_hash).expect("getblockheader");
     assert!(json.into_model().is_ok());
 }
@@ -92,7 +86,7 @@ fn getblockstats() {
     let json = node.client.get_block_stats_by_height(1).expect("getblockstats");
     assert!(json.into_model().is_ok());
 
-    let block_hash = best_block_hash();
+    let block_hash = node.client.best_block_hash().expect("best_block_hash failed");
     let json = node.client.get_block_stats_by_block_hash(&block_hash).expect("getblockstats");
     assert!(json.into_model().is_ok());
 }
@@ -105,7 +99,7 @@ fn getblockstats_txindex() {
     let json = node.client.get_block_stats_by_height(1).expect("getblockstats");
     assert!(json.into_model().is_ok());
 
-    let block_hash = best_block_hash();
+    let block_hash = node.client.best_block_hash().expect("best_block_hash failed");
     let json = node.client.get_block_stats_by_block_hash(&block_hash).expect("getblockstats");
     assert!(json.into_model().is_ok());
 }
@@ -234,7 +228,7 @@ fn get_tx_out_set_info() {
 fn precious_block() {
     let node = Node::new_with_default_wallet();
     node.mine_a_block();
-    let hash = node.client.best_block_hash().expect("bestblockhash");
+    let hash = node.client.best_block_hash().expect("best_block_hash failed");
     node.mine_a_block();
 
     let _ = node.client.precious_block(hash).expect("preciousblock");

--- a/integration_test/tests/blockchain.rs
+++ b/integration_test/tests/blockchain.rs
@@ -64,10 +64,6 @@ fn get_block_header_verbose() { // verbose = true
     assert!(json.into_model().is_ok());
 }
 
-#[cfg(not(any(feature = "v19", feature = "v20", feature = "v21", feature = "v22", feature = "v23", feature = "v24")))]
-// `getblockstats` used to not work on the genesis block as it doesn't have undo data saved to disk
-// (see https://github.com/bitcoin/bitcoin/pull/19888). We therefore only run tests for versions
-// allowing to.
 #[test]
 fn get_block_stats() {
     // Version 18 cannot getblockstats if -txindex is not enabled.
@@ -78,10 +74,9 @@ fn get_block_stats() {
     getblockstats_txindex();
 }
 
-#[cfg(not(any(feature = "v18", feature = "v19", feature = "v20", feature = "v21", feature = "v22", feature = "v23", feature = "v24")))]
 fn getblockstats() {
     let node = Node::new_with_default_wallet();
-    node.mine_a_block();
+    node.fund_wallet();
 
     let json = node.client.get_block_stats_by_height(1).expect("getblockstats");
     assert!(json.into_model().is_ok());
@@ -91,12 +86,11 @@ fn getblockstats() {
     assert!(json.into_model().is_ok());
 }
 
-#[cfg(not(any(feature = "v19", feature = "v20", feature = "v21", feature = "v22", feature = "v23", feature = "v24")))]
 fn getblockstats_txindex() {
     let node = Node::new_with_default_wallet_txindex();
-    node.mine_a_block();
+    node.fund_wallet();
 
-    let json = node.client.get_block_stats_by_height(1).expect("getblockstats");
+    let json = node.client.get_block_stats_by_height(101).expect("getblockstats");
     assert!(json.into_model().is_ok());
 
     let block_hash = node.client.best_block_hash().expect("best_block_hash failed");

--- a/types/src/v19/mod.rs
+++ b/types/src/v19/mod.rs
@@ -24,7 +24,7 @@
 //! | getblockfilter                     | todo            |
 //! | getblockhash                       | done            |
 //! | getblockheader                     | done            |
-//! | getblockstats                      | done (untested) |
+//! | getblockstats                      | done            |
 //! | getchaintips                       | done            |
 //! | getchaintxstats                    | done            |
 //! | getdifficulty                      | done            |

--- a/types/src/v20/mod.rs
+++ b/types/src/v20/mod.rs
@@ -24,7 +24,7 @@
 //! | getblockfilter                     | todo            |
 //! | getblockhash                       | done            |
 //! | getblockheader                     | done            |
-//! | getblockstats                      | done (untested) |
+//! | getblockstats                      | done            |
 //! | getchaintips                       | done            |
 //! | getchaintxstats                    | done            |
 //! | getdifficulty                      | done            |

--- a/types/src/v21/mod.rs
+++ b/types/src/v21/mod.rs
@@ -24,7 +24,7 @@
 //! | getblockfilter                     | todo            |
 //! | getblockhash                       | done            |
 //! | getblockheader                     | done            |
-//! | getblockstats                      | done (untested) |
+//! | getblockstats                      | done            |
 //! | getchaintips                       | done            |
 //! | getchaintxstats                    | done            |
 //! | getdifficulty                      | done            |

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -24,7 +24,7 @@
 //! | getblockfilter                     | todo            |
 //! | getblockhash                       | done            |
 //! | getblockheader                     | done            |
-//! | getblockstats                      | done (untested) |
+//! | getblockstats                      | done            |
 //! | getchaintips                       | done            |
 //! | getchaintxstats                    | done            |
 //! | getdifficulty                      | done            |

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -25,7 +25,7 @@
 //! | getblockfrompeer                   | todo            |
 //! | getblockhash                       | done            |
 //! | getblockheader                     | done            |
-//! | getblockstats                      | done (untested) |
+//! | getblockstats                      | done            |
 //! | getchaintips                       | done            |
 //! | getchaintxstats                    | done            |
 //! | getdeploymentinfo                  | todo            |

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -25,7 +25,7 @@
 //! | getblockfrompeer                   | todo            |
 //! | getblockhash                       | done            |
 //! | getblockheader                     | done            |
-//! | getblockstats                      | done (untested) |
+//! | getblockstats                      | done            |
 //! | getchaintips                       | done            |
 //! | getchaintxstats                    | done            |
 //! | getdeploymentinfo                  | todo            |

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -25,7 +25,7 @@
 //! | getblockfrompeer                   | todo            |
 //! | getblockhash                       | done            |
 //! | getblockheader                     | done            |
-//! | getblockstats                      | done (untested) |
+//! | getblockstats                      | done            |
 //! | getchaintips                       | done            |
 //! | getchaintxstats                    | done            |
 //! | getdeploymentinfo                  | todo            |

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -26,7 +26,7 @@
 //! | getblockfrompeer                   | todo            |
 //! | getblockhash                       | done            |
 //! | getblockheader                     | done            |
-//! | getblockstats                      | done (untested) |
+//! | getblockstats                      | done            |
 //! | getchainstates                     | todo            |
 //! | getchaintips                       | done            |
 //! | getchaintxstats                    | done            |

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -26,7 +26,7 @@
 //! | getblockfrompeer                   | todo            |
 //! | getblockhash                       | done            |
 //! | getblockheader                     | done            |
-//! | getblockstats                      | done (untested) |
+//! | getblockstats                      | done            |
 //! | getchainstates                     | todo            |
 //! | getchaintips                       | done            |
 //! | getchaintxstats                    | done            |

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -26,7 +26,7 @@
 //! | getblockfrompeer                   | todo            |
 //! | getblockhash                       | done            |
 //! | getblockheader                     | done            |
-//! | getblockstats                      | done (untested) |
+//! | getblockstats                      | done            |
 //! | getchainstates                     | todo            |
 //! | getchaintips                       | done            |
 //! | getchaintxstats                    | done            |


### PR DESCRIPTION
I was confused by `getblockstats` not working and thought it did not work for version 19-24 however there was a bug in a helper function that meant we always tried to get block stats for the genesis block and this does not work for these versions. That bug is fixed in patch 2 then in patch 3 we test and set the status of `getblockstats` for all versions.

Patch 1 is a trivial cleanup to the `NodeExt` constructors. Unrelated but done while debugging this.