### PR TITLE
verify: Comment sections

### DIFF
--- a/verify/src/method/v19.rs
+++ b/verify/src/method/v19.rs
@@ -6,6 +6,7 @@ use super::Method;
 
 /// Data for the JSON RPC methods provided by Bitcoin Core v19.
 pub const METHODS: &[Method] = &[
+    // blockchain
     Method::new_modelled("getbestblockhash", "GetBestBlockHash", "get_best_block_hash"),
     Method::new_modelled("getblock", "GetBlockVerboseZero", "get_block"), // We only check one of the types.
     Method::new_modelled("getblockchaininfo", "GetBlockchainInfo", "get_blockchain_info"),
@@ -36,18 +37,22 @@ pub const METHODS: &[Method] = &[
     Method::new_bool("verifychain", "verify_chain"),
     Method::new_modelled("verifytxoutproof", "VerifyTxOutProof", "verify_tx_out_proof"),
     Method::new_no_model("getrpcinfo", "GetRpcInfo", "get_rpc_info"),
+    // control
     Method::new_no_model("getmemoryinfo", "GetMemoryInfoStats", "get_memory_info"),
     Method::new_string("help", "help"),
     Method::new_no_model("logging", "Logging", "logging"),
     Method::new_nothing("stop", "stop"),
     Method::new_numeric("uptime", "uptime"),
+    // generating
     Method::new_modelled("generatetoaddress", "GenerateToAddress", "generate_to_address"),
+    // mining
     Method::new_modelled("getblocktemplate", "GetBlockTemplate", "get_block_template"),
     Method::new_no_model("getmininginfo", "GetMiningInfo", "get_mining_info"),
     Method::new_nothing("getnetworkhashps", "get_network_hashes_per_second"),
     Method::new_bool("prioritisetransaction", "prioritise_transaction"),
     Method::new_nothing("submitblock", "submit_block"),
     Method::new_nothing("submitheader", "submit_header"),
+    // network
     Method::new_nothing("addnode", "add_node"),
     Method::new_nothing("clearbanned", "clear_banned"),
     Method::new_nothing("disconnectnode", "disconnect_node"),
@@ -61,6 +66,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("ping", "ping"),
     Method::new_nothing("setban", "set_ban"),
     Method::new_nothing("setnetworkactive", "set_network_active"),
+    // raw transactions
     Method::new_modelled("analyzepsbt", "AnalyzePsbt", "analyze_psbt"),
     Method::new_nothing("combinepsbt", "combine_psbt"),
     Method::new_nothing("combinerawtransaction", "combine_raw_transaction"),
@@ -78,6 +84,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("signrawtransactionwithkey", "sign_raw_transaction_with_key"),
     Method::new_nothing("testmempoolaccept", "test_mempool_accept"),
     Method::new_modelled("utxoupdatepsbt", "UtxoUpdatePsbt", "utxo_update_psbt"),
+    // util
     Method::new_modelled("createmultisig", "CreateMultisig", "create_multisig"),
     Method::new_modelled("deriveaddresses", "DeriveAddresses", "derive_addresses"),
     Method::new_nothing("estimatesmartfee", "estimate_smart_fee"),
@@ -85,6 +92,7 @@ pub const METHODS: &[Method] = &[
     Method::new_string("signmessagewithprivkey", "sign_message_with_priv_key"),
     Method::new_modelled("validateaddress", "ValidateAddress", "validate_address"),
     Method::new_bool("verifymessage", "verify_message"),
+    // wallet
     Method::new_nothing("abandontransaction", "abandon_transaction"),
     Method::new_nothing("abortrescan", "abort_rescan"),
     Method::new_modelled("addmultisigaddress", "AddMultisigAddress", "add_multisig_address"),
@@ -156,5 +164,6 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("walletpassphrase", "wallet_passphrase"),
     Method::new_nothing("walletpassphrasechange", "wallet_passphrase_change"),
     Method::new_modelled("walletprocesspsbt", "WalletProcessPsbt", "wallet_process_psbt"),
+    // zmq
     Method::new_no_model("getzmqnotifications", "GetZmqNotifications", "get_zmq_notifications"),
 ];

--- a/verify/src/method/v20.rs
+++ b/verify/src/method/v20.rs
@@ -6,6 +6,7 @@ use super::Method;
 
 /// Data for the JSON RPC methods provided by Bitcoin Core v20.
 pub const METHODS: &[Method] = &[
+    // blockchain
     Method::new_modelled("getbestblockhash", "GetBestBlockHash", "get_best_block_hash"),
     Method::new_modelled("getblock", "GetBlockVerboseZero", "get_block"), // We only check one of the types.
     Method::new_modelled("getblockchaininfo", "GetBlockchainInfo", "get_blockchain_info"),
@@ -36,19 +37,23 @@ pub const METHODS: &[Method] = &[
     Method::new_bool("verifychain", "verify_chain"),
     Method::new_modelled("verifytxoutproof", "VerifyTxOutProof", "verify_tx_out_proof"),
     Method::new_no_model("getrpcinfo", "GetRpcInfo", "get_rpc_info"),
+    // control
     Method::new_no_model("getmemoryinfo", "GetMemoryInfoStats", "get_memory_info"),
     Method::new_string("help", "help"),
     Method::new_no_model("logging", "Logging", "logging"),
     Method::new_nothing("stop", "stop"),
     Method::new_numeric("uptime", "uptime"),
+    // generating
     Method::new_modelled("generatetoaddress", "GenerateToAddress", "generate_to_address"),
     Method::new_modelled("generatetodescriptor", "GenerateToDescriptor", "generate_to_descriptor"),
+    // mining
     Method::new_modelled("getblocktemplate", "GetBlockTemplate", "get_block_template"),
     Method::new_no_model("getmininginfo", "GetMiningInfo", "get_mining_info"),
     Method::new_nothing("getnetworkhashps", "get_network_hashes_per_second"),
     Method::new_bool("prioritisetransaction", "prioritise_transaction"),
     Method::new_nothing("submitblock", "submit_block"),
     Method::new_nothing("submitheader", "submit_header"),
+    // network
     Method::new_nothing("addnode", "add_node"),
     Method::new_nothing("clearbanned", "clear_banned"),
     Method::new_nothing("disconnectnode", "disconnect_node"),
@@ -62,6 +67,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("ping", "ping"),
     Method::new_nothing("setban", "set_ban"),
     Method::new_nothing("setnetworkactive", "set_network_active"),
+    // raw transactions
     Method::new_modelled("analyzepsbt", "AnalyzePsbt", "analyze_psbt"),
     Method::new_nothing("combinepsbt", "combine_psbt"),
     Method::new_nothing("combinerawtransaction", "combine_raw_transaction"),
@@ -79,6 +85,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("signrawtransactionwithkey", "sign_raw_transaction_with_key"),
     Method::new_nothing("testmempoolaccept", "test_mempool_accept"),
     Method::new_modelled("utxoupdatepsbt", "UtxoUpdatePsbt", "utxo_update_psbt"),
+    // util
     Method::new_modelled("createmultisig", "CreateMultisig", "create_multisig"),
     Method::new_modelled("deriveaddresses", "DeriveAddresses", "derive_addresses"),
     Method::new_nothing("estimatesmartfee", "estimate_smart_fee"),
@@ -86,6 +93,7 @@ pub const METHODS: &[Method] = &[
     Method::new_string("signmessagewithprivkey", "sign_message_with_priv_key"),
     Method::new_modelled("validateaddress", "ValidateAddress", "validate_address"),
     Method::new_bool("verifymessage", "verify_message"),
+    // wallet
     Method::new_nothing("abandontransaction", "abandon_transaction"),
     Method::new_nothing("abortrescan", "abort_rescan"),
     Method::new_modelled("addmultisigaddress", "AddMultisigAddress", "add_multisig_address"),
@@ -157,5 +165,6 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("walletpassphrase", "wallet_passphrase"),
     Method::new_nothing("walletpassphrasechange", "wallet_passphrase_change"),
     Method::new_modelled("walletprocesspsbt", "WalletProcessPsbt", "wallet_process_psbt"),
+    // zmq
     Method::new_no_model("getzmqnotifications", "GetZmqNotifications", "get_zmq_notifications"),
 ];

--- a/verify/src/method/v21.rs
+++ b/verify/src/method/v21.rs
@@ -6,6 +6,7 @@ use super::Method;
 
 /// Data for the JSON RPC methods provided by Bitcoin Core v21.
 pub const METHODS: &[Method] = &[
+    // blockchain
     Method::new_modelled("getbestblockhash", "GetBestBlockHash", "get_best_block_hash"),
     Method::new_modelled("getblock", "GetBlockVerboseZero", "get_block"), // We only check one of the types.
     Method::new_modelled("getblockchaininfo", "GetBlockchainInfo", "get_blockchain_info"),
@@ -35,21 +36,25 @@ pub const METHODS: &[Method] = &[
     Method::new_modelled("scantxoutset", "ScanTxOutSet", "scan_tx_out_set"),
     Method::new_bool("verifychain", "verify_chain"),
     Method::new_modelled("verifytxoutproof", "VerifyTxOutProof", "verify_tx_out_proof"),
-    Method::new_no_model("getrpcinfo", "GetRpcInfo", "get_rpc_info"),
+    // control
     Method::new_no_model("getmemoryinfo", "GetMemoryInfoStats", "get_memory_info"),
+    Method::new_no_model("getrpcinfo", "GetRpcInfo", "get_rpc_info"),
     Method::new_string("help", "help"),
     Method::new_no_model("logging", "Logging", "logging"),
     Method::new_nothing("stop", "stop"),
     Method::new_numeric("uptime", "uptime"),
+    // generating
     Method::new_modelled("generateblock", "GenerateBlock", "generate_block"),
     Method::new_modelled("generatetoaddress", "GenerateToAddress", "generate_to_address"),
     Method::new_modelled("generatetodescriptor", "GenerateToDescriptor", "generate_to_descriptor"),
+    // mining
     Method::new_modelled("getblocktemplate", "GetBlockTemplate", "get_block_template"),
     Method::new_no_model("getmininginfo", "GetMiningInfo", "get_mining_info"),
     Method::new_nothing("getnetworkhashps", "get_network_hashes_per_second"),
     Method::new_bool("prioritisetransaction", "prioritise_transaction"),
     Method::new_nothing("submitblock", "submit_block"),
     Method::new_nothing("submitheader", "submit_header"),
+    // network
     Method::new_nothing("addnode", "add_node"),
     Method::new_nothing("clearbanned", "clear_banned"),
     Method::new_nothing("disconnectnode", "disconnect_node"),
@@ -63,6 +68,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("ping", "ping"),
     Method::new_nothing("setban", "set_ban"),
     Method::new_nothing("setnetworkactive", "set_network_active"),
+    // raw transactions
     Method::new_modelled("analyzepsbt", "AnalyzePsbt", "analyze_psbt"),
     Method::new_nothing("combinepsbt", "combine_psbt"),
     Method::new_nothing("combinerawtransaction", "combine_raw_transaction"),
@@ -80,6 +86,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("signrawtransactionwithkey", "sign_raw_transaction_with_key"),
     Method::new_nothing("testmempoolaccept", "test_mempool_accept"),
     Method::new_modelled("utxoupdatepsbt", "UtxoUpdatePsbt", "utxo_update_psbt"),
+    // util
     Method::new_modelled("createmultisig", "CreateMultisig", "create_multisig"),
     Method::new_modelled("deriveaddresses", "DeriveAddresses", "derive_addresses"),
     Method::new_nothing("estimatesmartfee", "estimate_smart_fee"),
@@ -88,6 +95,7 @@ pub const METHODS: &[Method] = &[
     Method::new_string("signmessagewithprivkey", "sign_message_with_priv_key"),
     Method::new_modelled("validateaddress", "ValidateAddress", "validate_address"),
     Method::new_bool("verifymessage", "verify_message"),
+    // wallet
     Method::new_nothing("abandontransaction", "abandon_transaction"),
     Method::new_nothing("abortrescan", "abort_rescan"),
     Method::new_modelled("addmultisigaddress", "AddMultisigAddress", "add_multisig_address"),
@@ -163,5 +171,6 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("walletpassphrase", "wallet_passphrase"),
     Method::new_nothing("walletpassphrasechange", "wallet_passphrase_change"),
     Method::new_modelled("walletprocesspsbt", "WalletProcessPsbt", "wallet_process_psbt"),
+    // zmq
     Method::new_no_model("getzmqnotifications", "GetZmqNotifications", "get_zmq_notifications"),
 ];

--- a/verify/src/method/v22.rs
+++ b/verify/src/method/v22.rs
@@ -6,6 +6,7 @@ use super::Method;
 
 /// Data for the JSON RPC methods provided by Bitcoin Core v22.
 pub const METHODS: &[Method] = &[
+    // blockchain
     Method::new_modelled("getbestblockhash", "GetBestBlockHash", "get_best_block_hash"),
     Method::new_modelled("getblock", "GetBlockVerboseZero", "get_block"), // We only check one of the types.
     Method::new_modelled("getblockchaininfo", "GetBlockchainInfo", "get_blockchain_info"),
@@ -35,21 +36,25 @@ pub const METHODS: &[Method] = &[
     Method::new_modelled("scantxoutset", "ScanTxOutSet", "scan_tx_out_set"),
     Method::new_bool("verifychain", "verify_chain"),
     Method::new_modelled("verifytxoutproof", "VerifyTxOutProof", "verify_tx_out_proof"),
-    Method::new_no_model("getrpcinfo", "GetRpcInfo", "get_rpc_info"),
+    // control
     Method::new_no_model("getmemoryinfo", "GetMemoryInfoStats", "get_memory_info"),
+    Method::new_no_model("getrpcinfo", "GetRpcInfo", "get_rpc_info"),
     Method::new_string("help", "help"),
     Method::new_no_model("logging", "Logging", "logging"),
     Method::new_nothing("stop", "stop"),
     Method::new_numeric("uptime", "uptime"),
+    // generating
     Method::new_modelled("generateblock", "GenerateBlock", "generate_block"),
     Method::new_modelled("generatetoaddress", "GenerateToAddress", "generate_to_address"),
     Method::new_modelled("generatetodescriptor", "GenerateToDescriptor", "generate_to_descriptor"),
+    // mining
     Method::new_modelled("getblocktemplate", "GetBlockTemplate", "get_block_template"),
     Method::new_no_model("getmininginfo", "GetMiningInfo", "get_mining_info"),
     Method::new_nothing("getnetworkhashps", "get_network_hashes_per_second"),
     Method::new_bool("prioritisetransaction", "prioritise_transaction"),
     Method::new_nothing("submitblock", "submit_block"),
     Method::new_nothing("submitheader", "submit_header"),
+    // network
     Method::new_nothing("addnode", "add_node"),
     Method::new_nothing("clearbanned", "clear_banned"),
     Method::new_nothing("disconnectnode", "disconnect_node"),
@@ -63,6 +68,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("ping", "ping"),
     Method::new_nothing("setban", "set_ban"),
     Method::new_nothing("setnetworkactive", "set_network_active"),
+    // raw transactions
     Method::new_modelled("analyzepsbt", "AnalyzePsbt", "analyze_psbt"),
     Method::new_nothing("combinepsbt", "combine_psbt"),
     Method::new_nothing("combinerawtransaction", "combine_raw_transaction"),
@@ -80,7 +86,9 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("signrawtransactionwithkey", "sign_raw_transaction_with_key"),
     Method::new_nothing("testmempoolaccept", "test_mempool_accept"),
     Method::new_modelled("utxoupdatepsbt", "UtxoUpdatePsbt", "utxo_update_psbt"),
+    // signer
     Method::new_modelled("enumeratesigners", "EnumerateSigners", "enumerate_signers"),
+    // util
     Method::new_modelled("createmultisig", "CreateMultisig", "create_multisig"),
     Method::new_modelled("deriveaddresses", "DeriveAddresses", "derive_addresses"),
     Method::new_nothing("estimatesmartfee", "estimate_smart_fee"),
@@ -89,6 +97,7 @@ pub const METHODS: &[Method] = &[
     Method::new_string("signmessagewithprivkey", "sign_message_with_priv_key"),
     Method::new_modelled("validateaddress", "ValidateAddress", "validate_address"),
     Method::new_bool("verifymessage", "verify_message"),
+    // wallet
     Method::new_nothing("abandontransaction", "abandon_transaction"),
     Method::new_nothing("abortrescan", "abort_rescan"),
     Method::new_modelled("addmultisigaddress", "AddMultisigAddress", "add_multisig_address"),
@@ -166,5 +175,6 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("walletpassphrase", "wallet_passphrase"),
     Method::new_nothing("walletpassphrasechange", "wallet_passphrase_change"),
     Method::new_modelled("walletprocesspsbt", "WalletProcessPsbt", "wallet_process_psbt"),
+    // zmq
     Method::new_no_model("getzmqnotifications", "GetZmqNotifications", "get_zmq_notifications"),
 ];

--- a/verify/src/method/v23.rs
+++ b/verify/src/method/v23.rs
@@ -6,6 +6,7 @@ use super::Method;
 
 /// Data for the JSON RPC methods provided by Bitcoin Core v23.
 pub const METHODS: &[Method] = &[
+    // blockchain
     Method::new_modelled("getbestblockhash", "GetBestBlockHash", "get_best_block_hash"),
     Method::new_modelled("getblock", "GetBlockVerboseZero", "get_block"), // We only check one of the types.
     Method::new_modelled("getblockchaininfo", "GetBlockchainInfo", "get_blockchain_info"),
@@ -37,18 +38,21 @@ pub const METHODS: &[Method] = &[
     Method::new_modelled("scantxoutset", "ScanTxOutSet", "scan_tx_out_set"),
     Method::new_bool("verifychain", "verify_chain"),
     Method::new_modelled("verifytxoutproof", "VerifyTxOutProof", "verify_tx_out_proof"),
-    Method::new_no_model("getrpcinfo", "GetRpcInfo", "get_rpc_info"),
+    // control
     Method::new_no_model("getmemoryinfo", "GetMemoryInfoStats", "get_memory_info"),
+    Method::new_no_model("getrpcinfo", "GetRpcInfo", "get_rpc_info"),
     Method::new_string("help", "help"),
     Method::new_no_model("logging", "Logging", "logging"),
     Method::new_nothing("stop", "stop"),
     Method::new_numeric("uptime", "uptime"),
+    // mining
     Method::new_modelled("getblocktemplate", "GetBlockTemplate", "get_block_template"),
     Method::new_no_model("getmininginfo", "GetMiningInfo", "get_mining_info"),
     Method::new_nothing("getnetworkhashps", "get_network_hashes_per_second"),
     Method::new_bool("prioritisetransaction", "prioritise_transaction"),
     Method::new_nothing("submitblock", "submit_block"),
     Method::new_nothing("submitheader", "submit_header"),
+    // network
     Method::new_nothing("addnode", "add_node"),
     Method::new_nothing("clearbanned", "clear_banned"),
     Method::new_nothing("disconnectnode", "disconnect_node"),
@@ -62,6 +66,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("ping", "ping"),
     Method::new_nothing("setban", "set_ban"),
     Method::new_nothing("setnetworkactive", "set_network_active"),
+    // raw transactions
     Method::new_modelled("analyzepsbt", "AnalyzePsbt", "analyze_psbt"),
     Method::new_nothing("combinepsbt", "combine_psbt"),
     Method::new_nothing("combinerawtransaction", "combine_raw_transaction"),
@@ -88,6 +93,7 @@ pub const METHODS: &[Method] = &[
     Method::new_string("signmessagewithprivkey", "sign_message_with_priv_key"),
     Method::new_modelled("validateaddress", "ValidateAddress", "validate_address"),
     Method::new_bool("verifymessage", "verify_message"),
+    // wallet
     Method::new_nothing("abandontransaction", "abandon_transaction"),
     Method::new_nothing("abortrescan", "abort_rescan"),
     Method::new_modelled("addmultisigaddress", "AddMultisigAddress", "add_multisig_address"),
@@ -167,5 +173,6 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("walletpassphrase", "wallet_passphrase"),
     Method::new_nothing("walletpassphrasechange", "wallet_passphrase_change"),
     Method::new_modelled("walletprocesspsbt", "WalletProcessPsbt", "wallet_process_psbt"),
+    // zmq
     Method::new_no_model("getzmqnotifications", "GetZmqNotifications", "get_zmq_notifications"),
 ];

--- a/verify/src/method/v24.rs
+++ b/verify/src/method/v24.rs
@@ -6,6 +6,7 @@ use super::Method;
 
 /// Data for the JSON RPC methods provided by Bitcoin Core v24.
 pub const METHODS: &[Method] = &[
+    // blockchain
     Method::new_modelled("getbestblockhash", "GetBestBlockHash", "get_best_block_hash"),
     Method::new_modelled("getblock", "GetBlockVerboseZero", "get_block"), // We only check one of the types.
     Method::new_modelled("getblockchaininfo", "GetBlockchainInfo", "get_blockchain_info"),
@@ -38,18 +39,21 @@ pub const METHODS: &[Method] = &[
     Method::new_modelled("scantxoutset", "ScanTxOutSet", "scan_tx_out_set"),
     Method::new_bool("verifychain", "verify_chain"),
     Method::new_modelled("verifytxoutproof", "VerifyTxOutProof", "verify_tx_out_proof"),
-    Method::new_no_model("getrpcinfo", "GetRpcInfo", "get_rpc_info"),
+    // control
     Method::new_no_model("getmemoryinfo", "GetMemoryInfoStats", "get_memory_info"),
+    Method::new_no_model("getrpcinfo", "GetRpcInfo", "get_rpc_info"),
     Method::new_string("help", "help"),
     Method::new_no_model("logging", "Logging", "logging"),
     Method::new_nothing("stop", "stop"),
     Method::new_numeric("uptime", "uptime"),
+    // mining
     Method::new_modelled("getblocktemplate", "GetBlockTemplate", "get_block_template"),
     Method::new_no_model("getmininginfo", "GetMiningInfo", "get_mining_info"),
     Method::new_nothing("getnetworkhashps", "get_network_hashes_per_second"),
     Method::new_bool("prioritisetransaction", "prioritise_transaction"),
     Method::new_nothing("submitblock", "submit_block"),
     Method::new_nothing("submitheader", "submit_header"),
+    // network
     Method::new_nothing("addnode", "add_node"),
     Method::new_nothing("clearbanned", "clear_banned"),
     Method::new_nothing("disconnectnode", "disconnect_node"),
@@ -63,6 +67,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("ping", "ping"),
     Method::new_nothing("setban", "set_ban"),
     Method::new_nothing("setnetworkactive", "set_network_active"),
+    // raw transactions
     Method::new_modelled("analyzepsbt", "AnalyzePsbt", "analyze_psbt"),
     Method::new_nothing("combinepsbt", "combine_psbt"),
     Method::new_nothing("combinerawtransaction", "combine_raw_transaction"),
@@ -89,6 +94,7 @@ pub const METHODS: &[Method] = &[
     Method::new_string("signmessagewithprivkey", "sign_message_with_priv_key"),
     Method::new_modelled("validateaddress", "ValidateAddress", "validate_address"),
     Method::new_bool("verifymessage", "verify_message"),
+    // wallet
     Method::new_nothing("abandontransaction", "abandon_transaction"),
     Method::new_nothing("abortrescan", "abort_rescan"),
     Method::new_modelled("addmultisigaddress", "AddMultisigAddress", "add_multisig_address"),
@@ -171,5 +177,6 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("walletpassphrase", "wallet_passphrase"),
     Method::new_nothing("walletpassphrasechange", "wallet_passphrase_change"),
     Method::new_modelled("walletprocesspsbt", "WalletProcessPsbt", "wallet_process_psbt"),
+    // zmq
     Method::new_no_model("getzmqnotifications", "GetZmqNotifications", "get_zmq_notifications"),
 ];

--- a/verify/src/method/v25.rs
+++ b/verify/src/method/v25.rs
@@ -6,6 +6,7 @@ use super::Method;
 
 /// Data for the JSON RPC methods provided by Bitcoin Core v25.
 pub const METHODS: &[Method] = &[
+    // blockchain
     Method::new_modelled("getbestblockhash", "GetBestBlockHash", "get_best_block_hash"),
     Method::new_modelled("getblock", "GetBlockVerboseZero", "get_block"), // We only check one of the types.
     Method::new_modelled("getblockchaininfo", "GetBlockchainInfo", "get_blockchain_info"),
@@ -39,18 +40,21 @@ pub const METHODS: &[Method] = &[
     Method::new_modelled("scantxoutset", "ScanTxOutSet", "scan_tx_out_set"),
     Method::new_bool("verifychain", "verify_chain"),
     Method::new_modelled("verifytxoutproof", "VerifyTxOutProof", "verify_tx_out_proof"),
-    Method::new_no_model("getrpcinfo", "GetRpcInfo", "get_rpc_info"),
+    // control
     Method::new_no_model("getmemoryinfo", "GetMemoryInfoStats", "get_memory_info"),
+    Method::new_no_model("getrpcinfo", "GetRpcInfo", "get_rpc_info"),
     Method::new_string("help", "help"),
     Method::new_no_model("logging", "Logging", "logging"),
     Method::new_nothing("stop", "stop"),
     Method::new_numeric("uptime", "uptime"),
+    // mining
     Method::new_modelled("getblocktemplate", "GetBlockTemplate", "get_block_template"),
     Method::new_no_model("getmininginfo", "GetMiningInfo", "get_mining_info"),
     Method::new_nothing("getnetworkhashps", "get_network_hashes_per_second"),
     Method::new_bool("prioritisetransaction", "prioritise_transaction"),
     Method::new_nothing("submitblock", "submit_block"),
     Method::new_nothing("submitheader", "submit_header"),
+    // network
     Method::new_nothing("addnode", "add_node"),
     Method::new_nothing("clearbanned", "clear_banned"),
     Method::new_nothing("disconnectnode", "disconnect_node"),
@@ -64,6 +68,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("ping", "ping"),
     Method::new_nothing("setban", "set_ban"),
     Method::new_nothing("setnetworkactive", "set_network_active"),
+    // raw transactions
     Method::new_modelled("analyzepsbt", "AnalyzePsbt", "analyze_psbt"),
     Method::new_nothing("combinepsbt", "combine_psbt"),
     Method::new_nothing("combinerawtransaction", "combine_raw_transaction"),
@@ -91,6 +96,7 @@ pub const METHODS: &[Method] = &[
     Method::new_modelled("validateaddress", "ValidateAddress", "validate_address"),
     Method::new_bool("verifymessage", "verify_message"),
     Method::new_nothing("abandontransaction", "abandon_transaction"),
+    // wallet
     Method::new_nothing("abortrescan", "abort_rescan"),
     Method::new_modelled("addmultisigaddress", "AddMultisigAddress", "add_multisig_address"),
     Method::new_nothing("backupwallet", "backup_wallet"),
@@ -172,5 +178,6 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("walletpassphrase", "wallet_passphrase"),
     Method::new_nothing("walletpassphrasechange", "wallet_passphrase_change"),
     Method::new_modelled("walletprocesspsbt", "WalletProcessPsbt", "wallet_process_psbt"),
+    // zmq
     Method::new_no_model("getzmqnotifications", "GetZmqNotifications", "get_zmq_notifications"),
 ];

--- a/verify/src/method/v26.rs
+++ b/verify/src/method/v26.rs
@@ -6,6 +6,7 @@ use super::Method;
 
 /// Data for the JSON RPC methods provided by Bitcoin Core v26.
 pub const METHODS: &[Method] = &[
+    // blockchain
     Method::new_no_model("dumptxoutset", "DumpTxOutSet", "dump_tx_out_set"),
     Method::new_modelled("getbestblockhash", "GetBestBlockHash", "get_best_block_hash"),
     Method::new_modelled("getblock", "GetBlockVerboseZero", "get_block"), // We only check one of the types.
@@ -43,12 +44,14 @@ pub const METHODS: &[Method] = &[
     Method::new_modelled("scantxoutset", "ScanTxOutSet", "scan_tx_out_set"),
     Method::new_bool("verifychain", "verify_chain"),
     Method::new_modelled("verifytxoutproof", "VerifyTxOutProof", "verify_tx_out_proof"),
-    Method::new_no_model("getrpcinfo", "GetRpcInfo", "get_rpc_info"),
+    // control
     Method::new_no_model("getmemoryinfo", "GetMemoryInfoStats", "get_memory_info"),
+    Method::new_no_model("getrpcinfo", "GetRpcInfo", "get_rpc_info"),
     Method::new_string("help", "help"),
     Method::new_no_model("logging", "Logging", "logging"),
     Method::new_nothing("stop", "stop"),
     Method::new_numeric("uptime", "uptime"),
+    // mining
     Method::new_modelled("getblocktemplate", "GetBlockTemplate", "get_block_template"),
     Method::new_no_model("getmininginfo", "GetMiningInfo", "get_mining_info"),
     Method::new_nothing("getnetworkhashps", "get_network_hashes_per_second"),
@@ -56,6 +59,7 @@ pub const METHODS: &[Method] = &[
     Method::new_bool("prioritisetransaction", "prioritise_transaction"),
     Method::new_nothing("submitblock", "submit_block"),
     Method::new_nothing("submitheader", "submit_header"),
+    // network
     Method::new_nothing("addnode", "add_node"),
     Method::new_nothing("clearbanned", "clear_banned"),
     Method::new_nothing("disconnectnode", "disconnect_node"),
@@ -98,6 +102,7 @@ pub const METHODS: &[Method] = &[
     Method::new_string("signmessagewithprivkey", "sign_message_with_priv_key"),
     Method::new_modelled("validateaddress", "ValidateAddress", "validate_address"),
     Method::new_bool("verifymessage", "verify_message"),
+    // wallet
     Method::new_nothing("abandontransaction", "abandon_transaction"),
     Method::new_nothing("abortrescan", "abort_rescan"),
     Method::new_modelled("addmultisigaddress", "AddMultisigAddress", "add_multisig_address"),
@@ -180,5 +185,6 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("walletpassphrase", "wallet_passphrase"),
     Method::new_nothing("walletpassphrasechange", "wallet_passphrase_change"),
     Method::new_modelled("walletprocesspsbt", "WalletProcessPsbt", "wallet_process_psbt"),
+    // zmq
     Method::new_no_model("getzmqnotifications", "GetZmqNotifications", "get_zmq_notifications"),
 ];

--- a/verify/src/method/v27.rs
+++ b/verify/src/method/v27.rs
@@ -6,6 +6,7 @@ use super::Method;
 
 /// Data for the JSON RPC methods provided by Bitcoin Core v26.
 pub const METHODS: &[Method] = &[
+    // blockchain
     Method::new_no_model("dumptxoutset", "DumpTxOutSet", "dump_tx_out_set"),
     Method::new_modelled("getbestblockhash", "GetBestBlockHash", "get_best_block_hash"),
     Method::new_modelled("getblock", "GetBlockVerboseZero", "get_block"), // We only check one of the types.
@@ -44,11 +45,13 @@ pub const METHODS: &[Method] = &[
     Method::new_bool("verifychain", "verify_chain"),
     Method::new_modelled("verifytxoutproof", "VerifyTxOutProof", "verify_tx_out_proof"),
     Method::new_no_model("getrpcinfo", "GetRpcInfo", "get_rpc_info"),
+    // control
     Method::new_no_model("getmemoryinfo", "GetMemoryInfoStats", "get_memory_info"),
     Method::new_string("help", "help"),
     Method::new_no_model("logging", "Logging", "logging"),
     Method::new_nothing("stop", "stop"),
     Method::new_numeric("uptime", "uptime"),
+    // mining
     Method::new_modelled("getblocktemplate", "GetBlockTemplate", "get_block_template"),
     Method::new_no_model("getmininginfo", "GetMiningInfo", "get_mining_info"),
     Method::new_nothing("getnetworkhashps", "get_network_hashes_per_second"),
@@ -58,6 +61,7 @@ pub const METHODS: &[Method] = &[
     Method::new_bool("prioritisetransaction", "prioritise_transaction"),
     Method::new_nothing("submitblock", "submit_block"),
     Method::new_nothing("submitheader", "submit_header"),
+    // network
     Method::new_nothing("addnode", "add_node"),
     Method::new_nothing("clearbanned", "clear_banned"),
     Method::new_nothing("disconnectnode", "disconnect_node"),
@@ -72,6 +76,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("ping", "ping"),
     Method::new_nothing("setban", "set_ban"),
     Method::new_nothing("setnetworkactive", "set_network_active"),
+    // raw transactions
     Method::new_modelled("analyzepsbt", "AnalyzePsbt", "analyze_psbt"),
     Method::new_nothing("combinepsbt", "combine_psbt"),
     Method::new_nothing("combinerawtransaction", "combine_raw_transaction"),
@@ -100,6 +105,7 @@ pub const METHODS: &[Method] = &[
     Method::new_string("signmessagewithprivkey", "sign_message_with_priv_key"),
     Method::new_modelled("validateaddress", "ValidateAddress", "validate_address"),
     Method::new_bool("verifymessage", "verify_message"),
+    // wallet
     Method::new_nothing("abandontransaction", "abandon_transaction"),
     Method::new_nothing("abortrescan", "abort_rescan"),
     Method::new_modelled("addmultisigaddress", "AddMultisigAddress", "add_multisig_address"),
@@ -182,5 +188,6 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("walletpassphrase", "wallet_passphrase"),
     Method::new_nothing("walletpassphrasechange", "wallet_passphrase_change"),
     Method::new_modelled("walletprocesspsbt", "WalletProcessPsbt", "wallet_process_psbt"),
+    // zmq
     Method::new_no_model("getzmqnotifications", "GetZmqNotifications", "get_zmq_notifications"),
 ];

--- a/verify/src/method/v28.rs
+++ b/verify/src/method/v28.rs
@@ -6,6 +6,7 @@ use super::Method;
 
 /// Data for the JSON RPC methods provided by Bitcoin Core v26.
 pub const METHODS: &[Method] = &[
+    // blockchain
     Method::new_no_model("dumptxoutset", "DumpTxOutSet", "dump_tx_out_set"),
     Method::new_modelled("getbestblockhash", "GetBestBlockHash", "get_best_block_hash"),
     Method::new_modelled("getblock", "GetBlockVerboseZero", "get_block"), // We only check one of the types.
@@ -44,11 +45,13 @@ pub const METHODS: &[Method] = &[
     Method::new_bool("verifychain", "verify_chain"),
     Method::new_modelled("verifytxoutproof", "VerifyTxOutProof", "verify_tx_out_proof"),
     Method::new_no_model("getrpcinfo", "GetRpcInfo", "get_rpc_info"),
+    // controll
     Method::new_no_model("getmemoryinfo", "GetMemoryInfoStats", "get_memory_info"),
     Method::new_string("help", "help"),
     Method::new_no_model("logging", "Logging", "logging"),
     Method::new_nothing("stop", "stop"),
     Method::new_numeric("uptime", "uptime"),
+    // mining
     Method::new_modelled("getblocktemplate", "GetBlockTemplate", "get_block_template"),
     Method::new_no_model("getmininginfo", "GetMiningInfo", "get_mining_info"),
     Method::new_nothing("getnetworkhashps", "get_network_hashes_per_second"),
@@ -58,6 +61,7 @@ pub const METHODS: &[Method] = &[
     Method::new_bool("prioritisetransaction", "prioritise_transaction"),
     Method::new_nothing("submitblock", "submit_block"),
     Method::new_nothing("submitheader", "submit_header"),
+    // network
     Method::new_nothing("addnode", "add_node"),
     Method::new_nothing("clearbanned", "clear_banned"),
     Method::new_nothing("disconnectnode", "disconnect_node"),
@@ -72,6 +76,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("ping", "ping"),
     Method::new_nothing("setban", "set_ban"),
     Method::new_nothing("setnetworkactive", "set_network_active"),
+    // raw transactions
     Method::new_modelled("analyzepsbt", "AnalyzePsbt", "analyze_psbt"),
     Method::new_nothing("combinepsbt", "combine_psbt"),
     Method::new_nothing("combinerawtransaction", "combine_raw_transaction"),
@@ -100,6 +105,7 @@ pub const METHODS: &[Method] = &[
     Method::new_string("signmessagewithprivkey", "sign_message_with_priv_key"),
     Method::new_modelled("validateaddress", "ValidateAddress", "validate_address"),
     Method::new_bool("verifymessage", "verify_message"),
+    // wallet
     Method::new_nothing("abandontransaction", "abandon_transaction"),
     Method::new_nothing("abortrescan", "abort_rescan"),
     Method::new_modelled("addmultisigaddress", "AddMultisigAddress", "add_multisig_address"),
@@ -184,5 +190,6 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("walletpassphrase", "wallet_passphrase"),
     Method::new_nothing("walletpassphrasechange", "wallet_passphrase_change"),
     Method::new_modelled("walletprocesspsbt", "WalletProcessPsbt", "wallet_process_psbt"),
+    // zmq
     Method::new_no_model("getzmqnotifications", "GetZmqNotifications", "get_zmq_notifications"),
 ];


### PR DESCRIPTION
Break the sections up by adding comments. This was done already for v17 and v18 but not the rest.

Includes reorder of incorrectly ordered `getrpcinfo` to maintain the same order as output by `bitcoin-cli help`.