### PR TITLE
Fix `{create,load}wallet` on `v25`

### DIFF
--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -2,8 +2,6 @@
 
 //! Tests for methods found under the `== Wallet ==` section of the API docs.
 
-#![cfg(any(feature = "0_17_1", feature = "0_18_1"))]
-
 #[cfg(feature = "TODO")]
 use bitcoin::address::{Address, NetworkChecked};
 use bitcoin::Amount;
@@ -23,6 +21,7 @@ pub fn add_multisig_address() {
     assert!(json.into_model().is_ok());
 }
 
+#[cfg(any(feature = "0_17_1", feature = "0_18_1"))]
 #[test]
 pub fn bump_fee() {
     let node = Node::with_wallet(Wallet::Default, &[]);
@@ -40,6 +39,7 @@ pub fn bump_fee() {
     assert!(json.into_model().is_ok());
 }
 
+#[cfg(any(feature = "0_17_1", feature = "0_18_1"))]
 #[test]
 pub fn create_wallet() {
     // Implicitly tests `createwallet` because we create the default wallet.
@@ -49,6 +49,7 @@ pub fn create_wallet() {
     // optional `String` to an optional vector of strings in v25. Needs testing.
 }
 
+#[cfg(any(feature = "0_17_1", feature = "0_18_1"))]
 #[test]
 pub fn dump_priv_key() {
     let node = Node::with_wallet(Wallet::Default, &[]);
@@ -57,6 +58,7 @@ pub fn dump_priv_key() {
     assert!(json.into_model().is_ok());
 }
 
+#[cfg(any(feature = "0_17_1", feature = "0_18_1"))]
 #[test]
 pub fn dump_wallet() {
     let node = Node::with_wallet(Wallet::Default, &[]);
@@ -65,6 +67,7 @@ pub fn dump_wallet() {
     let _ = json.into_model();
 }
 
+#[cfg(any(feature = "0_17_1", feature = "0_18_1"))]
 #[test]
 pub fn get_addresses_by_label() {
     let node = Node::with_wallet(Wallet::Default, &[]);
@@ -76,6 +79,7 @@ pub fn get_addresses_by_label() {
     assert!(map.get(&addr).is_some());
 }
 
+#[cfg(any(feature = "0_17_1", feature = "0_18_1"))]
 #[test]
 // TODO: Consider testing a few different address types.
 #[cfg(feature = "TODO")]
@@ -86,6 +90,7 @@ pub fn get_address_info() {
     assert!(json.into_model().is_ok());
 }
 
+#[cfg(any(feature = "0_17_1", feature = "0_18_1"))]
 #[test]
 fn get_balance() {
     let node = Node::with_wallet(Wallet::Default, &[]);
@@ -97,6 +102,7 @@ fn get_balance() {
     assert!(json.into_model().is_ok());
 }
 
+#[cfg(any(feature = "0_17_1", feature = "0_18_1"))]
 #[test]
 #[cfg(feature = "v19")]
 fn get_balances() {
@@ -108,6 +114,7 @@ fn get_balances() {
     assert!(model.mine.trusted > Amount::ZERO); 
 }
 
+#[cfg(any(feature = "0_17_1", feature = "0_18_1"))]
 #[test]
 fn get_new_address() {
     let node = Node::with_wallet(Wallet::Default, &[]);
@@ -132,6 +139,7 @@ fn get_new_address() {
         .unwrap();
 }
 
+#[cfg(any(feature = "0_17_1", feature = "0_18_1"))]
 #[test]
 fn get_raw_change_address() {
     let node = Node::with_wallet(Wallet::Default, &[]);
@@ -139,6 +147,7 @@ fn get_raw_change_address() {
     assert!(json.into_model().is_ok());
 }
 
+#[cfg(any(feature = "0_17_1", feature = "0_18_1"))]
 #[test]
 fn get_received_by_address() {
     let amount = Amount::from_sat(10_000);
@@ -160,6 +169,7 @@ fn get_received_by_address() {
     assert_eq!(model.0, amount);
 }
 
+#[cfg(any(feature = "0_17_1", feature = "0_18_1"))]
 #[test]
 fn get_transaction() {
     let node = Node::with_wallet(Wallet::Default, &[]);
@@ -177,12 +187,14 @@ fn get_transaction() {
     assert!(json.into_model().is_ok());
 }
 
+#[cfg(any(feature = "0_17_1", feature = "0_18_1"))]
 #[test]
 fn load_wallet() {
     // Implicitly test loadwalled because we load the default wallet.
     let _ = Node::with_wallet(Wallet::Default, &[]);
 }
 
+#[cfg(any(feature = "0_17_1", feature = "0_18_1"))]
 #[test]
 #[cfg(not(any(feature = "v17", feature = "v18", feature = "v19", feature = "v20")))]
 fn unload_wallet() {
@@ -193,6 +205,7 @@ fn unload_wallet() {
     assert!(json.into_model().is_ok())
 }
 
+#[cfg(any(feature = "0_17_1", feature = "0_18_1"))]
 #[test]
 fn send_to_address() {
     let node = Node::with_wallet(Wallet::Default, &[]);

--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -39,7 +39,6 @@ pub fn bump_fee() {
     assert!(json.into_model().is_ok());
 }
 
-#[cfg(any(feature = "0_17_1", feature = "0_18_1"))]
 #[test]
 pub fn create_wallet() {
     // Implicitly tests `createwallet` because we create the default wallet.
@@ -187,7 +186,6 @@ fn get_transaction() {
     assert!(json.into_model().is_ok());
 }
 
-#[cfg(any(feature = "0_17_1", feature = "0_18_1"))]
 #[test]
 fn load_wallet() {
     // Implicitly test loadwalled because we load the default wallet.

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -247,9 +247,11 @@
 //! - Method is deprecated.
 
 mod blockchain;
+mod wallet;
 
 #[doc(inline)]
 pub use self::blockchain::{GetTxOutSetInfo, GetTxOutSetInfoError};
+pub use self::wallet::{CreateWallet, LoadWallet};
 #[doc(inline)]
 pub use crate::{
     v17::{
@@ -283,5 +285,4 @@ pub use crate::{
     },
     v21::UnloadWallet,
     v22::{GetTxOut, GetTxOutError, Logging, ScriptPubkey},
-    v25::{CreateWallet, LoadWallet},
 };

--- a/types/src/v26/wallet.rs
+++ b/types/src/v26/wallet.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! The JSON-RPC API for Bitcoin Core `v25` - wallet.
+//! The JSON-RPC API for Bitcoin Core `v26` - wallet.
 //!
 //! Types for methods found under the `== Wallet ==` section of the API docs.
 
@@ -29,11 +29,6 @@ pub struct CreateWallet {
     ///
     /// If the wallet was created using a full path, the wallet_name will be the full path.
     pub name: String,
-    /// Warning messages, if any, related to creating the wallet. Multiple messages will be delimited by newlines.
-    ///
-    /// DEPRECATED, returned only if config option -deprecatedrpc=walletwarningfield is passed. As
-    /// the content would still be the same as `warnings`, we simply ignore the field.
-    pub warning: Option<String>,
     /// Warning messages, if any, related to creating and loading the wallet.
     pub warnings: Option<Vec<String>>,
 }
@@ -41,8 +36,6 @@ pub struct CreateWallet {
 impl CreateWallet {
     /// Converts version specific type to a version nonspecific, more strongly typed type.
     pub fn into_model(self) -> model::CreateWallet {
-        // As the content of the deprecated `warning` field would be the same as `warnings`, we
-        // simply ignore the field, even in case it's set.
         model::CreateWallet { name: self.name, warnings: self.warnings.unwrap_or_default() }
     }
 
@@ -65,11 +58,6 @@ impl CreateWallet {
 pub struct LoadWallet {
     /// The wallet name if loaded successfully.
     pub name: String,
-    /// Warning messages, if any, related to creating the wallet. Multiple messages will be delimited by newlines.
-    ///
-    /// DEPRECATED, returned only if config option -deprecatedrpc=walletwarningfield is passed. As
-    /// the content would still be the same as `warnings`, we simply ignore the field.
-    pub warning: Option<String>,
     /// Warning messages, if any, related to loading the wallet.
     pub warnings: Option<Vec<String>>,
 }
@@ -77,8 +65,6 @@ pub struct LoadWallet {
 impl LoadWallet {
     /// Converts version specific type to a version nonspecific, more strongly typed type.
     pub fn into_model(self) -> model::LoadWallet {
-        // As the content of the deprecated `warning` field would be the same as `warnings`, we
-        // simply ignore the field, even in case it's set.
         model::LoadWallet { name: self.name, warnings: self.warnings.unwrap_or_default() }
     }
 

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -279,6 +279,5 @@ pub use crate::{
     },
     v21::UnloadWallet,
     v22::{GetTxOut, GetTxOutError, Logging, ScriptPubkey},
-    v25::{CreateWallet, LoadWallet},
-    v26::{GetTxOutSetInfo, GetTxOutSetInfoError},
+    v26::{CreateWallet, GetTxOutSetInfo, GetTxOutSetInfoError, LoadWallet},
 };

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -292,6 +292,5 @@ pub use crate::{
     },
     v21::UnloadWallet,
     v22::{GetTxOut, GetTxOutError, Logging, ScriptPubkey},
-    v25::{CreateWallet, LoadWallet},
-    v26::{GetTxOutSetInfo, GetTxOutSetInfoError},
+    v26::{CreateWallet, GetTxOutSetInfo, GetTxOutSetInfoError, LoadWallet},
 };


### PR DESCRIPTION
With `v25` the `warning` field was deprecated for `warnings`. While it should only be available when the `-deprecatedrpc=walletwarningfield` is passed, I was hitting parse errors even though I did not find where I
passed this argument. Here, we add the `warning` field to the `v25` types (although we ignore it as it's literally duplicative of what's in `warnings` already) to avoid the parse error.