### PR TITLE
verify: Check that no model type exists

### DIFF
--- a/types/src/model/mod.rs
+++ b/types/src/model/mod.rs
@@ -51,8 +51,9 @@ pub use self::{
         GetTransactionDetail, GetUnconfirmedBalance, GetWalletInfo, ListAddressGroupings,
         ListAddressGroupingsItem, ListLabels, ListLockUnspent, ListLockUnspentItem,
         ListReceivedByAddress, ListReceivedByAddressItem, ListSinceBlock,
-        ListSinceBlockTransaction, ListTransactions, ListTransactionsItem, ListUnspentItem,
-        ListWallets, LoadWallet, RescanBlockchain, ScriptType, SendMany, SendToAddress,
-        SignMessage, TransactionCategory, UnloadWallet, WalletCreateFundedPsbt, WalletProcessPsbt,
+        ListSinceBlockTransaction, ListTransactions, ListTransactionsItem, ListUnspent,
+        ListUnspentItem, ListWallets, LoadWallet, RescanBlockchain, ScriptType, SendMany,
+        SendToAddress, SignMessage, TransactionCategory, UnloadWallet, WalletCreateFundedPsbt,
+        WalletProcessPsbt,
     },
 };

--- a/verify/src/main.rs
+++ b/verify/src/main.rs
@@ -164,6 +164,10 @@ fn check_types_exist_if_required(version: Version, method_name: &str) -> Result<
         if !model::type_exists(version, method_name)? {
             eprintln!("missing model type: {}", output_method(out));
         }
+    } else {
+        if model::type_exists(version, method_name)? {
+            eprintln!("found model type when none expected: {}", output_method(out));
+        }
     }
     Ok(())
 }

--- a/verify/src/method/v19.rs
+++ b/verify/src/method/v19.rs
@@ -10,7 +10,7 @@ pub const METHODS: &[Method] = &[
     Method::new_modelled("getblock", "GetBlockVerboseZero", "get_block"), // We only check one of the types.
     Method::new_modelled("getblockchaininfo", "GetBlockchainInfo", "get_blockchain_info"),
     Method::new_modelled("getblockcount", "GetBlockCount", "get_block_count"),
-    Method::new_no_model("getblockfilter", "GetBlockFilter", "get_block_filter"), // TODO: Use modelled.
+    Method::new_modelled("getblockfilter", "GetBlockFilter", "get_block_filter"),
     Method::new_modelled("getblockhash", "GetBlockHash", "get_block_hash"),
     Method::new_modelled("getblockheader", "GetBlockHeader", "get_block_header"),
     Method::new_modelled("getblockstats", "GetBlockStats", "get_block_stats"),

--- a/verify/src/model.rs
+++ b/verify/src/model.rs
@@ -40,9 +40,7 @@ pub fn type_exists(version: Version, method_name: &str) -> Result<bool> {
     };
 
     if let Some(Return::Type(s)) = method.ret {
-        if method.requires_model {
-            return crate::grep_for_string(&path(), s);
-        }
+        return crate::grep_for_re_export(&path(), s);
     }
     Ok(false)
 }


### PR DESCRIPTION
If a method does not require a model we currently do not check this. Add logic to do so.

Fix the warnings found:

- Re-export `ListUnspent`
- Use the correct `Method` constructor in v19

Fix: #70