### PR TITLE
Bump version number to 0.7.0 in all three crates

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -153,7 +153,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "corepc-client"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "bitcoin",
  "corepc-types",
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-node"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-types"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "bitcoin",
  "serde",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -153,7 +153,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "corepc-client"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "bitcoin",
  "corepc-types",
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-node"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-types"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "bitcoin",
  "serde",

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.7.0 2025-04-04
+
+- Fix unloadwallet method [#110](https://github.com/rust-bitcoin/corepc/pull/110)
+- Implement methods from the mining section [#106](https://github.com/rust-bitcoin/corepc/pull/106)
+
 # 0.6.1 - 2025-13-13
 
 - Enable `std` feature in `types` crate [#98](https://github.com/rust-bitcoin/corepc/pull/98)

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-client"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/corepc"
@@ -22,7 +22,7 @@ client-sync = ["jsonrpc"]
 
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false, features = ["std", "serde"] }
-types = { package = "corepc-types", version = "0.6.1", default-features = false, features = ["std"] }
+types = { package = "corepc-types", version = "0.7.0", default-features = false, features = ["std"] }
 log = "0.4"
 serde = { version = "1.0.103", default-features = false, features = [ "derive", "alloc" ] }
 serde_json = { version = "1.0.117" }

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -50,8 +50,8 @@ TODO = []                       # This is a dirty hack while writing the tests.
 
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false, features = ["std", "serde"] }
-client = { package = "corepc-client", version = "0.6.1", default-features = false, features = ["client-sync"] }
-node = { package = "corepc-node", version = "0.6.1", default-features = false, features = ["download"] }
+client = { package = "corepc-client", version = "0.7.0", default-features = false, features = ["client-sync"] }
+node = { package = "corepc-node", version = "0.7.0", default-features = false, features = ["download"] }
 rand = "0.8.5"
 env_logger = "0.9.0"
 

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.7.0 2025-04-04
+
+- Retry initial client connections [#111](https://github.com/rust-bitcoin/corepc/pull/111)
+- 
+
 # 0.6.1 - 2025-03-11
 
 - Fix the docs.rs build [#92](https://github.com/rust-bitcoin/corepc/pull/92)

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-node"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["Riccardo Casatta <riccardo@casatta.it>", "Tobin C. Harding <me@tobin.cc>"]
 license = "MIT"
 repository = "https://github.com/rust-bitcoin/corepc"
@@ -13,7 +13,7 @@ rust-version = "1.63.0"
 exclude = ["tests", "contrib"]
 
 [dependencies]
-corepc-client = { version = "0.6.1", features = ["client-sync"] }
+corepc-client = { version = "0.7.0", features = ["client-sync"] }
 log = { version = "0.4", default-features = false }
 which = { version = "3.1.1", default-features = false }
 anyhow = { version = "1.0.66", default-features = false, features = ["std"] }

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.7.0 2025-04-04
+
+- Fix `{create,load}wallet` on `v25` [#108](https://github.com/rust-bitcoin/corepc/pull/108)
+- Fix unloadwallet method [#110](https://github.com/rust-bitcoin/corepc/pull/110)
+- Implement methods from the mining section [#106](https://github.com/rust-bitcoin/corepc/pull/106)
+
 # 0.6.1 - 2025-03-11
 
 - Add missing transaction categories [#91](https://github.com/rust-bitcoin/corepc/pull/91)

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-types"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/corepc"


### PR DESCRIPTION
In preparation for releasing all three crates; add changelog entries, bump the version number, and update the lock files.