### PR TITLE
simplify error message output for unsupported version output

### DIFF
--- a/verify/src/main.rs
+++ b/verify/src/main.rs
@@ -43,10 +43,8 @@ fn main() -> Result<()> {
     } else if let Ok(v) = version.parse::<Version>() {
         verify_version(v, test_output, quiet)?;
     } else {
-        eprint!("Unrecognised version: {} (supported versions:", version);
-        for version in VERSIONS {
-            eprint!(" {}", version);
-        }
+        eprint!("Unrecognised version: {} (supported versions: ", version);
+        eprint!("{} - {}", VERSIONS[0], VERSIONS[VERSIONS.len() - 1]);
         eprintln!(")");
         process::exit(1);
     }


### PR DESCRIPTION
#### Revised the output for unrecognised versions to:

```shell
  verify v1234

  Unrecognised version: v1234 (supported versions: v17 - v28)
```
This removes the noise of listing all versions by displaying a concise version range.

Closes #65
