### PR TITLE
Remove model for dumpwallet

### DIFF
--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -95,7 +95,7 @@ fn wallet__dump_priv_key__modelled() {
 }
 
 #[test]
-fn wallet__dump_wallet__modelled() {
+fn wallet__dump_wallet() {
     // As of Core v23 the default wallet is an native descriptor wallet which does not
     // support dumping private keys. Legacy wallets are supported upto v25 it seems.
     #[cfg(any(
@@ -109,8 +109,7 @@ fn wallet__dump_wallet__modelled() {
         node.client.create_legacy_wallet("legacy_wallet").expect("legacy create_wallet");
         let out = integration_test::random_tmp_file();
 
-        let json: DumpWallet = node.client.dump_wallet(&out).expect("dumpwallet");
-        let _: mtype::DumpWallet = json.into_model();
+        let _: DumpWallet = node.client.dump_wallet(&out).expect("dumpwallet");
     }
 
     #[cfg(any(
@@ -125,8 +124,7 @@ fn wallet__dump_wallet__modelled() {
         let node = Node::with_wallet(Wallet::Default, &[]);
         let out = integration_test::random_tmp_file();
 
-        let json: DumpWallet = node.client.dump_wallet(&out).expect("dumpwallet");
-        let _: mtype::DumpWallet = json.into_model();
+        let _: DumpWallet = node.client.dump_wallet(&out).expect("dumpwallet");
     }
 }
 

--- a/types/src/model/mod.rs
+++ b/types/src/model/mod.rs
@@ -45,7 +45,7 @@ pub use self::{
     },
     wallet::{
         AddMultisigAddress, AddressInformation, AddressLabel, AddressPurpose, Bip125Replaceable,
-        BumpFee, CreateWallet, DumpPrivKey, DumpWallet, GetAddressInfo, GetAddressInfoEmbedded,
+        BumpFee, CreateWallet, DumpPrivKey, GetAddressInfo, GetAddressInfoEmbedded,
         GetAddressesByLabel, GetBalance, GetBalances, GetBalancesMine, GetBalancesWatchOnly,
         GetNewAddress, GetRawChangeAddress, GetReceivedByAddress, GetTransaction,
         GetTransactionDetail, GetUnconfirmedBalance, GetWalletInfo, ListAddressGroupings,

--- a/types/src/model/wallet.rs
+++ b/types/src/model/wallet.rs
@@ -87,12 +87,6 @@ pub struct CreateWallet {
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct DumpPrivKey(pub PrivateKey);
 
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-pub struct DumpWallet {
-    /// The filename with full absolute path.
-    pub file_name: String, // FIXME: Should this be `PathBuf`?
-}
-
 /// Models the result of JSON-RPC method `getaddressesbylabel`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetAddressesByLabel(pub BTreeMap<Address<NetworkUnchecked>, AddressInformation>);

--- a/types/src/v17/wallet/into.rs
+++ b/types/src/v17/wallet/into.rs
@@ -98,11 +98,6 @@ impl DumpPrivKey {
     }
 }
 
-impl DumpWallet {
-    /// Converts version specific type to a version nonspecific, more strongly typed type.
-    pub fn into_model(self) -> model::DumpWallet { model::DumpWallet { file_name: self.file_name } }
-}
-
 impl AddressInformation {
     /// Converts version specific type to a version nonspecific, more strongly typed type.
     pub fn into_model(self) -> model::AddressInformation {

--- a/verify/src/method/v17.rs
+++ b/verify/src/method/v17.rs
@@ -93,7 +93,7 @@ pub const METHODS: &[Method] = &[
     Method::new_modelled("bumpfee", "BumpFee", "bump_fee"),
     Method::new_modelled("createwallet", "CreateWallet", "create_wallet"),
     Method::new_modelled("dumpprivkey", "DumpPrivKey", "dump_priv_key"),
-    Method::new_modelled("dumpwallet", "DumpWallet", "dump_wallet"),
+    Method::new_no_model("dumpwallet", "DumpWallet", "dump_wallet"),
     Method::new_nothing("encryptwallet", "encrypt_wallet"),
     Method::new_nothing("getaccount", "get_account"), // Deprecated
     Method::new_nothing("getaccountaddress", "get_account_address"), // Deprecated

--- a/verify/src/method/v18.rs
+++ b/verify/src/method/v18.rs
@@ -100,7 +100,7 @@ pub const METHODS: &[Method] = &[
     Method::new_modelled("bumpfee", "BumpFee", "bump_fee"),
     Method::new_modelled("createwallet", "CreateWallet", "create_wallet"),
     Method::new_modelled("dumpprivkey", "DumpPrivKey", "dump_priv_key"),
-    Method::new_modelled("dumpwallet", "DumpWallet", "dump_wallet"),
+    Method::new_no_model("dumpwallet", "DumpWallet", "dump_wallet"),
     Method::new_nothing("encryptwallet", "encrypt_wallet"),
     Method::new_modelled("getaddressesbylabel", "GetAddressesByLabel", "get_addresses_by_label"),
     Method::new_modelled("getaddressinfo", "GetAddressInfo", "get_address_info"),

--- a/verify/src/method/v19.rs
+++ b/verify/src/method/v19.rs
@@ -92,7 +92,7 @@ pub const METHODS: &[Method] = &[
     Method::new_modelled("bumpfee", "BumpFee", "bump_fee"),
     Method::new_modelled("createwallet", "CreateWallet", "create_wallet"),
     Method::new_modelled("dumpprivkey", "DumpPrivKey", "dump_priv_key"),
-    Method::new_modelled("dumpwallet", "DumpWallet", "dump_wallet"),
+    Method::new_no_model("dumpwallet", "DumpWallet", "dump_wallet"),
     Method::new_nothing("encryptwallet", "encrypt_wallet"),
     Method::new_modelled("getaddressesbylabel", "GetAddressesByLabel", "get_addresses_by_label"),
     Method::new_modelled("getaddressinfo", "GetAddressInfo", "get_address_info"),

--- a/verify/src/method/v20.rs
+++ b/verify/src/method/v20.rs
@@ -93,7 +93,7 @@ pub const METHODS: &[Method] = &[
     Method::new_modelled("bumpfee", "BumpFee", "bump_fee"),
     Method::new_modelled("createwallet", "CreateWallet", "create_wallet"),
     Method::new_modelled("dumpprivkey", "DumpPrivKey", "dump_priv_key"),
-    Method::new_modelled("dumpwallet", "DumpWallet", "dump_wallet"),
+    Method::new_no_model("dumpwallet", "DumpWallet", "dump_wallet"),
     Method::new_nothing("encryptwallet", "encrypt_wallet"),
     Method::new_modelled("getaddressesbylabel", "GetAddressesByLabel", "get_addresses_by_label"),
     Method::new_modelled("getaddressinfo", "GetAddressInfo", "get_address_info"),

--- a/verify/src/method/v21.rs
+++ b/verify/src/method/v21.rs
@@ -95,7 +95,7 @@ pub const METHODS: &[Method] = &[
     Method::new_modelled("bumpfee", "BumpFee", "bump_fee"),
     Method::new_modelled("createwallet", "CreateWallet", "create_wallet"),
     Method::new_modelled("dumpprivkey", "DumpPrivKey", "dump_priv_key"),
-    Method::new_modelled("dumpwallet", "DumpWallet", "dump_wallet"),
+    Method::new_no_model("dumpwallet", "DumpWallet", "dump_wallet"),
     Method::new_nothing("encryptwallet", "encrypt_wallet"),
     Method::new_modelled("getaddressesbylabel", "GetAddressesByLabel", "get_addresses_by_label"),
     Method::new_modelled("getaddressinfo", "GetAddressInfo", "get_address_info"),

--- a/verify/src/method/v22.rs
+++ b/verify/src/method/v22.rs
@@ -96,7 +96,7 @@ pub const METHODS: &[Method] = &[
     Method::new_modelled("bumpfee", "BumpFee", "bump_fee"),
     Method::new_modelled("createwallet", "CreateWallet", "create_wallet"),
     Method::new_modelled("dumpprivkey", "DumpPrivKey", "dump_priv_key"),
-    Method::new_modelled("dumpwallet", "DumpWallet", "dump_wallet"),
+    Method::new_no_model("dumpwallet", "DumpWallet", "dump_wallet"),
     Method::new_nothing("encryptwallet", "encrypt_wallet"),
     Method::new_modelled("getaddressesbylabel", "GetAddressesByLabel", "get_addresses_by_label"),
     Method::new_modelled("getaddressinfo", "GetAddressInfo", "get_address_info"),

--- a/verify/src/method/v23.rs
+++ b/verify/src/method/v23.rs
@@ -95,7 +95,7 @@ pub const METHODS: &[Method] = &[
     Method::new_modelled("bumpfee", "BumpFee", "bump_fee"),
     Method::new_modelled("createwallet", "CreateWallet", "create_wallet"),
     Method::new_modelled("dumpprivkey", "DumpPrivKey", "dump_priv_key"),
-    Method::new_modelled("dumpwallet", "DumpWallet", "dump_wallet"),
+    Method::new_no_model("dumpwallet", "DumpWallet", "dump_wallet"),
     Method::new_nothing("encryptwallet", "encrypt_wallet"),
     Method::new_modelled("getaddressesbylabel", "GetAddressesByLabel", "get_addresses_by_label"),
     Method::new_modelled("getaddressinfo", "GetAddressInfo", "get_address_info"),

--- a/verify/src/method/v24.rs
+++ b/verify/src/method/v24.rs
@@ -96,7 +96,7 @@ pub const METHODS: &[Method] = &[
     Method::new_modelled("bumpfee", "BumpFee", "bump_fee"),
     Method::new_modelled("createwallet", "CreateWallet", "create_wallet"),
     Method::new_modelled("dumpprivkey", "DumpPrivKey", "dump_priv_key"),
-    Method::new_modelled("dumpwallet", "DumpWallet", "dump_wallet"),
+    Method::new_no_model("dumpwallet", "DumpWallet", "dump_wallet"),
     Method::new_nothing("encryptwallet", "encrypt_wallet"),
     Method::new_modelled("getaddressesbylabel", "GetAddressesByLabel", "get_addresses_by_label"),
     Method::new_modelled("getaddressinfo", "GetAddressInfo", "get_address_info"),

--- a/verify/src/method/v25.rs
+++ b/verify/src/method/v25.rs
@@ -97,7 +97,7 @@ pub const METHODS: &[Method] = &[
     Method::new_modelled("bumpfee", "BumpFee", "bump_fee"),
     Method::new_modelled("createwallet", "CreateWallet", "create_wallet"),
     Method::new_modelled("dumpprivkey", "DumpPrivKey", "dump_priv_key"),
-    Method::new_modelled("dumpwallet", "DumpWallet", "dump_wallet"),
+    Method::new_no_model("dumpwallet", "DumpWallet", "dump_wallet"),
     Method::new_nothing("encryptwallet", "encrypt_wallet"),
     Method::new_modelled("getaddressesbylabel", "GetAddressesByLabel", "get_addresses_by_label"),
     Method::new_modelled("getaddressinfo", "GetAddressInfo", "get_address_info"),

--- a/verify/src/method/v26.rs
+++ b/verify/src/method/v26.rs
@@ -105,7 +105,7 @@ pub const METHODS: &[Method] = &[
     Method::new_modelled("bumpfee", "BumpFee", "bump_fee"),
     Method::new_modelled("createwallet", "CreateWallet", "create_wallet"),
     Method::new_modelled("dumpprivkey", "DumpPrivKey", "dump_priv_key"),
-    Method::new_modelled("dumpwallet", "DumpWallet", "dump_wallet"),
+    Method::new_no_model("dumpwallet", "DumpWallet", "dump_wallet"),
     Method::new_nothing("encryptwallet", "encrypt_wallet"),
     Method::new_modelled("getaddressesbylabel", "GetAddressesByLabel", "get_addresses_by_label"),
     Method::new_modelled("getaddressinfo", "GetAddressInfo", "get_address_info"),

--- a/verify/src/method/v27.rs
+++ b/verify/src/method/v27.rs
@@ -107,7 +107,7 @@ pub const METHODS: &[Method] = &[
     Method::new_modelled("bumpfee", "BumpFee", "bump_fee"),
     Method::new_modelled("createwallet", "CreateWallet", "create_wallet"),
     Method::new_modelled("dumpprivkey", "DumpPrivKey", "dump_priv_key"),
-    Method::new_modelled("dumpwallet", "DumpWallet", "dump_wallet"),
+    Method::new_no_model("dumpwallet", "DumpWallet", "dump_wallet"),
     Method::new_nothing("encryptwallet", "encrypt_wallet"),
     Method::new_modelled("getaddressesbylabel", "GetAddressesByLabel", "get_addresses_by_label"),
     Method::new_modelled("getaddressinfo", "GetAddressInfo", "get_address_info"),

--- a/verify/src/method/v28.rs
+++ b/verify/src/method/v28.rs
@@ -108,7 +108,7 @@ pub const METHODS: &[Method] = &[
     Method::new_modelled("createwallet", "CreateWallet", "create_wallet"),
     Method::new_no_model("createwalletdescriptor", "CreateWalletDescriptor", "create_wallet_descriptor"),
     Method::new_modelled("dumpprivkey", "DumpPrivKey", "dump_priv_key"),
-    Method::new_modelled("dumpwallet", "DumpWallet", "dump_wallet"),
+    Method::new_no_model("dumpwallet", "DumpWallet", "dump_wallet"),
     Method::new_nothing("encryptwallet", "encrypt_wallet"),
     Method::new_modelled("getaddressesbylabel", "GetAddressesByLabel", "get_addresses_by_label"),
     Method::new_modelled("getaddressinfo", "GetAddressInfo", "get_address_info"),


### PR DESCRIPTION
The `dumpwallet` method returns a filename, this is not a `rust-bitcoin` type so there should not be a modelled version of the `DumpWallet` type.