### PR TITLE
Fix version for 27.2 feature flag

### DIFF
--- a/node/src/versions.rs
+++ b/node/src/versions.rs
@@ -25,7 +25,7 @@ compile_error!("enable a feature in order to select the version of Bitcoin Core 
 pub const VERSION: &str = "28.0";
 
 #[cfg(all(feature = "27_2", not(feature = "28_0")))]
-pub const VERSION: &str = "27.1";
+pub const VERSION: &str = "27.2";
 
 #[cfg(all(feature = "27_1", not(feature = "27_2")))]
 pub const VERSION: &str = "27.1";


### PR DESCRIPTION
When running with the "27_2" feature flag enabled, the VERSION constant was incorrectly set to "27.1". This PR fixes the version string to properly reflect "27.2" when the corresponding feature flag is active.