### PR TITLE
Fix `unloadwallet` method

### DIFF
--- a/client/src/client_sync/v17/mod.rs
+++ b/client/src/client_sync/v17/mod.rs
@@ -101,6 +101,7 @@ crate::impl_client_v17__sendmany!();
 crate::impl_client_v17__sendtoaddress!();
 crate::impl_client_v17__signmessage!();
 crate::impl_client_v17__signrawtransactionwithwallet!();
+crate::impl_client_v17__unloadwallet!();
 crate::impl_client_v17__walletcreatefundedpsbt!();
 crate::impl_client_v17__walletprocesspsbt!();
 

--- a/client/src/client_sync/v17/wallet.rs
+++ b/client/src/client_sync/v17/wallet.rs
@@ -432,6 +432,22 @@ macro_rules! impl_client_v17__signrawtransactionwithwallet {
     };
 }
 
+/// Implements Bitcoin Core JSON-RPC API method `unloadwallet`.
+#[macro_export]
+macro_rules! impl_client_v17__unloadwallet {
+    () => {
+        impl Client {
+            pub fn unload_wallet(&self, wallet_name: &str) -> Result<()> {
+                match self.call("unloadwallet", &[into_json(wallet_name)?]) {
+                    Ok(serde_json::Value::Null) => Ok(()),
+                    Ok(res) => Err(Error::Returned(res.to_string())),
+                    Err(err) => Err(err.into()),
+                }
+            }
+        }
+    };
+}
+
 /// Implements Bitcoin Core JSON-RPC API method `walletcreatefundedpsbt`.
 #[macro_export]
 macro_rules! impl_client_v17__walletcreatefundedpsbt {

--- a/client/src/client_sync/v18/mod.rs
+++ b/client/src/client_sync/v18/mod.rs
@@ -96,5 +96,6 @@ crate::impl_client_v17__sendmany!();
 crate::impl_client_v17__sendtoaddress!();
 crate::impl_client_v17__signmessage!();
 crate::impl_client_v17__signrawtransactionwithwallet!();
+crate::impl_client_v17__unloadwallet!();
 crate::impl_client_v17__walletcreatefundedpsbt!();
 crate::impl_client_v17__walletprocesspsbt!();

--- a/client/src/client_sync/v19/mod.rs
+++ b/client/src/client_sync/v19/mod.rs
@@ -94,5 +94,6 @@ crate::impl_client_v17__sendmany!();
 crate::impl_client_v17__sendtoaddress!();
 crate::impl_client_v17__signmessage!();
 crate::impl_client_v17__signrawtransactionwithwallet!();
+crate::impl_client_v17__unloadwallet!();
 crate::impl_client_v17__walletcreatefundedpsbt!();
 crate::impl_client_v17__walletprocesspsbt!();

--- a/client/src/client_sync/v20.rs
+++ b/client/src/client_sync/v20.rs
@@ -92,5 +92,6 @@ crate::impl_client_v17__sendmany!();
 crate::impl_client_v17__sendtoaddress!();
 crate::impl_client_v17__signmessage!();
 crate::impl_client_v17__signrawtransactionwithwallet!();
+crate::impl_client_v17__unloadwallet!();
 crate::impl_client_v17__walletcreatefundedpsbt!();
 crate::impl_client_v17__walletprocesspsbt!();

--- a/client/src/client_sync/v21/mod.rs
+++ b/client/src/client_sync/v21/mod.rs
@@ -4,6 +4,8 @@
 //!
 //! We ignore option arguments unless they effect the shape of the returned JSON data.
 
+mod wallet;
+
 use std::collections::BTreeMap;
 use std::path::Path;
 
@@ -92,5 +94,6 @@ crate::impl_client_v17__sendmany!();
 crate::impl_client_v17__sendtoaddress!();
 crate::impl_client_v17__signmessage!();
 crate::impl_client_v17__signrawtransactionwithwallet!();
+crate::impl_client_v21__unloadwallet!();
 crate::impl_client_v17__walletcreatefundedpsbt!();
 crate::impl_client_v17__walletprocesspsbt!();

--- a/client/src/client_sync/v21/wallet.rs
+++ b/client/src/client_sync/v21/wallet.rs
@@ -3,19 +3,19 @@
 //! Macros for implementing JSON-RPC methods on a client.
 //!
 //! Specifically this is methods found under the `== Wallet ==` section of the
-//! API docs of Bitcoin Core `v22`.
+//! API docs of Bitcoin Core `v21`.
 //!
 //! All macros require `Client` to be in scope.
 //!
 //! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
 
-/// Implements Bitcoin Core JSON-RPC API method `loadwallet`
+/// Implements Bitcoin Core JSON-RPC API method `unloadwallet`
 #[macro_export]
-macro_rules! impl_client_v22__loadwallet {
+macro_rules! impl_client_v21__unloadwallet {
     () => {
         impl Client {
-            pub fn load_wallet(&self, wallet: &str) -> Result<LoadWallet> {
-                self.call("loadwallet", &[wallet.into()])
+            pub fn unload_wallet(&self, wallet: &str) -> Result<UnloadWallet> {
+                self.call("unloadwallet", &[wallet.into()])
             }
         }
     };

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -95,5 +95,6 @@ crate::impl_client_v17__sendmany!();
 crate::impl_client_v17__sendtoaddress!();
 crate::impl_client_v17__signmessage!();
 crate::impl_client_v17__signrawtransactionwithwallet!();
+crate::impl_client_v21__unloadwallet!();
 crate::impl_client_v17__walletcreatefundedpsbt!();
 crate::impl_client_v17__walletprocesspsbt!();

--- a/client/src/client_sync/v23.rs
+++ b/client/src/client_sync/v23.rs
@@ -93,7 +93,7 @@ crate::impl_client_v17__sendmany!();
 crate::impl_client_v17__sendtoaddress!();
 crate::impl_client_v17__signmessage!();
 crate::impl_client_v17__signrawtransactionwithwallet!();
-crate::impl_client_v22__unloadwallet!();
+crate::impl_client_v21__unloadwallet!();
 crate::impl_client_v17__walletcreatefundedpsbt!();
 crate::impl_client_v17__walletprocesspsbt!();
 

--- a/client/src/client_sync/v24.rs
+++ b/client/src/client_sync/v24.rs
@@ -92,6 +92,6 @@ crate::impl_client_v17__sendmany!();
 crate::impl_client_v17__sendtoaddress!();
 crate::impl_client_v17__signmessage!();
 crate::impl_client_v17__signrawtransactionwithwallet!();
-crate::impl_client_v22__unloadwallet!();
+crate::impl_client_v21__unloadwallet!();
 crate::impl_client_v17__walletcreatefundedpsbt!();
 crate::impl_client_v17__walletprocesspsbt!();

--- a/client/src/client_sync/v25.rs
+++ b/client/src/client_sync/v25.rs
@@ -92,6 +92,6 @@ crate::impl_client_v17__sendmany!();
 crate::impl_client_v17__sendtoaddress!();
 crate::impl_client_v17__signmessage!();
 crate::impl_client_v17__signrawtransactionwithwallet!();
-crate::impl_client_v22__unloadwallet!();
+crate::impl_client_v21__unloadwallet!();
 crate::impl_client_v17__walletcreatefundedpsbt!();
 crate::impl_client_v17__walletprocesspsbt!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -94,6 +94,6 @@ crate::impl_client_v17__sendmany!();
 crate::impl_client_v17__sendtoaddress!();
 crate::impl_client_v17__signmessage!();
 crate::impl_client_v17__signrawtransactionwithwallet!();
-crate::impl_client_v22__unloadwallet!();
+crate::impl_client_v21__unloadwallet!();
 crate::impl_client_v17__walletcreatefundedpsbt!();
 crate::impl_client_v17__walletprocesspsbt!();

--- a/client/src/client_sync/v27.rs
+++ b/client/src/client_sync/v27.rs
@@ -92,6 +92,6 @@ crate::impl_client_v17__sendmany!();
 crate::impl_client_v17__sendtoaddress!();
 crate::impl_client_v17__signmessage!();
 crate::impl_client_v17__signrawtransactionwithwallet!();
-crate::impl_client_v22__unloadwallet!();
+crate::impl_client_v21__unloadwallet!();
 crate::impl_client_v17__walletcreatefundedpsbt!();
 crate::impl_client_v17__walletprocesspsbt!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -95,6 +95,6 @@ crate::impl_client_v17__sendmany!();
 crate::impl_client_v17__sendtoaddress!();
 crate::impl_client_v17__signmessage!();
 crate::impl_client_v17__signrawtransactionwithwallet!();
-crate::impl_client_v22__unloadwallet!();
+crate::impl_client_v21__unloadwallet!();
 crate::impl_client_v17__walletcreatefundedpsbt!();
 crate::impl_client_v17__walletprocesspsbt!();

--- a/types/src/v17/mod.rs
+++ b/types/src/v17/mod.rs
@@ -193,7 +193,7 @@
 //! | settxfee                           | omitted         |
 //! | signmessage                        | done (untested) |
 //! | signrawtransactionwithwallet       | done (untested) |
-//! | unloadwallet                       | omitted         |
+//! | unloadwallet                       | done            |
 //! | walletcreatefundedpsbt             | done (untested) |
 //! | walletlock                         | omitted         |
 //! | walletpassphrase                   | omitted         |

--- a/types/src/v18/mod.rs
+++ b/types/src/v18/mod.rs
@@ -200,7 +200,7 @@
 //! | settxfee                           | omitted         |
 //! | signmessage                        | done (untested) |
 //! | signrawtransactionwithwallet       | done (untested) |
-//! | unloadwallet                       | omitted         |
+//! | unloadwallet                       | done            |
 //! | walletcreatefundedpsbt             | done (untested) |
 //! | walletlock                         | omitted         |
 //! | walletpassphrase                   | omitted         |

--- a/types/src/v19/mod.rs
+++ b/types/src/v19/mod.rs
@@ -197,7 +197,7 @@
 //! | setwalletflag                      | todo            |
 //! | signmessage                        | done (untested) |
 //! | signrawtransactionwithwallet       | done (untested) |
-//! | unloadwallet                       | omitted         |
+//! | unloadwallet                       | done            |
 //! | walletcreatefundedpsbt             | done (untested) |
 //! | walletlock                         | omitted         |
 //! | walletpassphrase                   | omitted         |

--- a/types/src/v20/mod.rs
+++ b/types/src/v20/mod.rs
@@ -198,7 +198,7 @@
 //! | setwalletflag                      | todo            |
 //! | signmessage                        | done (untested) |
 //! | signrawtransactionwithwallet       | done (untested) |
-//! | unloadwallet                       | omitted         |
+//! | unloadwallet                       | done            |
 //! | walletcreatefundedpsbt             | done (untested) |
 //! | walletlock                         | omitted         |
 //! | walletpassphrase                   | omitted         |

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -213,7 +213,7 @@
 //! | setwalletflag                      | todo            |
 //! | signmessage                        | done (untested) |
 //! | signrawtransactionwithwallet       | done (untested) |
-//! | unloadwallet                       | omitted         |
+//! | unloadwallet                       | done            |
 //! | upgradewallet                      | todo            |
 //! | walletcreatefundedpsbt             | done (untested) |
 //! | walletdisplayaddress               | todo            |

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -206,7 +206,7 @@
 //! | setwalletflag                      | todo            |
 //! | signmessage                        | done (untested) |
 //! | signrawtransactionwithwallet       | done (untested) |
-//! | unloadwallet                       | omitted         |
+//! | unloadwallet                       | done            |
 //! | upgradewallet                      | todo            |
 //! | walletcreatefundedpsbt             | done (untested) |
 //! | walletdisplayaddress               | todo            |

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -210,7 +210,7 @@
 //! | signmessage                        | done (untested) |
 //! | signrawtransactionwithwallet       | done (untested) |
 //! | simulaterawtransaction             | todo            |
-//! | unloadwallet                       | omitted         |
+//! | unloadwallet                       | done            |
 //! | upgradewallet                      | todo            |
 //! | walletcreatefundedpsbt             | done (untested) |
 //! | walletdisplayaddress               | todo            |

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -211,7 +211,7 @@
 //! | signmessage                        | done (untested) |
 //! | signrawtransactionwithwallet       | done (untested) |
 //! | simulaterawtransaction             | todo            |
-//! | unloadwallet                       | omitted         |
+//! | unloadwallet                       | done            |
 //! | upgradewallet                      | todo            |
 //! | walletcreatefundedpsbt             | done (untested) |
 //! | walletdisplayaddress               | todo            |
@@ -241,7 +241,7 @@
 mod wallet;
 
 #[doc(inline)]
-pub use self::wallet::{CreateWallet, LoadWallet};
+pub use self::wallet::{CreateWallet, LoadWallet, UnloadWallet};
 #[doc(inline)]
 pub use crate::{
     v17::{
@@ -273,6 +273,5 @@ pub use crate::{
         MempoolEntry, MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, Softfork,
         SoftforkType,
     },
-    v21::UnloadWallet,
     v22::{GetTxOut, GetTxOutError, Logging, ScriptPubkey},
 };

--- a/types/src/v25/wallet.rs
+++ b/types/src/v25/wallet.rs
@@ -65,7 +65,7 @@ impl CreateWallet {
 pub struct LoadWallet {
     /// The wallet name if loaded successfully.
     pub name: String,
-    /// Warning messages, if any, related to creating the wallet. Multiple messages will be delimited by newlines.
+    /// Warning messages, if any, related to loading the wallet. Multiple messages will be delimited by newlines.
     ///
     /// DEPRECATED, returned only if config option -deprecatedrpc=walletwarningfield is passed. As
     /// the content would still be the same as `warnings`, we simply ignore the field.
@@ -84,4 +84,32 @@ impl LoadWallet {
 
     /// Returns the loaded wallet name.
     pub fn name(self) -> String { self.into_model().name }
+}
+
+/// Result of the JSON-RPC method `unloadwallet`.
+///
+/// > unloadwallet ( "wallet_name" load_on_startup )
+/// >
+/// > Unloads the wallet referenced by the request endpoint otherwise unloads the wallet specified in the argument.
+/// > Specifying the wallet name on a wallet endpoint is invalid.
+/// >
+/// > Arguments:
+/// > 1. wallet_name        (string, optional, default=the wallet name from the RPC endpoint) The name of the wallet to unload. If provided both here and in the RPC endpoint, the two must be identical.
+/// > 2. load_on_startup    (boolean, optional) Save wallet name to persistent settings and load on startup. True to add wallet to startup list, false to remove, null to leave unchanged.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct UnloadWallet {
+    /// Warning messages, if any, related to unloading the wallet. Multiple messages will be delimited by newlines.
+    ///
+    /// DEPRECATED, returned only if config option -deprecatedrpc=walletwarningfield is passed. As
+    /// the content would still be the same as `warnings`, we simply ignore the field.
+    pub warning: Option<String>,
+    /// Warning messages, if any, related to loading the wallet.
+    pub warnings: Option<Vec<String>>,
+}
+
+impl UnloadWallet {
+    /// Converts version specific type to a version nonspecific, more strongly typed type.
+    pub fn into_model(self) -> model::UnloadWallet {
+        model::UnloadWallet { warnings: self.warnings.unwrap_or_default() }
+    }
 }

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -219,7 +219,7 @@
 //! | signmessage                        | done (untested) |
 //! | signrawtransactionwithwallet       | done (untested) |
 //! | simulaterawtransaction             | todo            |
-//! | unloadwallet                       | omitted         |
+//! | unloadwallet                       | done            |
 //! | upgradewallet                      | todo            |
 //! | walletcreatefundedpsbt             | done (untested) |
 //! | walletdisplayaddress               | todo            |
@@ -251,7 +251,7 @@ mod wallet;
 
 #[doc(inline)]
 pub use self::blockchain::{GetTxOutSetInfo, GetTxOutSetInfoError};
-pub use self::wallet::{CreateWallet, LoadWallet};
+pub use self::wallet::{CreateWallet, LoadWallet, UnloadWallet};
 #[doc(inline)]
 pub use crate::{
     v17::{
@@ -283,6 +283,5 @@ pub use crate::{
         MempoolEntry, MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, Softfork,
         SoftforkType,
     },
-    v21::UnloadWallet,
     v22::{GetTxOut, GetTxOutError, Logging, ScriptPubkey},
 };

--- a/types/src/v26/wallet.rs
+++ b/types/src/v26/wallet.rs
@@ -71,3 +71,26 @@ impl LoadWallet {
     /// Returns the loaded wallet name.
     pub fn name(self) -> String { self.into_model().name }
 }
+
+/// Result of the JSON-RPC method `unloadwallet`.
+///
+/// > unloadwallet ( "wallet_name" load_on_startup )
+/// >
+/// > Unloads the wallet referenced by the request endpoint, otherwise unloads the wallet specified in the argument.
+/// > Specifying the wallet name on a wallet endpoint is invalid.
+/// >
+/// > Arguments:
+/// > 1. wallet_name        (string, optional, default=the wallet name from the RPC endpoint) The name of the wallet to unload. If provided both here and in the RPC endpoint, the two must be identical.
+/// > 2. load_on_startup    (boolean, optional) Save wallet name to persistent settings and load on startup. True to add wallet to startup list, false to remove, null to leave unchanged.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct UnloadWallet {
+    /// Warning messages, if any, related to loading the wallet.
+    pub warnings: Option<Vec<String>>,
+}
+
+impl UnloadWallet {
+    /// Converts version specific type to a version nonspecific, more strongly typed type.
+    pub fn into_model(self) -> model::UnloadWallet {
+        model::UnloadWallet { warnings: self.warnings.unwrap_or_default() }
+    }
+}

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -219,7 +219,7 @@
 //! | signmessage                        | done (untested) |
 //! | signrawtransactionwithwallet       | done (untested) |
 //! | simulaterawtransaction             | todo            |
-//! | unloadwallet                       | omitted         |
+//! | unloadwallet                       | done            |
 //! | upgradewallet                      | todo            |
 //! | walletcreatefundedpsbt             | done (untested) |
 //! | walletdisplayaddress               | todo            |
@@ -277,7 +277,6 @@ pub use crate::{
         MempoolEntry, MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, Softfork,
         SoftforkType,
     },
-    v21::UnloadWallet,
     v22::{GetTxOut, GetTxOutError, Logging, ScriptPubkey},
-    v26::{CreateWallet, GetTxOutSetInfo, GetTxOutSetInfoError, LoadWallet},
+    v26::{CreateWallet, GetTxOutSetInfo, GetTxOutSetInfoError, LoadWallet, UnloadWallet},
 };

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -221,7 +221,7 @@
 //! | signmessage                        | done (untested) |
 //! | signrawtransactionwithwallet       | done (untested) |
 //! | simulaterawtransaction             | todo            |
-//! | unloadwallet                       | omitted         |
+//! | unloadwallet                       | done            |
 //! | upgradewallet                      | todo            |
 //! | walletcreatefundedpsbt             | done (untested) |
 //! | walletdisplayaddress               | todo            |
@@ -290,7 +290,6 @@ pub use crate::{
         GetMempoolDescendantsVerbose, GetMempoolEntry, MapMempoolEntryError, MempoolEntry,
         MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, Softfork, SoftforkType,
     },
-    v21::UnloadWallet,
     v22::{GetTxOut, GetTxOutError, Logging, ScriptPubkey},
-    v26::{CreateWallet, GetTxOutSetInfo, GetTxOutSetInfoError, LoadWallet},
+    v26::{CreateWallet, GetTxOutSetInfo, GetTxOutSetInfoError, LoadWallet, UnloadWallet},
 };


### PR DESCRIPTION
Starting at Core version 21 the `unloadwallet` method starts returning a json object (with warnings in it). Prior to v21 it returned null.

There is a mistake in the client currently, the `unloadwallet` method is changed in v22 but should have been in v21.

Fix up the types, the client implementation, and the integration tests to fully test unload.

Add an integration test function that creates, loads, unloads a random wallet.

As a side note, keep the test names `load_wallet`, `unload_wallet` and call the other function - this is done so that the tests can be verified with the `verify` tool.
