### PR TITLE
types: Improve the version specific SSOT docs

### DIFF
--- a/types/src/v17/mod.rs
+++ b/types/src/v17/mod.rs
@@ -9,205 +9,214 @@
 //!
 //! ### Method name and implementation status
 //!
-//! Every JSON-RPC method supported by this version of Bitcoin Core is listed below along with its
-//! current implementation status.
+//! Every JSON-RPC method supported by this version of Bitcoin Core is listed below along with the
+//! type it returns and any implementation notes.
+//!
+//! Key to 'Returns' column:
+//!
+//! * version: method returns a version specific type but has no model type.
+//! * version + model: method returns a version specific type and can be converted to a model type.
+//! * returns foo: method returns a foo (e.g. string, boolean, or nothing).
+//! * omitted: method intentionally unsupported with no plans of adding support.
+//!
+//! If a method has UNTESTED then there is no integration test yet for it.
 //!
 //! <details>
 //! <summary> Methods from the == Blockchain == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getbestblockhash                   | done            |
-//! | getblock                           | done            |
-//! | getblockchaininfo                  | done            |
-//! | getblockcount                      | done            |
-//! | getblockhash                       | done            |
-//! | getblockheader                     | done            |
-//! | getblockstats                      | done            |
-//! | getchaintips                       | done            |
-//! | getchaintxstats                    | done            |
-//! | getdifficulty                      | done            |
-//! | getmempoolancestors                | done (untested) |
-//! | getmempooldescendants              | done (untested) |
-//! | getmempoolentry                    | done            |
-//! | getmempoolinfo                     | done            |
-//! | getrawmempool                      | done            |
-//! | gettxout                           | done            |
-//! | gettxoutproof                      | done            |
-//! | gettxoutsetinfo                    | done            |
-//! | preciousblock                      | done            |
-//! | pruneblockchain                    | omitted         |
-//! | savemempool                        | omitted         |
-//! | scantxoutset                       | omitted         |
-//! | verifychain                        | omitted         |
-//! | verifytxoutproof                   | done            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getbestblockhash                   | version + model |                                        |
+//! | getblock                           | version + model | Includes additional 'verbose' type     |
+//! | getblockchaininfo                  | version + model |                                        |
+//! | getblockcount                      | version + model |                                        |
+//! | getblockhash                       | version + model |                                        |
+//! | getblockheader                     | version + model | Includes additional 'verbose' type     |
+//! | getblockstats                      | version + model |                                        |
+//! | getchaintips                       | version + model |                                        |
+//! | getchaintxstats                    | version + model |                                        |
+//! | getdifficulty                      | version + model |                                        |
+//! | getmempoolancestors                | version + model | UNTESTED (incl. verbose type)          |
+//! | getmempooldescendants              | version + model | UNTESTED (incl. verbose type)          |
+//! | getmempoolentry                    | version + model |                                        |
+//! | getmempoolinfo                     | version + model |                                        |
+//! | getrawmempool                      | version + model |                                        |
+//! | gettxout                           | version + model |                                        |
+//! | gettxoutproof                      | returns string  |                                        |
+//! | gettxoutsetinfo                    | version + model |                                        |
+//! | preciousblock                      | returns nothing |                                        |
+//! | pruneblockchain                    | returns numeric |                                        |
+//! | savemempool                        | returns nothing |                                        |
+//! | scantxoutset                       | omitted         | API marked as experimental             |
+//! | verifychain                        | returns boolean |                                        |
+//! | verifytxoutproof                   | version + model |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Control == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getmemoryinfo                      | done            |
-//! | help                               | done            |
-//! | logging                            | done            |
-//! | stop                               | done            |
-//! | uptime                             | done            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getmemoryinfo                      | version         |                                        |
+//! | help                               | returns string  |                                        |
+//! | logging                            | version         |                                        |
+//! | stop                               | returns string  |                                        |
+//! | uptime                             | returns numeric |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Generating == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | generate                           | done            |
-//! | generatetoaddress                  | done            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | generate                           | version + model |                                        |
+//! | generatetoaddress                  | version + model |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Mining == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getblocktemplate                   | done            |
-//! | getmininginfo                      | done            |
-//! | getnetworkhashps                   | done            |
-//! | prioritisetransaction              | done            |
-//! | submitblock                        | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getblocktemplate                   | version + model |                                        |
+//! | getmininginfo                      | version         |                                        |
+//! | getnetworkhashps                   | returns boolean |                                        |
+//! | prioritisetransaction              | returns boolean |                                        |
+//! | submitblock                        | returns nothing |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Network == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | addnode                            | omitted         |
-//! | clearbanned                        | omitted         |
-//! | disconnectnode                     | omitted         |
-//! | getaddednodeinfo                   | done            |
-//! | getconnectioncount                 | omitted         |
-//! | getnettotals                       | done            |
-//! | getnetworkinfo                     | done            |
-//! | getpeerinfo                        | done            |
-//! | listbanned                         | omitted         |
-//! | ping                               | omitted         |
-//! | setban                             | omitted         |
-//! | setnetworkactive                   | omitted         |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | addnode                            | returns nothing |                                        |
+//! | clearbanned                        | returns nothing |                                        |
+//! | disconnectnode                     | returns nothing |                                        |
+//! | getaddednodeinfo                   | version         |                                        |
+//! | getconnectioncount                 | returns numeric |                                        |
+//! | getnettotals                       | version         |                                        |
+//! | getnetworkinfo                     | version + model |                                        |
+//! | getpeerinfo                        | version         |                                        |
+//! | listbanned                         | returns string  |                                        |
+//! | ping                               | returns nothing |                                        |
+//! | setban                             | returns nothing |                                        |
+//! | setnetworkactive                   | returns nothing |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Rawtransactions == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | combinepsbt                        | done            |
-//! | combinerawtransaction              | done            |
-//! | converttopsbt                      | done            |
-//! | createpsbt                         | done            |
-//! | createrawtransaction               | done            |
-//! | decodepsbt                         | done            |
-//! | decoderawtransaction               | done            |
-//! | decodescript                       | done            |
-//! | finalizepsbt                       | done (untested) |
-//! | fundrawtransaction                 | done            |
-//! | getrawtransaction                  | done            |
-//! | sendrawtransaction                 | done            |
-//! | signrawtransaction                 | done            |
-//! | signrawtransactionwithkey          | done            |
-//! | testmempoolaccept                  | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | combinepsbt                        | version + model |                                        |
+//! | combinerawtransaction              | version + model |                                        |
+//! | converttopsbt                      | version + model |                                        |
+//! | createpsbt                         | version + model |                                        |
+//! | createrawtransaction               | version + model |                                        |
+//! | decodepsbt                         | version + model |                                        |
+//! | decoderawtransaction               | version + model |                                        |
+//! | decodescript                       | version + model |                                        |
+//! | finalizepsbt                       | version + model | UNTESTED                               |
+//! | fundrawtransaction                 | version + model |                                        |
+//! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
+//! | sendrawtransaction                 | version + model |                                        |
+//! | signrawtransaction                 | version + model |                                        |
+//! | signrawtransactionwithkey          | version + model |                                        |
+//! | testmempoolaccept                  | version + model | UNTESTED                               |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Util == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | createmultisig                     | omitted         |
-//! | estimatesmartfee                   | omitted         |
-//! | signmessagewithprivkey             | omitted         |
-//! | validateaddress                    | omitted         |
-//! | verifymessage                      | omitted         |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | createmultisig                     | version + model | TODO                                   |
+//! | estimatesmartfee                   | returns nothing | TODO                                   |
+//! | signmessagewithprivkey             | returns string  | TODO                                   |
+//! | validateaddress                    | version + model | TODO                                   |
+//! | verifymessage                      | returns boolean | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Wallet == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | abandontransaction                 | omitted         |
-//! | abortrescan                        | omitted         |
-//! | addmultisigaddress                 | done (untested) |
-//! | backupwallet                       | omitted         |
-//! | bumpfee                            | done            |
-//! | createwallet                       | done            |
-//! | dumpprivkey                        | done            |
-//! | dumpwallet                         | done            |
-//! | encryptwallet                      | omitted         |
-//! | getaccount                         | omitted         |
-//! | getaccountaddress                  | omitted         |
-//! | getaddressbyaccount                | omitted         |
-//! | getaddressesbylabel                | done            |
-//! | getaddressinfo                     | done (untested) |
-//! | getbalance                         | done            |
-//! | getnewaddress                      | done            |
-//! | getrawchangeaddress                | done            |
-//! | getreceivedbyaccount               | omitted         |
-//! | getreceivedbyaddress               | done            |
-//! | gettransaction                     | done            |
-//! | getunconfirmedbalance              | done (untested) |
-//! | getwalletinfo                      | done (untested) |
-//! | importaddress                      | omitted         |
-//! | importmulti                        | omitted         |
-//! | importprivkey                      | omitted         |
-//! | importprunedfunds                  | omitted         |
-//! | importpubkey                       | omitted         |
-//! | importwallet                       | omitted         |
-//! | keypoolrefill                      | omitted         |
-//! | listaccounts                       | omitted         |
-//! | listaddressgroupings               | done (untested) |
-//! | listlabels                         | done (untested) |
-//! | listlockunspent                    | done (untested) |
-//! | listreceivedbyaccount              | omitted         |
-//! | listreceivedbyaddress              | done (untested) |
-//! | listsinceblock                     | done (untested) |
-//! | listtransactions                   | done (untested) |
-//! | listunspent                        | done (untested) |
-//! | listwallets                        | done (untested) |
-//! | loadwallet                         | done            |
-//! | lockunspent                        | omitted         |
-//! | move                               | omitted         |
-//! | removeprunedfunds                  | omitted         |
-//! | rescanblockchain                   | done (untested) |
-//! | sendfrom                           | omitted         |
-//! | sendmany                           | done (untested) |
-//! | sendtoaddress                      | done            |
-//! | setaccount                         | omitted         |
-//! | sethdseed                          | omitted         |
-//! | settxfee                           | omitted         |
-//! | signmessage                        | done (untested) |
-//! | signrawtransactionwithwallet       | done            |
-//! | unloadwallet                       | done            |
-//! | walletcreatefundedpsbt             | done (untested) |
-//! | walletlock                         | omitted         |
-//! | walletpassphrase                   | omitted         |
-//! | walletpassphrasechange             | omitted         |
-//! | walletprocesspsbt                  | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | abandontransaction                 | returns nothing |                                        |
+//! | abortrescan                        | returns nothing |                                        |
+//! | addmultisigaddress                 | version + model | UNTESTED                               |
+//! | backupwallet                       | returns nothing |                                        |
+//! | bumpfee                            | version + model |                                        |
+//! | createwallet                       | version + model |                                        |
+//! | dumpprivkey                        | version + model |                                        |
+//! | dumpwallet                         | version + model |                                        |
+//! | encryptwallet                      | returns nothing |                                        |
+//! | getaccount                         | returns nothing |                                        |
+//! | getaccountaddress                  | returns nothing |                                        |
+//! | getaddressbyaccount                | returns nothing |                                        |
+//! | getaddressesbylabel                | version + model |                                        |
+//! | getaddressinfo                     | version + model | UNTESTED                               |
+//! | getbalance                         | version + model |                                        |
+//! | getnewaddress                      | version + model |                                        |
+//! | getrawchangeaddress                | version + model |                                        |
+//! | getreceivedbyaccount               | returns nothing |                                        |
+//! | getreceivedbyaddress               | version + model |                                        |
+//! | gettransaction                     | version + model |                                        |
+//! | getunconfirmedbalance              | version + model | UNTESTED                               |
+//! | getwalletinfo                      | version + model | UNTESTED                               |
+//! | importaddress                      | returns nothing |                                        |
+//! | importmulti                        | returns nothing |                                        |
+//! | importprivkey                      | returns nothing |                                        |
+//! | importprunedfunds                  | returns nothing |                                        |
+//! | importpubkey                       | returns nothing |                                        |
+//! | importwallet                       | returns nothing |                                        |
+//! | keypoolrefill                      | returns nothing |                                        |
+//! | listaccounts                       | returns nothing |                                        |
+//! | listaddressgroupings               | version + model | UNTESTED                               |
+//! | listlabels                         | version + model | UNTESTED                               |
+//! | listlockunspent                    | version + model | UNTESTED                               |
+//! | listreceivedbyaccount              | returns nothing |                                        |
+//! | listreceivedbyaddress              | version + model | UNTESTED                               |
+//! | listsinceblock                     | version + model | UNTESTED                               |
+//! | listtransactions                   | version + model | UNTESTED                               |
+//! | listunspent                        | version + model | UNTESTED                               |
+//! | listwallets                        | version + model | UNTESTED                               |
+//! | loadwallet                         | version + model |                                        |
+//! | lockunspent                        | returns boolean |                                        |
+//! | move                               | returns boolean |                                        |
+//! | removeprunedfunds                  | returns nothing |                                        |
+//! | rescanblockchain                   | version + model | UNTESTED                               |
+//! | sendfrom                           | returns nothing |                                        |
+//! | sendmany                           | version + model | UNTESTED                               |
+//! | sendtoaddress                      | version + model |                                        |
+//! | setaccount                         | returns nothing |                                        |
+//! | sethdseed                          | returns nothing |                                        |
+//! | settxfee                           | returns boolean |                                        |
+//! | signmessage                        | version + model | UNTESTED                               |
+//! | signrawtransactionwithwallet       | version + model |                                        |
+//! | unloadwallet                       | returns nothing |                                        |
+//! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
+//! | walletlock                         | returns nothing |                                        |
+//! | walletpassphrase                   | returns nothing |                                        |
+//! | walletpassphrasechange             | returns nothing |                                        |
+//! | walletprocesspsbt                  | version + model | UNTESTED                               |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Zmq == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getzmqnotifications                | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getzmqnotifications                | version         | UNTESTED                               |
 //!
 //! </details>
 

--- a/types/src/v18/mod.rs
+++ b/types/src/v18/mod.rs
@@ -1,10 +1,5 @@
 // SPDX-License-Identifier: CC0-1.0
 
-// TODO: Work out how to solve the problem that the docs on the re-exported types are for v17.
-//
-// We probably need to write a script to pull the v18 docs from Core (code base or RPC call) and
-// check them against the v17 docs for differences.
-
 //! # JSON-RPC types for Bitcoin Core `v0.18`
 //!
 //! These structs are shaped for the JSON data returned by the JSON-RPC API. They use stdlib types

--- a/types/src/v18/mod.rs
+++ b/types/src/v18/mod.rs
@@ -9,207 +9,216 @@
 //!
 //! ### Method name and implementation status
 //!
-//! Every JSON-RPC method supported by this version of Bitcoin Core is listed below along with its
-//! current implementation status.
+//! Every JSON-RPC method supported by this version of Bitcoin Core is listed below along with the
+//! type it returns and any implementation notes.
+//!
+//! Key to 'Returns' column:
+//!
+//! * version: method returns a version specific type but has no model type.
+//! * version + model: method returns a version specific type and can be converted to a model type.
+//! * returns foo: method returns a foo (e.g. string, boolean, or nothing).
+//! * omitted: method intentionally unsupported with no plans of adding support.
+//!
+//! If a method has UNTESTED then there is no integration test yet for it.
 //!
 //! <details>
 //! <summary> Methods from the == Blockchain == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getbestblockhash                   | done            |
-//! | getblock                           | done            |
-//! | getblockchaininfo                  | done            |
-//! | getblockcount                      | done            |
-//! | getblockhash                       | done            |
-//! | getblockheader                     | done            |
-//! | getblockstats                      | done            |
-//! | getchaintips                       | done            |
-//! | getchaintxstats                    | done            |
-//! | getdifficulty                      | done            |
-//! | getmempoolancestors                | done (untested) |
-//! | getmempooldescendants              | done (untested) |
-//! | getmempoolentry                    | done            |
-//! | getmempoolinfo                     | done            |
-//! | getrawmempool                      | done            |
-//! | gettxout                           | done            |
-//! | gettxoutproof                      | done            |
-//! | gettxoutsetinfo                    | done            |
-//! | preciousblock                      | done            |
-//! | pruneblockchain                    | omitted         |
-//! | savemempool                        | omitted         |
-//! | scantxoutset                       | omitted         |
-//! | verifychain                        | omitted         |
-//! | verifytxoutproof                   | done            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getbestblockhash                   | version + model |                                        |
+//! | getblock                           | version + model | Includes additional 'verbose' type     |
+//! | getblockchaininfo                  | version + model |                                        |
+//! | getblockcount                      | version + model |                                        |
+//! | getblockhash                       | version + model |                                        |
+//! | getblockheader                     | version + model | Includes additional 'verbose' type     |
+//! | getblockstats                      | version + model |                                        |
+//! | getchaintips                       | version + model |                                        |
+//! | getchaintxstats                    | version + model |                                        |
+//! | getdifficulty                      | version + model |                                        |
+//! | getmempoolancestors                | version + model | UNTESTED (incl. verbose type)          |
+//! | getmempooldescendants              | version + model | UNTESTED (incl. verbose type)          |
+//! | getmempoolentry                    | version + model |                                        |
+//! | getmempoolinfo                     | version + model |                                        |
+//! | getrawmempool                      | version + model | Includes additional 'verbose' type     |
+//! | gettxout                           | version + model |                                        |
+//! | gettxoutproof                      | returns string  |                                        |
+//! | gettxoutsetinfo                    | version + model |                                        |
+//! | preciousblock                      | returns nothing |                                        |
+//! | pruneblockchain                    | returns numeric |                                        |
+//! | savemempool                        | returns nothing |                                        |
+//! | scantxoutset                       | omitted         | API marked as experimental             |
+//! | verifychain                        | returns boolean |                                        |
+//! | verifytxoutproof                   | version + model |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Control == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getmemoryinfo                      | done            |
-//! | getrpcinfo                         | done            |
-//! | help                               | done            |
-//! | logging                            | done            |
-//! | stop                               | done            |
-//! | uptime                             | done            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getmemoryinfo                      | version         |                                        |
+//! | getrpcinfo                         | version + model |                                        |
+//! | help                               | returns string  |                                        |
+//! | logging                            | version         |                                        |
+//! | stop                               | returns string  |                                        |
+//! | uptime                             | returns numeric |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Generating == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | generate                           | omitted         |
-//! | generatetoaddress                  | done            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | generate                           | omitted         | Deprecated                             |
+//! | generatetoaddress                  | version + model |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Mining == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getblocktemplate                   | done            |
-//! | getmininginfo                      | done            |
-//! | getnetworkhashps                   | done            |
-//! | prioritisetransaction              | done            |
-//! | submitblock                        | done (untested) |
-//! | submitheader                       | todo            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getblocktemplate                   | version + model |                                        |
+//! | getmininginfo                      | version         |                                        |
+//! | getnetworkhashps                   | returns boolean |                                        |
+//! | prioritisetransaction              | returns boolean |                                        |
+//! | submitblock                        | returns nothing |                                        |
+//! | submitheader                       | return nothing  | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Network == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | addnode                            | omitted         |
-//! | clearbanned                        | omitted         |
-//! | disconnectnode                     | omitted         |
-//! | getaddednodeinfo                   | done            |
-//! | getconnectioncount                 | omitted         |
-//! | getnettotals                       | done            |
-//! | getnetworkinfo                     | done            |
-//! | getnodeaddresses                   | todo            |
-//! | getpeerinfo                        | done            |
-//! | listbanned                         | omitted         |
-//! | ping                               | omitted         |
-//! | setban                             | omitted         |
-//! | setnetworkactive                   | omitted         |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | addnode                            | returns nothing |                                        |
+//! | clearbanned                        | returns nothing |                                        |
+//! | disconnectnode                     | returns nothing |                                        |
+//! | getaddednodeinfo                   | version         |                                        |
+//! | getconnectioncount                 | returns numeric |                                        |
+//! | getnettotals                       | version         |                                        |
+//! | getnetworkinfo                     | version + model |                                        |
+//! | getnodeaddresses                   | version         | TODO                                   |
+//! | getpeerinfo                        | version         |                                        |
+//! | listbanned                         | returns string  |                                        |
+//! | ping                               | returns nothing |                                        |
+//! | setban                             | returns nothing |                                        |
+//! | setnetworkactive                   | returns nothing |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Rawtransactions == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | analyzepsbt                        | done            |
-//! | combinepsbt                        | done            |
-//! | combinerawtransaction              | done            |
-//! | converttopsbt                      | done            |
-//! | createpsbt                         | done            |
-//! | createrawtransaction               | done            |
-//! | decodepsbt                         | done            |
-//! | decoderawtransaction               | done            |
-//! | decodescript                       | done            |
-//! | finalizepsbt                       | done (untested) |
-//! | fundrawtransaction                 | done            |
-//! | getrawtransaction                  | done            |
-//! | joinpsbts                          | done (untested) |
-//! | sendrawtransaction                 | done            |
-//! | signrawtransactionwithkey          | done            |
-//! | testmempoolaccept                  | done (untested) |
-//! | utxoupdatepsbt                     | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | analyzepsbt                        | version + model |                                        |
+//! | combinepsbt                        | version + model |                                        |
+//! | combinerawtransaction              | version + model |                                        |
+//! | converttopsbt                      | version + model |                                        |
+//! | createpsbt                         | version + model |                                        |
+//! | createrawtransaction               | version + model |                                        |
+//! | decodepsbt                         | version + model |                                        |
+//! | decoderawtransaction               | version + model |                                        |
+//! | decodescript                       | version + model |                                        |
+//! | finalizepsbt                       | version + model | UNTESTED                               |
+//! | fundrawtransaction                 | version + model |                                        |
+//! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
+//! | joinpsbts                          | version + model | UNTESTED                               |
+//! | sendrawtransaction                 | version + model |                                        |
+//! | signrawtransactionwithkey          | version + model |                                        |
+//! | testmempoolaccept                  | version + model | UNTESTED                               |
+//! | utxoupdatepsbt                     | version + model | UNTESTED                               |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Util == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | createmultisig                     | omitted         |
-//! | deriveaddresses                    | todo            |
-//! | estimatesmartfee                   | omitted         |
-//! | getdescriptorinfo                  | todo            |
-//! | signmessagewithprivkey             | omitted         |
-//! | validateaddress                    | omitted         |
-//! | verifymessage                      | omitted         |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | createmultisig                     | version + model | TODO                                   |
+//! | deriveaddresses                    | version + model | TODO                                   |
+//! | estimatesmartfee                   | returns nothing | TODO                                   |
+//! | getdescriptorinfo                  | version         | TODO                                   |
+//! | signmessagewithprivkey             | returns string  | TODO                                   |
+//! | validateaddress                    | version + model | TODO                                   |
+//! | verifymessage                      | returns boolean | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Wallet == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | abandontransaction                 | omitted         |
-//! | abortrescan                        | omitted         |
-//! | addmultisigaddress                 | done (untested) |
-//! | backupwallet                       | omitted         |
-//! | bumpfee                            | done            |
-//! | createwallet                       | done            |
-//! | dumpprivkey                        | done            |
-//! | dumpwallet                         | done            |
-//! | encryptwallet                      | omitted         |
-//! | getaddressesbylabel                | done            |
-//! | getaddressinfo                     | done (untested) |
-//! | getbalance                         | done            |
-//! | getnewaddress                      | done            |
-//! | getrawchangeaddress                | done            |
-//! | getreceivedbyaddress               | done            |
-//! | getreceivedbylabel                 | todo            |
-//! | gettransaction                     | done            |
-//! | getunconfirmedbalance              | done (untested) |
-//! | getwalletinfo                      | done (untested) |
-//! | importaddress                      | omitted         |
-//! | importmulti                        | omitted         |
-//! | importprivkey                      | omitted         |
-//! | importprunedfunds                  | omitted         |
-//! | importpubkey                       | omitted         |
-//! | importwallet                       | omitted         |
-//! | keypoolrefill                      | omitted         |
-//! | listaddressgroupings               | done (untested) |
-//! | listlabels                         | done (untested) |
-//! | listlockunspent                    | done (untested) |
-//! | listreceivedbyaddress              | done (untested) |
-//! | listreceivedbylabel                | todo            |
-//! | listsinceblock                     | done (untested) |
-//! | listtransactions                   | done (untested) |
-//! | listunspent                        | done (untested) |
-//! | listwalletdir                      | todo            |
-//! | listwallets                        | done (untested) |
-//! | loadwallet                         | done            |
-//! | lockunspent                        | omitted         |
-//! | removeprunedfunds                  | omitted         |
-//! | rescanblockchain                   | done (untested) |
-//! | sendmany                           | done (untested) |
-//! | sendtoaddress                      | done            |
-//! | sethdseed                          | omitted         |
-//! | setlabel                           | todo            |
-//! | settxfee                           | omitted         |
-//! | signmessage                        | done (untested) |
-//! | signrawtransactionwithwallet       | done (untested) |
-//! | unloadwallet                       | done            |
-//! | walletcreatefundedpsbt             | done (untested) |
-//! | walletlock                         | omitted         |
-//! | walletpassphrase                   | omitted         |
-//! | walletpassphrasechange             | omitted         |
-//! | walletprocesspsbt                  | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | abandontransaction                 | returns nothing |                                        |
+//! | abortrescan                        | returns nothing |                                        |
+//! | addmultisigaddress                 | version + model | UNTESTED                               |
+//! | backupwallet                       | returns nothing |                                        |
+//! | bumpfee                            | version + model |                                        |
+//! | createwallet                       | version + model |                                        |
+//! | dumpprivkey                        | version + model |                                        |
+//! | dumpwallet                         | version + model |                                        |
+//! | encryptwallet                      | returns nothing |                                        |
+//! | getaddressesbylabel                | version + model |                                        |
+//! | getaddressinfo                     | version + model | UNTESTED                               |
+//! | getbalance                         | version + model |                                        |
+//! | getnewaddress                      | version + model |                                        |
+//! | getrawchangeaddress                | version + model |                                        |
+//! | getreceivedbyaddress               | version + model | TODO                                   |
+//! | getreceivedbylabel                 | version + model | TODO                                   |
+//! | gettransaction                     | version + model |                                        |
+//! | getunconfirmedbalance              | version + model | UNTESTED                               |
+//! | getwalletinfo                      | version + model | UNTESTED                               |
+//! | importaddress                      | returns nothing |                                        |
+//! | importmulti                        | returns nothing |                                        |
+//! | importprivkey                      | returns nothing |                                        |
+//! | importprunedfunds                  | returns nothing |                                        |
+//! | importpubkey                       | returns nothing |                                        |
+//! | importwallet                       | returns nothing |                                        |
+//! | keypoolrefill                      | returns nothing |                                        |
+//! | listaddressgroupings               | version + model | UNTESTED                               |
+//! | listlabels                         | version + model | UNTESTED                               |
+//! | listlockunspent                    | version + model | UNTESTED                               |
+//! | listreceivedbyaddress              | version + model | UNTESTED                               |
+//! | listreceivedbylabel                | version + model | TODO                                   |
+//! | listsinceblock                     | version + model | UNTESTED                               |
+//! | listtransactions                   | version + model | UNTESTED                               |
+//! | listunspent                        | version + model | UNTESTED                               |
+//! | listwalletdir                      | version         | TODO                                   |
+//! | listwallets                        | version + model | UNTESTED                               |
+//! | loadwallet                         | version + model |                                        |
+//! | lockunspent                        | returns boolean |                                        |
+//! | removeprunedfunds                  | returns nothing |                                        |
+//! | rescanblockchain                   | version + model | UNTESTED                               |
+//! | sendmany                           | version + model | UNTESTED                               |
+//! | sendtoaddress                      | version + model |                                        |
+//! | sethdseed                          | returns nothing |                                        |
+//! | setlabel                           | returns nothing |                                        |
+//! | settxfee                           | returns boolean |                                        |
+//! | signmessage                        | version + model | UNTESTED                               |
+//! | signrawtransactionwithwallet       | version + model |                                        |
+//! | unloadwallet                       | returns nothing |                                        |
+//! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
+//! | walletlock                         | returns nothing |                                        |
+//! | walletpassphrase                   | returns nothing |                                        |
+//! | walletpassphrasechange             | returns nothing |                                        |
+//! | walletprocesspsbt                  | version + model | UNTESTED                               |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Zmq == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getzmqnotifications                | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getzmqnotifications                | version         | UNTESTED                               |
 //!
 //! </details>
 

--- a/types/src/v19/mod.rs
+++ b/types/src/v19/mod.rs
@@ -9,209 +9,218 @@
 //!
 //! ### Method name and implementation status
 //!
-//! Every JSON-RPC method supported by this version of Bitcoin Core is listed below along with its
-//! current implementation status.
+//! Every JSON-RPC method supported by this version of Bitcoin Core is listed below along with the
+//! type it returns and any implementation notes.
+//!
+//! Key to 'Returns' column:
+//!
+//! * version: method returns a version specific type but has no model type.
+//! * version + model: method returns a version specific type and can be converted to a model type.
+//! * returns foo: method returns a foo (e.g. string, boolean, or nothing).
+//! * omitted: method intentionally unsupported with no plans of adding support.
+//!
+//! If a method has UNTESTED then there is no integration test yet for it.
 //!
 //! <details>
 //! <summary> Methods from the == Blockchain == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getbestblockhash                   | done            |
-//! | getblock                           | done            |
-//! | getblockchaininfo                  | done            |
-//! | getblockcount                      | done            |
-//! | getblockfilter                     | done            |
-//! | getblockhash                       | done            |
-//! | getblockheader                     | done            |
-//! | getblockstats                      | done            |
-//! | getchaintips                       | done            |
-//! | getchaintxstats                    | done            |
-//! | getdifficulty                      | done            |
-//! | getmempoolancestors                | done (untested) |
-//! | getmempooldescendants              | done (untested) |
-//! | getmempoolentry                    | done            |
-//! | getmempoolinfo                     | done            |
-//! | getrawmempool                      | done            |
-//! | gettxout                           | done            |
-//! | gettxoutproof                      | done            |
-//! | gettxoutsetinfo                    | done            |
-//! | preciousblock                      | done            |
-//! | pruneblockchain                    | omitted         |
-//! | savemempool                        | omitted         |
-//! | scantxoutset                       | omitted         |
-//! | verifychain                        | omitted         |
-//! | verifytxoutproof                   | done            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getbestblockhash                   | version + model |                                        |
+//! | getblock                           | version + model | Includes additional 'verbose' type     |
+//! | getblockchaininfo                  | version + model |                                        |
+//! | getblockcount                      | version + model |                                        |
+//! | getblockfilter                     | version         |                                        |
+//! | getblockhash                       | version + model |                                        |
+//! | getblockheader                     | version + model | Includes additional 'verbose' type     |
+//! | getblockstats                      | version + model |                                        |
+//! | getchaintips                       | version + model |                                        |
+//! | getchaintxstats                    | version + model |                                        |
+//! | getdifficulty                      | version + model |                                        |
+//! | getmempoolancestors                | version + model | UNTESTED (incl. verbose type)          |
+//! | getmempooldescendants              | version + model | UNTESTED (incl. verbose type)          |
+//! | getmempoolentry                    | version + model |                                        |
+//! | getmempoolinfo                     | version + model |                                        |
+//! | getrawmempool                      | version + model | Includes additional 'verbose' type     |
+//! | gettxout                           | version + model |                                        |
+//! | gettxoutproof                      | returns string  |                                        |
+//! | gettxoutsetinfo                    | version + model |                                        |
+//! | preciousblock                      | returns nothing |                                        |
+//! | pruneblockchain                    | returns numeric |                                        |
+//! | savemempool                        | returns nothing |                                        |
+//! | scantxoutset                       | omitted         | API marked as experimental             |
+//! | verifychain                        | returns boolean |                                        |
+//! | verifytxoutproof                   | version + model |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Control == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getmemoryinfo                      | done            |
-//! | getrpcinfo                         | done            |
-//! | help                               | done            |
-//! | logging                            | done            |
-//! | stop                               | done            |
-//! | uptime                             | done            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getmemoryinfo                      | version         |                                        |
+//! | getrpcinfo                         | version + model |                                        |
+//! | help                               | returns string  |                                        |
+//! | logging                            | version         |                                        |
+//! | stop                               | returns string  |                                        |
+//! | uptime                             | returns numeric |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Generating == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | generatetoaddress                  | done            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | generatetoaddress                  | version + model |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Mining == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getblocktemplate                   | done            |
-//! | getmininginfo                      | done            |
-//! | getnetworkhashps                   | done            |
-//! | prioritisetransaction              | done            |
-//! | submitblock                        | done (untested) |
-//! | submitheader                       | todo            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getblocktemplate                   | version + model |                                        |
+//! | getmininginfo                      | version         |                                        |
+//! | getnetworkhashps                   | returns boolean |                                        |
+//! | prioritisetransaction              | returns boolean |                                        |
+//! | submitblock                        | returns nothing |                                        |
+//! | submitheader                       | return nothing  | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Network == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | addnode                            | omitted         |
-//! | clearbanned                        | omitted         |
-//! | disconnectnode                     | omitted         |
-//! | getaddednodeinfo                   | done            |
-//! | getconnectioncount                 | omitted         |
-//! | getnettotals                       | done            |
-//! | getnetworkinfo                     | done            |
-//! | getnodeaddresses                   | todo            |
-//! | getpeerinfo                        | done            |
-//! | listbanned                         | omitted         |
-//! | ping                               | omitted         |
-//! | setban                             | omitted         |
-//! | setnetworkactive                   | omitted         |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | addnode                            | returns nothing |                                        |
+//! | clearbanned                        | returns nothing |                                        |
+//! | disconnectnode                     | returns nothing |                                        |
+//! | getaddednodeinfo                   | version         |                                        |
+//! | getconnectioncount                 | returns numeric |                                        |
+//! | getnettotals                       | version         |                                        |
+//! | getnetworkinfo                     | version + model |                                        |
+//! | getnodeaddresses                   | version         | TODO                                   |
+//! | getpeerinfo                        | version         |                                        |
+//! | listbanned                         | returns string  |                                        |
+//! | ping                               | returns nothing |                                        |
+//! | setban                             | returns nothing |                                        |
+//! | setnetworkactive                   | returns nothing |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Rawtransactions == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | analyzepsbt                        | done            |
-//! | combinepsbt                        | done            |
-//! | combinerawtransaction              | done            |
-//! | converttopsbt                      | done            |
-//! | createpsbt                         | done            |
-//! | createrawtransaction               | done            |
-//! | decodepsbt                         | done            |
-//! | decoderawtransaction               | done            |
-//! | decodescript                       | done            |
-//! | finalizepsbt                       | done (untested) |
-//! | fundrawtransaction                 | done            |
-//! | getrawtransaction                  | done            |
-//! | joinpsbts                          | done (untested) |
-//! | sendrawtransaction                 | done            |
-//! | signrawtransactionwithkey          | done            |
-//! | testmempoolaccept                  | done (untested) |
-//! | utxoupdatepsbt                     | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | analyzepsbt                        | version + model |                                        |
+//! | combinepsbt                        | version + model |                                        |
+//! | combinerawtransaction              | version + model |                                        |
+//! | converttopsbt                      | version + model |                                        |
+//! | createpsbt                         | version + model |                                        |
+//! | createrawtransaction               | version + model |                                        |
+//! | decodepsbt                         | version + model |                                        |
+//! | decoderawtransaction               | version + model |                                        |
+//! | decodescript                       | version + model |                                        |
+//! | finalizepsbt                       | version + model | UNTESTED                               |
+//! | fundrawtransaction                 | version + model |                                        |
+//! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
+//! | joinpsbts                          | version + model | UNTESTED                               |
+//! | sendrawtransaction                 | version + model |                                        |
+//! | signrawtransactionwithkey          | version + model |                                        |
+//! | testmempoolaccept                  | version + model | UNTESTED                               |
+//! | utxoupdatepsbt                     | version + model | UNTESTED                               |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Util == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | createmultisig                     | omitted         |
-//! | deriveaddresses                    | todo            |
-//! | estimatesmartfee                   | omitted         |
-//! | getdescriptorinfo                  | todo            |
-//! | signmessagewithprivkey             | omitted         |
-//! | validateaddress                    | omitted         |
-//! | verifymessage                      | omitted         |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | createmultisig                     | version + model | TODO                                   |
+//! | deriveaddresses                    | version + model | TODO                                   |
+//! | estimatesmartfee                   | returns nothing | TODO                                   |
+//! | getdescriptorinfo                  | version         | TODO                                   |
+//! | signmessagewithprivkey             | returns string  | TODO                                   |
+//! | validateaddress                    | version + model | TODO                                   |
+//! | verifymessage                      | returns boolean | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Wallet == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | abandontransaction                 | omitted         |
-//! | abortrescan                        | omitted         |
-//! | addmultisigaddress                 | done (untested) |
-//! | backupwallet                       | omitted         |
-//! | bumpfee                            | done            |
-//! | createwallet                       | done            |
-//! | dumpprivkey                        | done            |
-//! | dumpwallet                         | done            |
-//! | encryptwallet                      | omitted         |
-//! | getaddressesbylabel                | done            |
-//! | getaddressinfo                     | done (untested) |
-//! | getbalance                         | done            |
-//! | getbalances                        | done            |
-//! | getnewaddress                      | done            |
-//! | getrawchangeaddress                | done            |
-//! | getreceivedbyaddress               | done            |
-//! | getreceivedbylabel                 | todo            |
-//! | gettransaction                     | done            |
-//! | getunconfirmedbalance              | done (untested) |
-//! | getwalletinfo                      | done (untested) |
-//! | importaddress                      | omitted         |
-//! | importmulti                        | omitted         |
-//! | importprivkey                      | omitted         |
-//! | importprunedfunds                  | omitted         |
-//! | importpubkey                       | omitted         |
-//! | importwallet                       | omitted         |
-//! | keypoolrefill                      | omitted         |
-//! | listaddressgroupings               | done (untested) |
-//! | listlabels                         | done (untested) |
-//! | listlockunspent                    | done (untested) |
-//! | listreceivedbyaddress              | done (untested) |
-//! | listreceivedbylabel                | todo            |
-//! | listsinceblock                     | done (untested) |
-//! | listtransactions                   | done (untested) |
-//! | listunspent                        | done (untested) |
-//! | listwalletdir                      | todo            |
-//! | listwallets                        | done (untested) |
-//! | loadwallet                         | done            |
-//! | lockunspent                        | omitted         |
-//! | removeprunedfunds                  | omitted         |
-//! | rescanblockchain                   | done (untested) |
-//! | sendmany                           | done (untested) |
-//! | sendtoaddress                      | done            |
-//! | sethdseed                          | omitted         |
-//! | setlabel                           | todo            |
-//! | settxfee                           | omitted         |
-//! | setwalletflag                      | todo            |
-//! | signmessage                        | done (untested) |
-//! | signrawtransactionwithwallet       | done (untested) |
-//! | unloadwallet                       | done            |
-//! | walletcreatefundedpsbt             | done (untested) |
-//! | walletlock                         | omitted         |
-//! | walletpassphrase                   | omitted         |
-//! | walletpassphrasechange             | omitted         |
-//! | walletprocesspsbt                  | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | abandontransaction                 | returns nothing |                                        |
+//! | abortrescan                        | returns nothing |                                        |
+//! | addmultisigaddress                 | version + model | UNTESTED                               |
+//! | backupwallet                       | returns nothing |                                        |
+//! | bumpfee                            | version + model |                                        |
+//! | createwallet                       | version + model |                                        |
+//! | dumpprivkey                        | version + model |                                        |
+//! | dumpwallet                         | version + model |                                        |
+//! | encryptwallet                      | returns nothing |                                        |
+//! | getaddressesbylabel                | version + model |                                        |
+//! | getaddressinfo                     | version + model | UNTESTED                               |
+//! | getbalance                         | version + model |                                        |
+//! | getbalances                        | version + model |                                        |
+//! | getnewaddress                      | version + model |                                        |
+//! | getrawchangeaddress                | version + model |                                        |
+//! | getreceivedbyaddress               | version + model | TODO                                   |
+//! | getreceivedbylabel                 | version + model | TODO                                   |
+//! | gettransaction                     | version + model |                                        |
+//! | getunconfirmedbalance              | version + model | UNTESTED                               |
+//! | getwalletinfo                      | version + model | UNTESTED                               |
+//! | importaddress                      | returns nothing |                                        |
+//! | importmulti                        | returns nothing |                                        |
+//! | importprivkey                      | returns nothing |                                        |
+//! | importprunedfunds                  | returns nothing |                                        |
+//! | importpubkey                       | returns nothing |                                        |
+//! | importwallet                       | returns nothing |                                        |
+//! | keypoolrefill                      | returns nothing |                                        |
+//! | listaddressgroupings               | version + model | UNTESTED                               |
+//! | listlabels                         | version + model | UNTESTED                               |
+//! | listlockunspent                    | version + model | UNTESTED                               |
+//! | listreceivedbyaddress              | version + model | UNTESTED                               |
+//! | listreceivedbylabel                | version + model | TODO                                   |
+//! | listsinceblock                     | version + model | UNTESTED                               |
+//! | listtransactions                   | version + model | UNTESTED                               |
+//! | listunspent                        | version + model | UNTESTED                               |
+//! | listwalletdir                      | version         | TODO                                   |
+//! | listwallets                        | version + model | UNTESTED                               |
+//! | loadwallet                         | version + model |                                        |
+//! | lockunspent                        | returns boolean |                                        |
+//! | removeprunedfunds                  | returns nothing |                                        |
+//! | rescanblockchain                   | version + model | UNTESTED                               |
+//! | sendmany                           | version + model | UNTESTED                               |
+//! | sendtoaddress                      | version + model |                                        |
+//! | sethdseed                          | returns nothing |                                        |
+//! | setlabel                           | returns nothing |                                        |
+//! | settxfee                           | returns boolean |                                        |
+//! | setwalletflag                      | version         | TODO                                   |
+//! | signmessage                        | version + model | UNTESTED                               |
+//! | signrawtransactionwithwallet       | version + model |                                        |
+//! | unloadwallet                       | returns nothing |                                        |
+//! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
+//! | walletlock                         | returns nothing |                                        |
+//! | walletpassphrase                   | returns nothing |                                        |
+//! | walletpassphrasechange             | returns nothing |                                        |
+//! | walletprocesspsbt                  | version + model | UNTESTED                               |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Zmq == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getzmqnotifications                | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getzmqnotifications                | version         | UNTESTED                               |
 //!
 //! </details>
 

--- a/types/src/v20/mod.rs
+++ b/types/src/v20/mod.rs
@@ -9,210 +9,219 @@
 //!
 //! ### Method name and implementation status
 //!
-//! Every JSON-RPC method supported by this version of Bitcoin Core is listed below along with its
-//! current implementation status.
+//! Every JSON-RPC method supported by this version of Bitcoin Core is listed below along with the
+//! type it returns and any implementation notes.
+//!
+//! Key to 'Returns' column:
+//!
+//! * version: method returns a version specific type but has no model type.
+//! * version + model: method returns a version specific type and can be converted to a model type.
+//! * returns foo: method returns a foo (e.g. string, boolean, or nothing).
+//! * omitted: method intentionally unsupported with no plans of adding support.
+//!
+//! If a method has UNTESTED then there is no integration test yet for it.
 //!
 //! <details>
 //! <summary> Methods from the == Blockchain == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getbestblockhash                   | done            |
-//! | getblock                           | done            |
-//! | getblockchaininfo                  | done            |
-//! | getblockcount                      | done            |
-//! | getblockfilter                     | done            |
-//! | getblockhash                       | done            |
-//! | getblockheader                     | done            |
-//! | getblockstats                      | done            |
-//! | getchaintips                       | done            |
-//! | getchaintxstats                    | done            |
-//! | getdifficulty                      | done            |
-//! | getmempoolancestors                | done (untested) |
-//! | getmempooldescendants              | done (untested) |
-//! | getmempoolentry                    | done            |
-//! | getmempoolinfo                     | done            |
-//! | getrawmempool                      | done            |
-//! | gettxout                           | done            |
-//! | gettxoutproof                      | done            |
-//! | gettxoutsetinfo                    | done            |
-//! | preciousblock                      | done            |
-//! | pruneblockchain                    | omitted         |
-//! | savemempool                        | omitted         |
-//! | scantxoutset                       | omitted         |
-//! | verifychain                        | omitted         |
-//! | verifytxoutproof                   | done            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getbestblockhash                   | version + model |                                        |
+//! | getblock                           | version + model | Includes additional 'verbose' type     |
+//! | getblockchaininfo                  | version + model |                                        |
+//! | getblockcount                      | version + model |                                        |
+//! | getblockfilter                     | version         |                                        |
+//! | getblockhash                       | version + model |                                        |
+//! | getblockheader                     | version + model | Includes additional 'verbose' type     |
+//! | getblockstats                      | version + model |                                        |
+//! | getchaintips                       | version + model |                                        |
+//! | getchaintxstats                    | version + model |                                        |
+//! | getdifficulty                      | version + model |                                        |
+//! | getmempoolancestors                | version + model | UNTESTED (incl. verbose type)          |
+//! | getmempooldescendants              | version + model | UNTESTED (incl. verbose type)          |
+//! | getmempoolentry                    | version + model |                                        |
+//! | getmempoolinfo                     | version + model |                                        |
+//! | getrawmempool                      | version + model | Includes additional 'verbose' type     |
+//! | gettxout                           | version + model |                                        |
+//! | gettxoutproof                      | returns string  |                                        |
+//! | gettxoutsetinfo                    | version + model |                                        |
+//! | preciousblock                      | returns nothing |                                        |
+//! | pruneblockchain                    | returns numeric |                                        |
+//! | savemempool                        | returns nothing |                                        |
+//! | scantxoutset                       | omitted         | API marked as experimental             |
+//! | verifychain                        | returns boolean |                                        |
+//! | verifytxoutproof                   | version + model |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Control == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getmemoryinfo                      | done            |
-//! | getrpcinfo                         | done            |
-//! | help                               | done            |
-//! | logging                            | done            |
-//! | stop                               | done            |
-//! | uptime                             | done            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getmemoryinfo                      | version         |                                        |
+//! | getrpcinfo                         | version + model |                                        |
+//! | help                               | returns string  |                                        |
+//! | logging                            | version         |                                        |
+//! | stop                               | returns string  |                                        |
+//! | uptime                             | returns numeric |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Generating == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | generatetoaddress                  | done            |
-//! | generatetodescriptor               | todo            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | generatetoaddress                  | version + model |                                        |
+//! | generatetodescriptor               | version + model | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Mining == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getblocktemplate                   | done            |
-//! | getmininginfo                      | done            |
-//! | getnetworkhashps                   | done            |
-//! | prioritisetransaction              | done            |
-//! | submitblock                        | done (untested) |
-//! | submitheader                       | todo            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getblocktemplate                   | version + model |                                        |
+//! | getmininginfo                      | version         |                                        |
+//! | getnetworkhashps                   | returns boolean |                                        |
+//! | prioritisetransaction              | returns boolean |                                        |
+//! | submitblock                        | returns nothing |                                        |
+//! | submitheader                       | return nothing  | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Network == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | addnode                            | omitted         |
-//! | clearbanned                        | omitted         |
-//! | disconnectnode                     | omitted         |
-//! | getaddednodeinfo                   | done            |
-//! | getconnectioncount                 | omitted         |
-//! | getnettotals                       | done            |
-//! | getnetworkinfo                     | done            |
-//! | getnodeaddresses                   | todo            |
-//! | getpeerinfo                        | done            |
-//! | listbanned                         | omitted         |
-//! | ping                               | omitted         |
-//! | setban                             | omitted         |
-//! | setnetworkactive                   | omitted         |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | addnode                            | returns nothing |                                        |
+//! | clearbanned                        | returns nothing |                                        |
+//! | disconnectnode                     | returns nothing |                                        |
+//! | getaddednodeinfo                   | version         |                                        |
+//! | getconnectioncount                 | returns numeric |                                        |
+//! | getnettotals                       | version         |                                        |
+//! | getnetworkinfo                     | version + model |                                        |
+//! | getnodeaddresses                   | version         | TODO                                   |
+//! | getpeerinfo                        | version         |                                        |
+//! | listbanned                         | returns string  |                                        |
+//! | ping                               | returns nothing |                                        |
+//! | setban                             | returns nothing |                                        |
+//! | setnetworkactive                   | returns nothing |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Rawtransactions == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | analyzepsbt                        | done            |
-//! | combinepsbt                        | done            |
-//! | combinerawtransaction              | done            |
-//! | converttopsbt                      | done            |
-//! | createpsbt                         | done            |
-//! | createrawtransaction               | done            |
-//! | decodepsbt                         | done            |
-//! | decoderawtransaction               | done            |
-//! | decodescript                       | done            |
-//! | finalizepsbt                       | done (untested) |
-//! | fundrawtransaction                 | done            |
-//! | getrawtransaction                  | done            |
-//! | joinpsbts                          | done (untested) |
-//! | sendrawtransaction                 | done            |
-//! | signrawtransactionwithkey          | done            |
-//! | testmempoolaccept                  | done (untested) |
-//! | utxoupdatepsbt                     | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | analyzepsbt                        | version + model |                                        |
+//! | combinepsbt                        | version + model |                                        |
+//! | combinerawtransaction              | version + model |                                        |
+//! | converttopsbt                      | version + model |                                        |
+//! | createpsbt                         | version + model |                                        |
+//! | createrawtransaction               | version + model |                                        |
+//! | decodepsbt                         | version + model |                                        |
+//! | decoderawtransaction               | version + model |                                        |
+//! | decodescript                       | version + model |                                        |
+//! | finalizepsbt                       | version + model | UNTESTED                               |
+//! | fundrawtransaction                 | version + model |                                        |
+//! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
+//! | joinpsbts                          | version + model | UNTESTED                               |
+//! | sendrawtransaction                 | version + model |                                        |
+//! | signrawtransactionwithkey          | version + model |                                        |
+//! | testmempoolaccept                  | version + model | UNTESTED                               |
+//! | utxoupdatepsbt                     | version + model | UNTESTED                               |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Util == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | createmultisig                     | omitted         |
-//! | deriveaddresses                    | todo            |
-//! | estimatesmartfee                   | omitted         |
-//! | getdescriptorinfo                  | todo            |
-//! | signmessagewithprivkey             | omitted         |
-//! | validateaddress                    | omitted         |
-//! | verifymessage                      | omitted         |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | createmultisig                     | version + model | TODO                                   |
+//! | deriveaddresses                    | version + model | TODO                                   |
+//! | estimatesmartfee                   | returns nothing | TODO                                   |
+//! | getdescriptorinfo                  | version         | TODO                                   |
+//! | signmessagewithprivkey             | returns string  | TODO                                   |
+//! | validateaddress                    | version + model | TODO                                   |
+//! | verifymessage                      | returns boolean | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Wallet == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | abandontransaction                 | omitted         |
-//! | abortrescan                        | omitted         |
-//! | addmultisigaddress                 | done (untested) |
-//! | backupwallet                       | omitted         |
-//! | bumpfee                            | done            |
-//! | createwallet                       | done            |
-//! | dumpprivkey                        | done            |
-//! | dumpwallet                         | done            |
-//! | encryptwallet                      | omitted         |
-//! | getaddressesbylabel                | done            |
-//! | getaddressinfo                     | done (untested) |
-//! | getbalance                         | done            |
-//! | getbalances                        | done            |
-//! | getnewaddress                      | done            |
-//! | getrawchangeaddress                | done            |
-//! | getreceivedbyaddress               | done            |
-//! | getreceivedbylabel                 | todo            |
-//! | gettransaction                     | done            |
-//! | getunconfirmedbalance              | done (untested) |
-//! | getwalletinfo                      | done (untested) |
-//! | importaddress                      | omitted         |
-//! | importmulti                        | omitted         |
-//! | importprivkey                      | omitted         |
-//! | importprunedfunds                  | omitted         |
-//! | importpubkey                       | omitted         |
-//! | importwallet                       | omitted         |
-//! | keypoolrefill                      | omitted         |
-//! | listaddressgroupings               | done (untested) |
-//! | listlabels                         | done (untested) |
-//! | listlockunspent                    | done (untested) |
-//! | listreceivedbyaddress              | done (untested) |
-//! | listreceivedbylabel                | todo            |
-//! | listsinceblock                     | done (untested) |
-//! | listtransactions                   | done (untested) |
-//! | listunspent                        | done (untested) |
-//! | listwalletdir                      | todo            |
-//! | listwallets                        | done (untested) |
-//! | loadwallet                         | done            |
-//! | lockunspent                        | omitted         |
-//! | removeprunedfunds                  | omitted         |
-//! | rescanblockchain                   | done (untested) |
-//! | sendmany                           | done (untested) |
-//! | sendtoaddress                      | done            |
-//! | sethdseed                          | omitted         |
-//! | setlabel                           | todo            |
-//! | settxfee                           | omitted         |
-//! | setwalletflag                      | todo            |
-//! | signmessage                        | done (untested) |
-//! | signrawtransactionwithwallet       | done (untested) |
-//! | unloadwallet                       | done            |
-//! | walletcreatefundedpsbt             | done (untested) |
-//! | walletlock                         | omitted         |
-//! | walletpassphrase                   | omitted         |
-//! | walletpassphrasechange             | omitted         |
-//! | walletprocesspsbt                  | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | abandontransaction                 | returns nothing |                                        |
+//! | abortrescan                        | returns nothing |                                        |
+//! | addmultisigaddress                 | version + model | UNTESTED                               |
+//! | backupwallet                       | returns nothing |                                        |
+//! | bumpfee                            | version + model |                                        |
+//! | createwallet                       | version + model |                                        |
+//! | dumpprivkey                        | version + model |                                        |
+//! | dumpwallet                         | version + model |                                        |
+//! | encryptwallet                      | returns nothing |                                        |
+//! | getaddressesbylabel                | version + model |                                        |
+//! | getaddressinfo                     | version + model | UNTESTED                               |
+//! | getbalance                         | version + model |                                        |
+//! | getbalances                        | version + model |                                        |
+//! | getnewaddress                      | version + model |                                        |
+//! | getrawchangeaddress                | version + model |                                        |
+//! | getreceivedbyaddress               | version + model | TODO                                   |
+//! | getreceivedbylabel                 | version + model | TODO                                   |
+//! | gettransaction                     | version + model |                                        |
+//! | getunconfirmedbalance              | version + model | UNTESTED                               |
+//! | getwalletinfo                      | version + model | UNTESTED                               |
+//! | importaddress                      | returns nothing |                                        |
+//! | importmulti                        | returns nothing |                                        |
+//! | importprivkey                      | returns nothing |                                        |
+//! | importprunedfunds                  | returns nothing |                                        |
+//! | importpubkey                       | returns nothing |                                        |
+//! | importwallet                       | returns nothing |                                        |
+//! | keypoolrefill                      | returns nothing |                                        |
+//! | listaddressgroupings               | version + model | UNTESTED                               |
+//! | listlabels                         | version + model | UNTESTED                               |
+//! | listlockunspent                    | version + model | UNTESTED                               |
+//! | listreceivedbyaddress              | version + model | UNTESTED                               |
+//! | listreceivedbylabel                | version + model | TODO                                   |
+//! | listsinceblock                     | version + model | UNTESTED                               |
+//! | listtransactions                   | version + model | UNTESTED                               |
+//! | listunspent                        | version + model | UNTESTED                               |
+//! | listwalletdir                      | version         | TODO                                   |
+//! | listwallets                        | version + model | UNTESTED                               |
+//! | loadwallet                         | version + model |                                        |
+//! | lockunspent                        | returns boolean |                                        |
+//! | removeprunedfunds                  | returns nothing |                                        |
+//! | rescanblockchain                   | version + model | UNTESTED                               |
+//! | sendmany                           | version + model | UNTESTED                               |
+//! | sendtoaddress                      | version + model |                                        |
+//! | sethdseed                          | returns nothing |                                        |
+//! | setlabel                           | returns nothing |                                        |
+//! | settxfee                           | returns boolean |                                        |
+//! | setwalletflag                      | version         | TODO                                   |
+//! | signmessage                        | version + model | UNTESTED                               |
+//! | signrawtransactionwithwallet       | version + model |                                        |
+//! | unloadwallet                       | returns nothing |                                        |
+//! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
+//! | walletlock                         | returns nothing |                                        |
+//! | walletpassphrase                   | returns nothing |                                        |
+//! | walletpassphrasechange             | returns nothing |                                        |
+//! | walletprocesspsbt                  | version + model | UNTESTED                               |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Zmq == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getzmqnotifications                | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getzmqnotifications                | version         | UNTESTED                               |
 //!
 //! </details>
 

--- a/types/src/v21/mod.rs
+++ b/types/src/v21/mod.rs
@@ -9,216 +9,225 @@
 //!
 //! ### Method name and implementation status
 //!
-//! Every JSON-RPC method supported by this version of Bitcoin Core is listed below along with its
-//! current implementation status.
+//! Every JSON-RPC method supported by this version of Bitcoin Core is listed below along with the
+//! type it returns and any implementation notes.
+//!
+//! Key to 'Returns' column:
+//!
+//! * version: method returns a version specific type but has no model type.
+//! * version + model: method returns a version specific type and can be converted to a model type.
+//! * returns foo: method returns a foo (e.g. string, boolean, or nothing).
+//! * omitted: method intentionally unsupported with no plans of adding support.
+//!
+//! If a method has UNTESTED then there is no integration test yet for it.
 //!
 //! <details>
 //! <summary> Methods from the == Blockchain == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getbestblockhash                   | done            |
-//! | getblock                           | done            |
-//! | getblockchaininfo                  | done            |
-//! | getblockcount                      | done            |
-//! | getblockfilter                     | done            |
-//! | getblockhash                       | done            |
-//! | getblockheader                     | done            |
-//! | getblockstats                      | done            |
-//! | getchaintips                       | done            |
-//! | getchaintxstats                    | done            |
-//! | getdifficulty                      | done            |
-//! | getmempoolancestors                | done (untested) |
-//! | getmempooldescendants              | done (untested) |
-//! | getmempoolentry                    | done            |
-//! | getmempoolinfo                     | done            |
-//! | getrawmempool                      | done            |
-//! | gettxout                           | done            |
-//! | gettxoutproof                      | done            |
-//! | gettxoutsetinfo                    | done            |
-//! | preciousblock                      | done            |
-//! | pruneblockchain                    | omitted         |
-//! | savemempool                        | omitted         |
-//! | scantxoutset                       | omitted         |
-//! | verifychain                        | omitted         |
-//! | verifytxoutproof                   | done            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getbestblockhash                   | version + model |                                        |
+//! | getblock                           | version + model | Includes additional 'verbose' type     |
+//! | getblockchaininfo                  | version + model |                                        |
+//! | getblockcount                      | version + model |                                        |
+//! | getblockfilter                     | version         |                                        |
+//! | getblockhash                       | version + model |                                        |
+//! | getblockheader                     | version + model | Includes additional 'verbose' type     |
+//! | getblockstats                      | version + model |                                        |
+//! | getchaintips                       | version + model |                                        |
+//! | getchaintxstats                    | version + model |                                        |
+//! | getdifficulty                      | version + model |                                        |
+//! | getmempoolancestors                | version + model | UNTESTED (incl. verbose type)          |
+//! | getmempooldescendants              | version + model | UNTESTED (incl. verbose type)          |
+//! | getmempoolentry                    | version + model |                                        |
+//! | getmempoolinfo                     | version + model |                                        |
+//! | getrawmempool                      | version + model | Includes additional 'verbose' type     |
+//! | gettxout                           | version + model |                                        |
+//! | gettxoutproof                      | returns string  |                                        |
+//! | gettxoutsetinfo                    | version + model |                                        |
+//! | preciousblock                      | returns nothing |                                        |
+//! | pruneblockchain                    | returns numeric |                                        |
+//! | savemempool                        | returns nothing |                                        |
+//! | scantxoutset                       | omitted         | API marked as experimental             |
+//! | verifychain                        | returns boolean |                                        |
+//! | verifytxoutproof                   | version + model |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Control == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getmemoryinfo                      | done            |
-//! | getrpcinfo                         | done            |
-//! | help                               | done            |
-//! | logging                            | done            |
-//! | stop                               | done            |
-//! | uptime                             | done            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getmemoryinfo                      | version         |                                        |
+//! | getrpcinfo                         | version + model |                                        |
+//! | help                               | returns string  |                                        |
+//! | logging                            | version         |                                        |
+//! | stop                               | returns string  |                                        |
+//! | uptime                             | returns numeric |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Generating == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | generateblock                      | todo            |
-//! | generatetoaddress                  | done            |
-//! | generatetodescriptor               | todo            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | generateblock                      | version + model | TODO                                   |
+//! | generatetoaddress                  | version + model |                                        |
+//! | generatetodescriptor               | version + model | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Mining == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getblocktemplate                   | done            |
-//! | getmininginfo                      | done            |
-//! | getnetworkhashps                   | done            |
-//! | prioritisetransaction              | done            |
-//! | submitblock                        | done (untested) |
-//! | submitheader                       | todo            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getblocktemplate                   | version + model |                                        |
+//! | getmininginfo                      | version         |                                        |
+//! | getnetworkhashps                   | returns boolean |                                        |
+//! | prioritisetransaction              | returns boolean |                                        |
+//! | submitblock                        | returns nothing |                                        |
+//! | submitheader                       | return nothing  | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Network == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | addnode                            | omitted         |
-//! | clearbanned                        | omitted         |
-//! | disconnectnode                     | omitted         |
-//! | getaddednodeinfo                   | done            |
-//! | getconnectioncount                 | omitted         |
-//! | getnettotals                       | done            |
-//! | getnetworkinfo                     | done            |
-//! | getnodeaddresses                   | todo            |
-//! | getpeerinfo                        | done            |
-//! | listbanned                         | omitted         |
-//! | ping                               | omitted         |
-//! | setban                             | omitted         |
-//! | setnetworkactive                   | omitted         |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | addnode                            | returns nothing |                                        |
+//! | clearbanned                        | returns nothing |                                        |
+//! | disconnectnode                     | returns nothing |                                        |
+//! | getaddednodeinfo                   | version         |                                        |
+//! | getconnectioncount                 | returns numeric |                                        |
+//! | getnettotals                       | version         |                                        |
+//! | getnetworkinfo                     | version + model |                                        |
+//! | getnodeaddresses                   | version         | TODO                                   |
+//! | getpeerinfo                        | version         |                                        |
+//! | listbanned                         | returns string  |                                        |
+//! | ping                               | returns nothing |                                        |
+//! | setban                             | returns nothing |                                        |
+//! | setnetworkactive                   | returns nothing |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Rawtransactions == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | analyzepsbt                        | done            |
-//! | combinepsbt                        | done            |
-//! | combinerawtransaction              | done            |
-//! | converttopsbt                      | done            |
-//! | createpsbt                         | done            |
-//! | createrawtransaction               | done            |
-//! | decodepsbt                         | done            |
-//! | decoderawtransaction               | done            |
-//! | decodescript                       | done            |
-//! | finalizepsbt                       | done (untested) |
-//! | fundrawtransaction                 | done            |
-//! | getrawtransaction                  | done            |
-//! | joinpsbts                          | done (untested) |
-//! | sendrawtransaction                 | done            |
-//! | signrawtransactionwithkey          | done            |
-//! | testmempoolaccept                  | done (untested) |
-//! | utxoupdatepsbt                     | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | analyzepsbt                        | version + model |                                        |
+//! | combinepsbt                        | version + model |                                        |
+//! | combinerawtransaction              | version + model |                                        |
+//! | converttopsbt                      | version + model |                                        |
+//! | createpsbt                         | version + model |                                        |
+//! | createrawtransaction               | version + model |                                        |
+//! | decodepsbt                         | version + model |                                        |
+//! | decoderawtransaction               | version + model |                                        |
+//! | decodescript                       | version + model |                                        |
+//! | finalizepsbt                       | version + model | UNTESTED                               |
+//! | fundrawtransaction                 | version + model |                                        |
+//! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
+//! | joinpsbts                          | version + model | UNTESTED                               |
+//! | sendrawtransaction                 | version + model |                                        |
+//! | signrawtransactionwithkey          | version + model |                                        |
+//! | testmempoolaccept                  | version + model | UNTESTED                               |
+//! | utxoupdatepsbt                     | version + model | UNTESTED                               |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Util == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | createmultisig                     | omitted         |
-//! | deriveaddresses                    | todo            |
-//! | estimatesmartfee                   | omitted         |
-//! | getdescriptorinfo                  | todo            |
-//! | getindexinfo                       | todo            |
-//! | signmessagewithprivkey             | omitted         |
-//! | validateaddress                    | omitted         |
-//! | verifymessage                      | omitted         |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | createmultisig                     | version + model | TODO                                   |
+//! | deriveaddresses                    | version + model | TODO                                   |
+//! | estimatesmartfee                   | returns nothing | TODO                                   |
+//! | getdescriptorinfo                  | version         | TODO                                   |
+//! | getindexinfo                       | version         | TODO                                   |
+//! | signmessagewithprivkey             | returns string  | TODO                                   |
+//! | validateaddress                    | version + model | TODO                                   |
+//! | verifymessage                      | returns boolean | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Wallet == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | abandontransaction                 | omitted         |
-//! | abortrescan                        | omitted         |
-//! | addmultisigaddress                 | done (untested) |
-//! | backupwallet                       | omitted         |
-//! | bumpfee                            | done            |
-//! | createwallet                       | done            |
-//! | dumpprivkey                        | done            |
-//! | dumpwallet                         | done            |
-//! | encryptwallet                      | omitted         |
-//! | getaddressesbylabel                | done            |
-//! | getaddressinfo                     | done (untested) |
-//! | getbalance                         | done            |
-//! | getbalances                        | done            |
-//! | getnewaddress                      | done            |
-//! | getrawchangeaddress                | done            |
-//! | getreceivedbyaddress               | done            |
-//! | getreceivedbylabel                 | todo            |
-//! | gettransaction                     | done            |
-//! | getunconfirmedbalance              | done (untested) |
-//! | getwalletinfo                      | done (untested) |
-//! | importaddress                      | omitted         |
-//! | importdescriptors                  | todo            |
-//! | importmulti                        | omitted         |
-//! | importprivkey                      | omitted         |
-//! | importprunedfunds                  | omitted         |
-//! | importpubkey                       | omitted         |
-//! | importwallet                       | omitted         |
-//! | keypoolrefill                      | omitted         |
-//! | listaddressgroupings               | done (untested) |
-//! | listlabels                         | done (untested) |
-//! | listlockunspent                    | done (untested) |
-//! | psbtbumpfee                        | todo            |
-//! | listreceivedbyaddress              | done (untested) |
-//! | listreceivedbylabel                | todo            |
-//! | listsinceblock                     | done (untested) |
-//! | listtransactions                   | done (untested) |
-//! | listunspent                        | done (untested) |
-//! | listwalletdir                      | todo            |
-//! | listwallets                        | done (untested) |
-//! | loadwallet                         | done            |
-//! | lockunspent                        | omitted         |
-//! | removeprunedfunds                  | omitted         |
-//! | rescanblockchain                   | done (untested) |
-//! | send                               | todo            |
-//! | sendmany                           | done (untested) |
-//! | sendtoaddress                      | done            |
-//! | sethdseed                          | omitted         |
-//! | setlabel                           | todo            |
-//! | settxfee                           | omitted         |
-//! | setwalletflag                      | todo            |
-//! | signmessage                        | done (untested) |
-//! | signrawtransactionwithwallet       | done (untested) |
-//! | unloadwallet                       | done            |
-//! | upgradewallet                      | todo            |
-//! | walletcreatefundedpsbt             | done (untested) |
-//! | walletlock                         | omitted         |
-//! | walletpassphrase                   | omitted         |
-//! | walletpassphrasechange             | omitted         |
-//! | walletprocesspsbt                  | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | abandontransaction                 | returns nothing |                                        |
+//! | abortrescan                        | returns nothing |                                        |
+//! | addmultisigaddress                 | version + model | UNTESTED                               |
+//! | backupwallet                       | returns nothing |                                        |
+//! | bumpfee                            | version + model |                                        |
+//! | createwallet                       | version + model |                                        |
+//! | dumpprivkey                        | version + model |                                        |
+//! | dumpwallet                         | version + model |                                        |
+//! | encryptwallet                      | returns nothing |                                        |
+//! | getaddressesbylabel                | version + model |                                        |
+//! | getaddressinfo                     | version + model | UNTESTED                               |
+//! | getbalance                         | version + model |                                        |
+//! | getbalances                        | version + model |                                        |
+//! | getnewaddress                      | version + model |                                        |
+//! | getrawchangeaddress                | version + model |                                        |
+//! | getreceivedbyaddress               | version + model | TODO                                   |
+//! | getreceivedbylabel                 | version + model | TODO                                   |
+//! | gettransaction                     | version + model |                                        |
+//! | getunconfirmedbalance              | version + model | UNTESTED                               |
+//! | getwalletinfo                      | version + model | UNTESTED                               |
+//! | importaddress                      | returns nothing |                                        |
+//! | importdescriptors                  | version         | TODO                                   |
+//! | importmulti                        | returns nothing |                                        |
+//! | importprivkey                      | returns nothing |                                        |
+//! | importprunedfunds                  | returns nothing |                                        |
+//! | importpubkey                       | returns nothing |                                        |
+//! | importwallet                       | returns nothing |                                        |
+//! | keypoolrefill                      | returns nothing |                                        |
+//! | listaddressgroupings               | version + model | UNTESTED                               |
+//! | listlabels                         | version + model | UNTESTED                               |
+//! | listlockunspent                    | version + model | UNTESTED                               |
+//! | psbtbumpfee                        | version + model | TODO                                   |
+//! | listreceivedbyaddress              | version + model | UNTESTED                               |
+//! | listreceivedbylabel                | version + model | TODO                                   |
+//! | listsinceblock                     | version + model | UNTESTED                               |
+//! | listtransactions                   | version + model | UNTESTED                               |
+//! | listunspent                        | version + model | UNTESTED                               |
+//! | listwalletdir                      | version         | TODO                                   |
+//! | listwallets                        | version + model | UNTESTED                               |
+//! | loadwallet                         | version + model |                                        |
+//! | lockunspent                        | returns boolean |                                        |
+//! | removeprunedfunds                  | returns nothing |                                        |
+//! | rescanblockchain                   | version + model | UNTESTED                               |
+//! | send                               | version + model | TODO                                   |
+//! | sendmany                           | version + model | UNTESTED                               |
+//! | sendtoaddress                      | version + model |                                        |
+//! | sethdseed                          | returns nothing |                                        |
+//! | setlabel                           | returns nothing |                                        |
+//! | settxfee                           | returns boolean |                                        |
+//! | setwalletflag                      | version         | TODO                                   |
+//! | signmessage                        | version + model | UNTESTED                               |
+//! | signrawtransactionwithwallet       | version + model |                                        |
+//! | unloadwallet                       | returns nothing |                                        |
+//! | upgradewallet                      | version         | TODO                                   |
+//! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
+//! | walletlock                         | returns nothing |                                        |
+//! | walletpassphrase                   | returns nothing |                                        |
+//! | walletpassphrasechange             | returns nothing |                                        |
+//! | walletprocesspsbt                  | version + model | UNTESTED                               |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Zmq == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getzmqnotifications                | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getzmqnotifications                | version         | UNTESTED                               |
 //!
 //! </details>
 

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -9,227 +9,236 @@
 //!
 //! ### Method name and implementation status
 //!
-//! Every JSON-RPC method supported by this version of Bitcoin Core is listed below along with its
-//! current implementation status.
+//! Every JSON-RPC method supported by this version of Bitcoin Core is listed below along with the
+//! type it returns and any implementation notes.
+//!
+//! Key to 'Returns' column:
+//!
+//! * version: method returns a version specific type but has no model type.
+//! * version + model: method returns a version specific type and can be converted to a model type.
+//! * returns foo: method returns a foo (e.g. string, boolean, or nothing).
+//! * omitted: method intentionally unsupported with no plans of adding support.
+//!
+//! If a method has UNTESTED then there is no integration test yet for it.
 //!
 //! <details>
 //! <summary> Methods from the == Blockchain == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getbestblockhash                   | done            |
-//! | getblock                           | done            |
-//! | getblockchaininfo                  | done            |
-//! | getblockcount                      | done            |
-//! | getblockfilter                     | done            |
-//! | getblockhash                       | done            |
-//! | getblockheader                     | done            |
-//! | getblockstats                      | done            |
-//! | getchaintips                       | done            |
-//! | getchaintxstats                    | done            |
-//! | getdifficulty                      | done            |
-//! | getmempoolancestors                | done (untested) |
-//! | getmempooldescendants              | done (untested) |
-//! | getmempoolentry                    | done            |
-//! | getmempoolinfo                     | done            |
-//! | getrawmempool                      | done            |
-//! | gettxout                           | done            |
-//! | gettxoutproof                      | done            |
-//! | gettxoutsetinfo                    | done            |
-//! | preciousblock                      | done            |
-//! | pruneblockchain                    | omitted         |
-//! | savemempool                        | omitted         |
-//! | scantxoutset                       | omitted         |
-//! | verifychain                        | omitted         |
-//! | verifytxoutproof                   | done            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getbestblockhash                   | version + model |                                        |
+//! | getblock                           | version + model | Includes additional 'verbose' type     |
+//! | getblockchaininfo                  | version + model |                                        |
+//! | getblockcount                      | version + model |                                        |
+//! | getblockfilter                     | version         |                                        |
+//! | getblockhash                       | version + model |                                        |
+//! | getblockheader                     | version + model | Includes additional 'verbose' type     |
+//! | getblockstats                      | version + model |                                        |
+//! | getchaintips                       | version + model |                                        |
+//! | getchaintxstats                    | version + model |                                        |
+//! | getdifficulty                      | version + model |                                        |
+//! | getmempoolancestors                | version + model | UNTESTED (incl. verbose type)          |
+//! | getmempooldescendants              | version + model | UNTESTED (incl. verbose type)          |
+//! | getmempoolentry                    | version + model |                                        |
+//! | getmempoolinfo                     | version + model |                                        |
+//! | getrawmempool                      | version + model | Includes additional 'verbose' type     |
+//! | gettxout                           | version + model |                                        |
+//! | gettxoutproof                      | returns string  |                                        |
+//! | gettxoutsetinfo                    | version + model |                                        |
+//! | preciousblock                      | returns nothing |                                        |
+//! | pruneblockchain                    | returns numeric |                                        |
+//! | savemempool                        | returns nothing |                                        |
+//! | scantxoutset                       | omitted         | API marked as experimental             |
+//! | verifychain                        | returns boolean |                                        |
+//! | verifytxoutproof                   | version + model |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Control == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getmemoryinfo                      | done            |
-//! | getrpcinfo                         | done            |
-//! | help                               | done            |
-//! | logging                            | done            |
-//! | stop                               | done            |
-//! | uptime                             | done            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getmemoryinfo                      | version         |                                        |
+//! | getrpcinfo                         | version + model |                                        |
+//! | help                               | returns string  |                                        |
+//! | logging                            | version         |                                        |
+//! | stop                               | returns string  |                                        |
+//! | uptime                             | returns numeric |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Generating == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | generateblock                      | todo            |
-//! | generatetoaddress                  | done            |
-//! | generatetodescriptor               | todo            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | generateblock                      | version + model | TODO                                   |
+//! | generatetoaddress                  | version + model |                                        |
+//! | generatetodescriptor               | version + model | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Mining == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getblocktemplate                   | done            |
-//! | getmininginfo                      | done            |
-//! | getnetworkhashps                   | done            |
-//! | prioritisetransaction              | done            |
-//! | submitblock                        | done (untested) |
-//! | submitheader                       | todo            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getblocktemplate                   | version + model |                                        |
+//! | getmininginfo                      | version         |                                        |
+//! | getnetworkhashps                   | returns boolean |                                        |
+//! | prioritisetransaction              | returns boolean |                                        |
+//! | submitblock                        | returns nothing |                                        |
+//! | submitheader                       | return nothing  | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Network == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | addnode                            | omitted         |
-//! | clearbanned                        | omitted         |
-//! | disconnectnode                     | omitted         |
-//! | getaddednodeinfo                   | done            |
-//! | getconnectioncount                 | omitted         |
-//! | getnettotals                       | done            |
-//! | getnetworkinfo                     | done            |
-//! | getnodeaddresses                   | todo            |
-//! | getpeerinfo                        | done            |
-//! | listbanned                         | omitted         |
-//! | ping                               | omitted         |
-//! | setban                             | omitted         |
-//! | setnetworkactive                   | omitted         |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | addnode                            | returns nothing |                                        |
+//! | clearbanned                        | returns nothing |                                        |
+//! | disconnectnode                     | returns nothing |                                        |
+//! | getaddednodeinfo                   | version         |                                        |
+//! | getconnectioncount                 | returns numeric |                                        |
+//! | getnettotals                       | version         |                                        |
+//! | getnetworkinfo                     | version + model |                                        |
+//! | getnodeaddresses                   | version         | TODO                                   |
+//! | getpeerinfo                        | version         |                                        |
+//! | listbanned                         | returns string  |                                        |
+//! | ping                               | returns nothing |                                        |
+//! | setban                             | returns nothing |                                        |
+//! | setnetworkactive                   | returns nothing |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Rawtransactions == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | analyzepsbt                        | done            |
-//! | combinepsbt                        | done            |
-//! | combinerawtransaction              | done            |
-//! | converttopsbt                      | done            |
-//! | createpsbt                         | done            |
-//! | createrawtransaction               | done            |
-//! | decodepsbt                         | done            |
-//! | decoderawtransaction               | done            |
-//! | decodescript                       | done            |
-//! | finalizepsbt                       | done (untested) |
-//! | fundrawtransaction                 | done            |
-//! | getrawtransaction                  | done            |
-//! | joinpsbts                          | done (untested) |
-//! | sendrawtransaction                 | done            |
-//! | signrawtransactionwithkey          | done            |
-//! | testmempoolaccept                  | done (untested) |
-//! | utxoupdatepsbt                     | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | analyzepsbt                        | version + model |                                        |
+//! | combinepsbt                        | version + model |                                        |
+//! | combinerawtransaction              | version + model |                                        |
+//! | converttopsbt                      | version + model |                                        |
+//! | createpsbt                         | version + model |                                        |
+//! | createrawtransaction               | version + model |                                        |
+//! | decodepsbt                         | version + model |                                        |
+//! | decoderawtransaction               | version + model |                                        |
+//! | decodescript                       | version + model |                                        |
+//! | finalizepsbt                       | version + model | UNTESTED                               |
+//! | fundrawtransaction                 | version + model |                                        |
+//! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
+//! | joinpsbts                          | version + model | UNTESTED                               |
+//! | sendrawtransaction                 | version + model |                                        |
+//! | signrawtransactionwithkey          | version + model |                                        |
+//! | testmempoolaccept                  | version + model | UNTESTED                               |
+//! | utxoupdatepsbt                     | version + model | UNTESTED                               |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Signer == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | enumeratesigners                   | todo            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | enumeratesigners                   | version + model | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Util == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | createmultisig                     | omitted         |
-//! | deriveaddresses                    | todo            |
-//! | estimatesmartfee                   | omitted         |
-//! | getdescriptorinfo                  | todo            |
-//! | getindexinfo                       | todo            |
-//! | signmessagewithprivkey             | omitted         |
-//! | validateaddress                    | omitted         |
-//! | verifymessage                      | omitted         |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | createmultisig                     | version + model | TODO                                   |
+//! | deriveaddresses                    | version + model | TODO                                   |
+//! | estimatesmartfee                   | returns nothing | TODO                                   |
+//! | getdescriptorinfo                  | version         | TODO                                   |
+//! | getindexinfo                       | version         | TODO                                   |
+//! | signmessagewithprivkey             | returns string  | TODO                                   |
+//! | validateaddress                    | version + model | TODO                                   |
+//! | verifymessage                      | returns boolean | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Wallet == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | abandontransaction                 | omitted         |
-//! | abortrescan                        | omitted         |
-//! | addmultisigaddress                 | done (untested) |
-//! | backupwallet                       | omitted         |
-//! | bumpfee                            | done            |
-//! | createwallet                       | done            |
-//! | dumpprivkey                        | done            |
-//! | dumpwallet                         | done            |
-//! | encryptwallet                      | omitted         |
-//! | getaddressesbylabel                | done            |
-//! | getaddressinfo                     | done (untested) |
-//! | getbalance                         | done            |
-//! | getbalances                        | done            |
-//! | getnewaddress                      | done            |
-//! | getrawchangeaddress                | done            |
-//! | getreceivedbyaddress               | done            |
-//! | getreceivedbylabel                 | todo            |
-//! | gettransaction                     | done            |
-//! | getunconfirmedbalance              | done (untested) |
-//! | getwalletinfo                      | done (untested) |
-//! | importaddress                      | omitted         |
-//! | importdescriptors                  | todo            |
-//! | importmulti                        | omitted         |
-//! | importprivkey                      | omitted         |
-//! | importprunedfunds                  | omitted         |
-//! | importpubkey                       | omitted         |
-//! | importwallet                       | omitted         |
-//! | keypoolrefill                      | omitted         |
-//! | listaddressgroupings               | done (untested) |
-//! | listdescriptors                    | todo            |
-//! | listlabels                         | done (untested) |
-//! | listlockunspent                    | done (untested) |
-//! | psbtbumpfee                        | todo            |
-//! | listreceivedbyaddress              | done (untested) |
-//! | listreceivedbylabel                | todo            |
-//! | listsinceblock                     | done (untested) |
-//! | listtransactions                   | done (untested) |
-//! | listunspent                        | done (untested) |
-//! | listwalletdir                      | todo            |
-//! | listwallets                        | done (untested) |
-//! | loadwallet                         | done            |
-//! | lockunspent                        | omitted         |
-//! | removeprunedfunds                  | omitted         |
-//! | rescanblockchain                   | done (untested) |
-//! | send                               | todo            |
-//! | sendmany                           | done (untested) |
-//! | sendtoaddress                      | done            |
-//! | sethdseed                          | omitted         |
-//! | setlabel                           | todo            |
-//! | settxfee                           | omitted         |
-//! | setwalletflag                      | todo            |
-//! | signmessage                        | done (untested) |
-//! | signrawtransactionwithwallet       | done (untested) |
-//! | unloadwallet                       | done            |
-//! | upgradewallet                      | todo            |
-//! | walletcreatefundedpsbt             | done (untested) |
-//! | walletdisplayaddress               | todo            |
-//! | walletlock                         | omitted         |
-//! | walletpassphrase                   | omitted         |
-//! | walletpassphrasechange             | omitted         |
-//! | walletprocesspsbt                  | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | abandontransaction                 | returns nothing |                                        |
+//! | abortrescan                        | returns nothing |                                        |
+//! | addmultisigaddress                 | version + model | UNTESTED                               |
+//! | backupwallet                       | returns nothing |                                        |
+//! | bumpfee                            | version + model |                                        |
+//! | createwallet                       | version + model |                                        |
+//! | dumpprivkey                        | version + model |                                        |
+//! | dumpwallet                         | version + model |                                        |
+//! | encryptwallet                      | returns nothing |                                        |
+//! | getaddressesbylabel                | version + model |                                        |
+//! | getaddressinfo                     | version + model | UNTESTED                               |
+//! | getbalance                         | version + model |                                        |
+//! | getbalances                        | version + model |                                        |
+//! | getnewaddress                      | version + model |                                        |
+//! | getrawchangeaddress                | version + model |                                        |
+//! | getreceivedbyaddress               | version + model | TODO                                   |
+//! | getreceivedbylabel                 | version + model | TODO                                   |
+//! | gettransaction                     | version + model |                                        |
+//! | getunconfirmedbalance              | version + model | UNTESTED                               |
+//! | getwalletinfo                      | version + model | UNTESTED                               |
+//! | importaddress                      | returns nothing |                                        |
+//! | importdescriptors                  | version         | TODO                                   |
+//! | importmulti                        | returns nothing |                                        |
+//! | importprivkey                      | returns nothing |                                        |
+//! | importprunedfunds                  | returns nothing |                                        |
+//! | importpubkey                       | returns nothing |                                        |
+//! | importwallet                       | returns nothing |                                        |
+//! | keypoolrefill                      | returns nothing |                                        |
+//! | listaddressgroupings               | version + model | UNTESTED                               |
+//! | listdescriptors                    | version + model | TODO                                   |
+//! | listlabels                         | version + model | UNTESTED                               |
+//! | listlockunspent                    | version + model | UNTESTED                               |
+//! | psbtbumpfee                        | version + model | TODO                                   |
+//! | listreceivedbyaddress              | version + model | UNTESTED                               |
+//! | listreceivedbylabel                | version + model | TODO                                   |
+//! | listsinceblock                     | version + model | UNTESTED                               |
+//! | listtransactions                   | version + model | UNTESTED                               |
+//! | listunspent                        | version + model | UNTESTED                               |
+//! | listwalletdir                      | version         | TODO                                   |
+//! | listwallets                        | version + model | UNTESTED                               |
+//! | loadwallet                         | version + model |                                        |
+//! | lockunspent                        | returns boolean |                                        |
+//! | removeprunedfunds                  | returns nothing |                                        |
+//! | rescanblockchain                   | version + model | UNTESTED                               |
+//! | send                               | version + model | TODO                                   |
+//! | sendmany                           | version + model | UNTESTED                               |
+//! | sendtoaddress                      | version + model |                                        |
+//! | sethdseed                          | returns nothing |                                        |
+//! | setlabel                           | returns nothing |                                        |
+//! | settxfee                           | returns boolean |                                        |
+//! | setwalletflag                      | version         | TODO                                   |
+//! | signmessage                        | version + model | UNTESTED                               |
+//! | signrawtransactionwithwallet       | version + model |                                        |
+//! | unloadwallet                       | returns nothing |                                        |
+//! | upgradewallet                      | version         | TODO                                   |
+//! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
+//! | walletdisplayaddress               | version + model | TODO                                   |
+//! | walletlock                         | returns nothing |                                        |
+//! | walletpassphrase                   | returns nothing |                                        |
+//! | walletpassphrasechange             | returns nothing |                                        |
+//! | walletprocesspsbt                  | version + model | UNTESTED                               |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Zmq == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getzmqnotifications                | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getzmqnotifications                | version         | UNTESTED                               |
 //!
 //! </details>
 

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -9,220 +9,229 @@
 //!
 //! ### Method name and implementation status
 //!
-//! Every JSON-RPC method supported by this version of Bitcoin Core is listed below along with its
-//! current implementation status.
+//! Every JSON-RPC method supported by this version of Bitcoin Core is listed below along with the
+//! type it returns and any implementation notes.
+//!
+//! Key to 'Returns' column:
+//!
+//! * version: method returns a version specific type but has no model type.
+//! * version + model: method returns a version specific type and can be converted to a model type.
+//! * returns foo: method returns a foo (e.g. string, boolean, or nothing).
+//! * omitted: method intentionally unsupported with no plans of adding support.
+//!
+//! If a method has UNTESTED then there is no integration test yet for it.
 //!
 //! <details>
 //! <summary> Methods from the == Blockchain == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getbestblockhash                   | done            |
-//! | getblock                           | done            |
-//! | getblockchaininfo                  | done            |
-//! | getblockcount                      | done            |
-//! | getblockfilter                     | done            |
-//! | getblockfrompeer                   | todo            |
-//! | getblockhash                       | done            |
-//! | getblockheader                     | done            |
-//! | getblockstats                      | done            |
-//! | getchaintips                       | done            |
-//! | getchaintxstats                    | done            |
-//! | getdeploymentinfo                  | todo            |
-//! | getdifficulty                      | done            |
-//! | getmempoolancestors                | done (untested) |
-//! | getmempooldescendants              | done (untested) |
-//! | getmempoolentry                    | done            |
-//! | getmempoolinfo                     | done            |
-//! | getrawmempool                      | done            |
-//! | gettxout                           | done            |
-//! | gettxoutproof                      | done            |
-//! | gettxoutsetinfo                    | done            |
-//! | preciousblock                      | done            |
-//! | pruneblockchain                    | omitted         |
-//! | savemempool                        | omitted         |
-//! | scantxoutset                       | omitted         |
-//! | verifychain                        | omitted         |
-//! | verifytxoutproof                   | done            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getbestblockhash                   | version + model |                                        |
+//! | getblock                           | version + model | Includes additional 'verbose' type     |
+//! | getblockchaininfo                  | version + model |                                        |
+//! | getblockcount                      | version + model |                                        |
+//! | getblockfilter                     | version         |                                        |
+//! | getblockfrompeer                   | version + model | TODO                                   |
+//! | getblockhash                       | version + model |                                        |
+//! | getblockheader                     | version + model | Includes additional 'verbose' type     |
+//! | getblockstats                      | version + model |                                        |
+//! | getchaintips                       | version + model |                                        |
+//! | getchaintxstats                    | version + model |                                        |
+//! | getdeploymentinfo                  | version + model | TODO                                   |
+//! | getdifficulty                      | version + model |                                        |
+//! | getmempoolancestors                | version + model | UNTESTED (incl. verbose type)          |
+//! | getmempooldescendants              | version + model | UNTESTED (incl. verbose type)          |
+//! | getmempoolentry                    | version + model |                                        |
+//! | getmempoolinfo                     | version + model |                                        |
+//! | getrawmempool                      | version + model | Includes additional 'verbose' type     |
+//! | gettxout                           | version + model |                                        |
+//! | gettxoutproof                      | returns string  |                                        |
+//! | gettxoutsetinfo                    | version + model |                                        |
+//! | preciousblock                      | returns nothing |                                        |
+//! | pruneblockchain                    | returns numeric |                                        |
+//! | savemempool                        | returns nothing |                                        |
+//! | scantxoutset                       | omitted         | API marked as experimental             |
+//! | verifychain                        | returns boolean |                                        |
+//! | verifytxoutproof                   | version + model |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Control == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getmemoryinfo                      | done            |
-//! | getrpcinfo                         | done            |
-//! | help                               | done            |
-//! | logging                            | done            |
-//! | stop                               | done            |
-//! | uptime                             | done            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getmemoryinfo                      | version         |                                        |
+//! | getrpcinfo                         | version + model |                                        |
+//! | help                               | returns string  |                                        |
+//! | logging                            | version         |                                        |
+//! | stop                               | returns string  |                                        |
+//! | uptime                             | returns numeric |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Mining == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getblocktemplate                   | done            |
-//! | getmininginfo                      | done            |
-//! | getnetworkhashps                   | done            |
-//! | prioritisetransaction              | done            |
-//! | submitblock                        | done (untested) |
-//! | submitheader                       | todo            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getblocktemplate                   | version + model |                                        |
+//! | getmininginfo                      | version         |                                        |
+//! | getnetworkhashps                   | returns boolean |                                        |
+//! | prioritisetransaction              | returns boolean |                                        |
+//! | submitblock                        | returns nothing |                                        |
+//! | submitheader                       | return nothing  | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Network == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | addnode                            | omitted         |
-//! | clearbanned                        | omitted         |
-//! | disconnectnode                     | omitted         |
-//! | getaddednodeinfo                   | done            |
-//! | getconnectioncount                 | omitted         |
-//! | getnettotals                       | done            |
-//! | getnetworkinfo                     | done            |
-//! | getnodeaddresses                   | todo            |
-//! | getpeerinfo                        | done            |
-//! | listbanned                         | omitted         |
-//! | ping                               | omitted         |
-//! | setban                             | omitted         |
-//! | setnetworkactive                   | omitted         |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | addnode                            | returns nothing |                                        |
+//! | clearbanned                        | returns nothing |                                        |
+//! | disconnectnode                     | returns nothing |                                        |
+//! | getaddednodeinfo                   | version         |                                        |
+//! | getconnectioncount                 | returns numeric |                                        |
+//! | getnettotals                       | version         |                                        |
+//! | getnetworkinfo                     | version + model |                                        |
+//! | getnodeaddresses                   | version         | TODO                                   |
+//! | getpeerinfo                        | version         |                                        |
+//! | listbanned                         | returns string  |                                        |
+//! | ping                               | returns nothing |                                        |
+//! | setban                             | returns nothing |                                        |
+//! | setnetworkactive                   | returns nothing |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Rawtransactions == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | analyzepsbt                        | todo            |
-//! | combinepsbt                        | done            |
-//! | combinerawtransaction              | done            |
-//! | converttopsbt                      | done            |
-//! | createpsbt                         | done            |
-//! | createrawtransaction               | done            |
-//! | decodepsbt                         | done            |
-//! | decoderawtransaction               | done            |
-//! | decodescript                       | done            |
-//! | finalizepsbt                       | done (untested) |
-//! | fundrawtransaction                 | done (untested) |
-//! | getrawtransaction                  | done            |
-//! | joinpsbts                          | todo            |
-//! | sendrawtransaction                 | done            |
-//! | signrawtransactionwithkey          | done            |
-//! | testmempoolaccept                  | done (untested) |
-//! | utxoupdatepsbt                     | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | analyzepsbt                        | version + model |                                        |
+//! | combinepsbt                        | version + model |                                        |
+//! | combinerawtransaction              | version + model |                                        |
+//! | converttopsbt                      | version + model |                                        |
+//! | createpsbt                         | version + model |                                        |
+//! | createrawtransaction               | version + model |                                        |
+//! | decodepsbt                         | version + model |                                        |
+//! | decoderawtransaction               | version + model |                                        |
+//! | decodescript                       | version + model |                                        |
+//! | finalizepsbt                       | version + model | UNTESTED                               |
+//! | fundrawtransaction                 | version + model |                                        |
+//! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
+//! | joinpsbts                          | version + model | UNTESTED                               |
+//! | sendrawtransaction                 | version + model |                                        |
+//! | signrawtransactionwithkey          | version + model |                                        |
+//! | testmempoolaccept                  | version + model | UNTESTED                               |
+//! | utxoupdatepsbt                     | version + model | UNTESTED                               |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Signer == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | enumeratesigners                   | todo            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | enumeratesigners                   | version + model | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Util == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | createmultisig                     | omitted         |
-//! | deriveaddresses                    | todo            |
-//! | estimatesmartfee                   | omitted         |
-//! | getdescriptorinfo                  | todo            |
-//! | getindexinfo                       | todo            |
-//! | signmessagewithprivkey             | omitted         |
-//! | validateaddress                    | omitted         |
-//! | verifymessage                      | omitted         |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | createmultisig                     | version + model | TODO                                   |
+//! | deriveaddresses                    | version + model | TODO                                   |
+//! | estimatesmartfee                   | returns nothing | TODO                                   |
+//! | getdescriptorinfo                  | version         | TODO                                   |
+//! | getindexinfo                       | version         | TODO                                   |
+//! | signmessagewithprivkey             | returns string  | TODO                                   |
+//! | validateaddress                    | version + model | TODO                                   |
+//! | verifymessage                      | returns boolean | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Wallet == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | abandontransaction                 | omitted         |
-//! | abortrescan                        | omitted         |
-//! | addmultisigaddress                 | done (untested) |
-//! | backupwallet                       | omitted         |
-//! | bumpfee                            | done            |
-//! | createwallet                       | done            |
-//! | dumpprivkey                        | done            |
-//! | dumpwallet                         | done            |
-//! | encryptwallet                      | omitted         |
-//! | getaddressesbylabel                | done            |
-//! | getaddressinfo                     | done (untested) |
-//! | getbalance                         | done            |
-//! | getbalances                        | done            |
-//! | getnewaddress                      | done            |
-//! | getrawchangeaddress                | done            |
-//! | getreceivedbyaddress               | done            |
-//! | getreceivedbylabel                 | todo            |
-//! | gettransaction                     | done            |
-//! | getunconfirmedbalance              | done (untested) |
-//! | getwalletinfo                      | done (untested) |
-//! | importaddress                      | omitted         |
-//! | importdescriptors                  | todo            |
-//! | importmulti                        | omitted         |
-//! | importprivkey                      | omitted         |
-//! | importprunedfunds                  | omitted         |
-//! | importpubkey                       | omitted         |
-//! | importwallet                       | omitted         |
-//! | keypoolrefill                      | omitted         |
-//! | listaddressgroupings               | done (untested) |
-//! | listdescriptors                    | todo            |
-//! | listlabels                         | done (untested) |
-//! | listlockunspent                    | done (untested) |
-//! | newkeypool                         | todo            |
-//! | psbtbumpfee                        | todo            |
-//! | listreceivedbyaddress              | done (untested) |
-//! | listreceivedbylabel                | todo            |
-//! | listsinceblock                     | done (untested) |
-//! | listtransactions                   | done (untested) |
-//! | listunspent                        | done (untested) |
-//! | listwalletdir                      | todo            |
-//! | listwallets                        | done (untested) |
-//! | loadwallet                         | done            |
-//! | lockunspent                        | omitted         |
-//! | removeprunedfunds                  | omitted         |
-//! | rescanblockchain                   | done (untested) |
-//! | restorewallet                      | todo            |
-//! | send                               | todo            |
-//! | sendmany                           | done (untested) |
-//! | sendtoaddress                      | done            |
-//! | sethdseed                          | omitted         |
-//! | setlabel                           | todo            |
-//! | settxfee                           | omitted         |
-//! | setwalletflag                      | todo            |
-//! | signmessage                        | done (untested) |
-//! | signrawtransactionwithwallet       | done            |
-//! | unloadwallet                       | done            |
-//! | upgradewallet                      | todo            |
-//! | walletcreatefundedpsbt             | done (untested) |
-//! | walletdisplayaddress               | todo            |
-//! | walletlock                         | omitted         |
-//! | walletpassphrase                   | omitted         |
-//! | walletpassphrasechange             | omitted         |
-//! | walletprocesspsbt                  | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | abandontransaction                 | returns nothing |                                        |
+//! | abortrescan                        | returns nothing |                                        |
+//! | addmultisigaddress                 | version + model | UNTESTED                               |
+//! | backupwallet                       | returns nothing |                                        |
+//! | bumpfee                            | version + model |                                        |
+//! | createwallet                       | version + model |                                        |
+//! | dumpprivkey                        | version + model |                                        |
+//! | dumpwallet                         | version + model |                                        |
+//! | encryptwallet                      | returns nothing |                                        |
+//! | getaddressesbylabel                | version + model |                                        |
+//! | getaddressinfo                     | version + model | UNTESTED                               |
+//! | getbalance                         | version + model |                                        |
+//! | getbalances                        | version + model |                                        |
+//! | getnewaddress                      | version + model |                                        |
+//! | getrawchangeaddress                | version + model |                                        |
+//! | getreceivedbyaddress               | version + model | TODO                                   |
+//! | getreceivedbylabel                 | version + model | TODO                                   |
+//! | gettransaction                     | version + model |                                        |
+//! | getunconfirmedbalance              | version + model | UNTESTED                               |
+//! | getwalletinfo                      | version + model | UNTESTED                               |
+//! | importaddress                      | returns nothing |                                        |
+//! | importdescriptors                  | version         | TODO                                   |
+//! | importmulti                        | returns nothing |                                        |
+//! | importprivkey                      | returns nothing |                                        |
+//! | importprunedfunds                  | returns nothing |                                        |
+//! | importpubkey                       | returns nothing |                                        |
+//! | importwallet                       | returns nothing |                                        |
+//! | keypoolrefill                      | returns nothing |                                        |
+//! | listaddressgroupings               | version + model | UNTESTED                               |
+//! | listdescriptors                    | version + model | TODO                                   |
+//! | listlabels                         | version + model | UNTESTED                               |
+//! | listlockunspent                    | version + model | UNTESTED                               |
+//! | newkeypool                         | version + model | TODO                                   |
+//! | psbtbumpfee                        | version + model | TODO                                   |
+//! | listreceivedbyaddress              | version + model | UNTESTED                               |
+//! | listreceivedbylabel                | version + model | TODO                                   |
+//! | listsinceblock                     | version + model | UNTESTED                               |
+//! | listtransactions                   | version + model | UNTESTED                               |
+//! | listunspent                        | version + model | UNTESTED                               |
+//! | listwalletdir                      | version         | TODO                                   |
+//! | listwallets                        | version + model | UNTESTED                               |
+//! | loadwallet                         | version + model |                                        |
+//! | lockunspent                        | returns boolean |                                        |
+//! | removeprunedfunds                  | returns nothing |                                        |
+//! | rescanblockchain                   | version + model | UNTESTED                               |
+//! | restorewallet                      | version + model | TODO                                   |
+//! | send                               | version + model | TODO                                   |
+//! | sendmany                           | version + model | UNTESTED                               |
+//! | sendtoaddress                      | version + model |                                        |
+//! | sethdseed                          | returns nothing |                                        |
+//! | setlabel                           | returns nothing |                                        |
+//! | settxfee                           | returns boolean |                                        |
+//! | setwalletflag                      | version         | TODO                                   |
+//! | signmessage                        | version + model | UNTESTED                               |
+//! | signrawtransactionwithwallet       | version + model |                                        |
+//! | unloadwallet                       | returns nothing |                                        |
+//! | upgradewallet                      | version         | TODO                                   |
+//! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
+//! | walletdisplayaddress               | version + model | TODO                                   |
+//! | walletlock                         | returns nothing |                                        |
+//! | walletpassphrase                   | returns nothing |                                        |
+//! | walletpassphrasechange             | returns nothing |                                        |
+//! | walletprocesspsbt                  | version + model | UNTESTED                               |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Zmq == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getzmqnotifications                | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getzmqnotifications                | version         | UNTESTED                               |
 //!
 //! </details>
 

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -9,224 +9,233 @@
 //!
 //! ### Method name and implementation status
 //!
-//! Every JSON-RPC method supported by this version of Bitcoin Core is listed below along with its
-//! current implementation status.
+//! Every JSON-RPC method supported by this version of Bitcoin Core is listed below along with the
+//! type it returns and any implementation notes.
+//!
+//! Key to 'Returns' column:
+//!
+//! * version: method returns a version specific type but has no model type.
+//! * version + model: method returns a version specific type and can be converted to a model type.
+//! * returns foo: method returns a foo (e.g. string, boolean, or nothing).
+//! * omitted: method intentionally unsupported with no plans of adding support.
+//!
+//! If a method has UNTESTED then there is no integration test yet for it.
 //!
 //! <details>
 //! <summary> Methods from the == Blockchain == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getbestblockhash                   | done            |
-//! | getblock                           | done            |
-//! | getblockchaininfo                  | done            |
-//! | getblockcount                      | done            |
-//! | getblockfilter                     | done            |
-//! | getblockfrompeer                   | todo            |
-//! | getblockhash                       | done            |
-//! | getblockheader                     | done            |
-//! | getblockstats                      | done            |
-//! | getchaintips                       | done            |
-//! | getchaintxstats                    | done            |
-//! | getdeploymentinfo                  | todo            |
-//! | getdifficulty                      | done            |
-//! | getmempoolancestors                | done (untested) |
-//! | getmempooldescendants              | done (untested) |
-//! | getmempoolentry                    | done            |
-//! | getmempoolinfo                     | done            |
-//! | getrawmempool                      | done            |
-//! | gettxout                           | done            |
-//! | gettxoutproof                      | done            |
-//! | gettxoutsetinfo                    | done            |
-//! | gettxspendingprevout               | todo            |
-//! | preciousblock                      | done            |
-//! | pruneblockchain                    | omitted         |
-//! | savemempool                        | omitted         |
-//! | scantxoutset                       | omitted         |
-//! | verifychain                        | omitted         |
-//! | verifytxoutproof                   | done            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getbestblockhash                   | version + model |                                        |
+//! | getblock                           | version + model | Includes additional 'verbose' type     |
+//! | getblockchaininfo                  | version + model |                                        |
+//! | getblockcount                      | version + model |                                        |
+//! | getblockfilter                     | version         |                                        |
+//! | getblockfrompeer                   | version + model | TODO                                   |
+//! | getblockhash                       | version + model |                                        |
+//! | getblockheader                     | version + model | Includes additional 'verbose' type     |
+//! | getblockstats                      | version + model |                                        |
+//! | getchaintips                       | version + model |                                        |
+//! | getchaintxstats                    | version + model |                                        |
+//! | getdeploymentinfo                  | version + model | TODO                                   |
+//! | getdifficulty                      | version + model |                                        |
+//! | getmempoolancestors                | version + model | UNTESTED (incl. verbose type)          |
+//! | getmempooldescendants              | version + model | UNTESTED (incl. verbose type)          |
+//! | getmempoolentry                    | version + model |                                        |
+//! | getmempoolinfo                     | version + model |                                        |
+//! | getrawmempool                      | version + model | Includes additional 'verbose' type     |
+//! | gettxout                           | version + model |                                        |
+//! | gettxoutproof                      | returns string  |                                        |
+//! | gettxoutsetinfo                    | version + model |                                        |
+//! | gettxspendingprevout               | version + model | TODO                                   |
+//! | preciousblock                      | returns nothing |                                        |
+//! | pruneblockchain                    | returns numeric |                                        |
+//! | savemempool                        | returns nothing |                                        |
+//! | scantxoutset                       | omitted         | API marked as experimental             |
+//! | verifychain                        | returns boolean |                                        |
+//! | verifytxoutproof                   | version + model |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Control == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getmemoryinfo                      | done            |
-//! | getrpcinfo                         | done            |
-//! | help                               | done            |
-//! | logging                            | done            |
-//! | stop                               | done            |
-//! | uptime                             | done            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getmemoryinfo                      | version         |                                        |
+//! | getrpcinfo                         | version + model |                                        |
+//! | help                               | returns string  |                                        |
+//! | logging                            | version         |                                        |
+//! | stop                               | returns string  |                                        |
+//! | uptime                             | returns numeric |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Mining == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getblocktemplate                   | done            |
-//! | getmininginfo                      | done            |
-//! | getnetworkhashps                   | done            |
-//! | prioritisetransaction              | done            |
-//! | submitblock                        | done (untested) |
-//! | submitheader                       | todo            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getblocktemplate                   | version + model |                                        |
+//! | getmininginfo                      | version         |                                        |
+//! | getnetworkhashps                   | returns boolean |                                        |
+//! | prioritisetransaction              | returns boolean |                                        |
+//! | submitblock                        | returns nothing |                                        |
+//! | submitheader                       | return nothing  | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Network == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | addnode                            | omitted         |
-//! | clearbanned                        | omitted         |
-//! | disconnectnode                     | omitted         |
-//! | getaddednodeinfo                   | done            |
-//! | getconnectioncount                 | omitted         |
-//! | getnettotals                       | done            |
-//! | getnetworkinfo                     | done            |
-//! | getnodeaddresses                   | todo            |
-//! | getpeerinfo                        | done            |
-//! | listbanned                         | omitted         |
-//! | ping                               | omitted         |
-//! | setban                             | omitted         |
-//! | setnetworkactive                   | omitted         |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | addnode                            | returns nothing |                                        |
+//! | clearbanned                        | returns nothing |                                        |
+//! | disconnectnode                     | returns nothing |                                        |
+//! | getaddednodeinfo                   | version         |                                        |
+//! | getconnectioncount                 | returns numeric |                                        |
+//! | getnettotals                       | version         |                                        |
+//! | getnetworkinfo                     | version + model |                                        |
+//! | getnodeaddresses                   | version         | TODO                                   |
+//! | getpeerinfo                        | version         |                                        |
+//! | listbanned                         | returns string  |                                        |
+//! | ping                               | returns nothing |                                        |
+//! | setban                             | returns nothing |                                        |
+//! | setnetworkactive                   | returns nothing |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Rawtransactions == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | analyzepsbt                        | done            |
-//! | combinepsbt                        | done            |
-//! | combinerawtransaction              | done            |
-//! | converttopsbt                      | done            |
-//! | createpsbt                         | done            |
-//! | createrawtransaction               | done            |
-//! | decodepsbt                         | done            |
-//! | decoderawtransaction               | done            |
-//! | decodescript                       | done            |
-//! | finalizepsbt                       | done (untested) |
-//! | fundrawtransaction                 | done            |
-//! | getrawtransaction                  | done            |
-//! | joinpsbts                          | done (untested) |
-//! | sendrawtransaction                 | done            |
-//! | signrawtransactionwithkey          | done            |
-//! | testmempoolaccept                  | done (untested) |
-//! | utxoupdatepsbt                     | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | analyzepsbt                        | version + model |                                        |
+//! | combinepsbt                        | version + model |                                        |
+//! | combinerawtransaction              | version + model |                                        |
+//! | converttopsbt                      | version + model |                                        |
+//! | createpsbt                         | version + model |                                        |
+//! | createrawtransaction               | version + model |                                        |
+//! | decodepsbt                         | version + model |                                        |
+//! | decoderawtransaction               | version + model |                                        |
+//! | decodescript                       | version + model |                                        |
+//! | finalizepsbt                       | version + model | UNTESTED                               |
+//! | fundrawtransaction                 | version + model |                                        |
+//! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
+//! | joinpsbts                          | version + model | UNTESTED                               |
+//! | sendrawtransaction                 | version + model |                                        |
+//! | signrawtransactionwithkey          | version + model |                                        |
+//! | testmempoolaccept                  | version + model | UNTESTED                               |
+//! | utxoupdatepsbt                     | version + model | UNTESTED                               |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Signer == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | enumeratesigners                   | todo            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | enumeratesigners                   | version + model | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Util == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | createmultisig                     | omitted         |
-//! | deriveaddresses                    | todo            |
-//! | estimatesmartfee                   | omitted         |
-//! | getdescriptorinfo                  | todo            |
-//! | getindexinfo                       | todo            |
-//! | signmessagewithprivkey             | omitted         |
-//! | validateaddress                    | omitted         |
-//! | verifymessage                      | omitted         |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | createmultisig                     | version + model | TODO                                   |
+//! | deriveaddresses                    | version + model | TODO                                   |
+//! | estimatesmartfee                   | returns nothing | TODO                                   |
+//! | getdescriptorinfo                  | version         | TODO                                   |
+//! | getindexinfo                       | version         | TODO                                   |
+//! | signmessagewithprivkey             | returns string  | TODO                                   |
+//! | validateaddress                    | version + model | TODO                                   |
+//! | verifymessage                      | returns boolean | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Wallet == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | abandontransaction                 | omitted         |
-//! | abortrescan                        | omitted         |
-//! | addmultisigaddress                 | done (untested) |
-//! | backupwallet                       | omitted         |
-//! | bumpfee                            | done            |
-//! | createwallet                       | done            |
-//! | dumpprivkey                        | done            |
-//! | dumpwallet                         | done            |
-//! | encryptwallet                      | omitted         |
-//! | getaddressesbylabel                | done            |
-//! | getaddressinfo                     | done (untested) |
-//! | getbalance                         | done            |
-//! | getbalances                        | done            |
-//! | getnewaddress                      | done            |
-//! | getrawchangeaddress                | done            |
-//! | getreceivedbyaddress               | done            |
-//! | getreceivedbylabel                 | todo            |
-//! | gettransaction                     | done            |
-//! | getunconfirmedbalance              | done (untested) |
-//! | getwalletinfo                      | done (untested) |
-//! | importaddress                      | omitted         |
-//! | importdescriptors                  | todo            |
-//! | importmulti                        | omitted         |
-//! | importprivkey                      | omitted         |
-//! | importprunedfunds                  | omitted         |
-//! | importpubkey                       | omitted         |
-//! | importwallet                       | omitted         |
-//! | keypoolrefill                      | omitted         |
-//! | listaddressgroupings               | done (untested) |
-//! | listdescriptors                    | todo            |
-//! | listlabels                         | done (untested) |
-//! | listlockunspent                    | done (untested) |
-//! | migratewallet                      | todo            |
-//! | newkeypool                         | todo            |
-//! | psbtbumpfee                        | todo            |
-//! | listreceivedbyaddress              | done (untested) |
-//! | listreceivedbylabel                | todo            |
-//! | listsinceblock                     | done (untested) |
-//! | listtransactions                   | done (untested) |
-//! | listunspent                        | done (untested) |
-//! | listwalletdir                      | todo            |
-//! | listwallets                        | done (untested) |
-//! | loadwallet                         | done            |
-//! | lockunspent                        | omitted         |
-//! | removeprunedfunds                  | omitted         |
-//! | rescanblockchain                   | done (untested) |
-//! | restorewallet                      | todo            |
-//! | send                               | todo            |
-//! | sendall                            | todo            |
-//! | sendmany                           | done (untested) |
-//! | sendtoaddress                      | done            |
-//! | sethdseed                          | omitted         |
-//! | setlabel                           | todo            |
-//! | settxfee                           | omitted         |
-//! | setwalletflag                      | todo            |
-//! | signmessage                        | done (untested) |
-//! | signrawtransactionwithwallet       | done (untested) |
-//! | simulaterawtransaction             | todo            |
-//! | unloadwallet                       | done            |
-//! | upgradewallet                      | todo            |
-//! | walletcreatefundedpsbt             | done (untested) |
-//! | walletdisplayaddress               | todo            |
-//! | walletlock                         | omitted         |
-//! | walletpassphrase                   | omitted         |
-//! | walletpassphrasechange             | omitted         |
-//! | walletprocesspsbt                  | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | abandontransaction                 | returns nothing |                                        |
+//! | abortrescan                        | returns nothing |                                        |
+//! | addmultisigaddress                 | version + model | UNTESTED                               |
+//! | backupwallet                       | returns nothing |                                        |
+//! | bumpfee                            | version + model |                                        |
+//! | createwallet                       | version + model |                                        |
+//! | dumpprivkey                        | version + model |                                        |
+//! | dumpwallet                         | version + model |                                        |
+//! | encryptwallet                      | returns nothing |                                        |
+//! | getaddressesbylabel                | version + model |                                        |
+//! | getaddressinfo                     | version + model | UNTESTED                               |
+//! | getbalance                         | version + model |                                        |
+//! | getbalances                        | version + model |                                        |
+//! | getnewaddress                      | version + model |                                        |
+//! | getrawchangeaddress                | version + model |                                        |
+//! | getreceivedbyaddress               | version + model | TODO                                   |
+//! | getreceivedbylabel                 | version + model | TODO                                   |
+//! | gettransaction                     | version + model |                                        |
+//! | getunconfirmedbalance              | version + model | UNTESTED                               |
+//! | getwalletinfo                      | version + model | UNTESTED                               |
+//! | importaddress                      | returns nothing |                                        |
+//! | importdescriptors                  | version         | TODO                                   |
+//! | importmulti                        | returns nothing |                                        |
+//! | importprivkey                      | returns nothing |                                        |
+//! | importprunedfunds                  | returns nothing |                                        |
+//! | importpubkey                       | returns nothing |                                        |
+//! | importwallet                       | returns nothing |                                        |
+//! | keypoolrefill                      | returns nothing |                                        |
+//! | listaddressgroupings               | version + model | UNTESTED                               |
+//! | listdescriptors                    | version + model | TODO                                   |
+//! | listlabels                         | version + model | UNTESTED                               |
+//! | listlockunspent                    | version + model | UNTESTED                               |
+//! | migratewallet                      | version + model | TODO                                   |
+//! | newkeypool                         | version + model | TODO                                   |
+//! | psbtbumpfee                        | version + model | TODO                                   |
+//! | listreceivedbyaddress              | version + model | UNTESTED                               |
+//! | listreceivedbylabel                | version + model | TODO                                   |
+//! | listsinceblock                     | version + model | UNTESTED                               |
+//! | listtransactions                   | version + model | UNTESTED                               |
+//! | listunspent                        | version + model | UNTESTED                               |
+//! | listwalletdir                      | version         | TODO                                   |
+//! | listwallets                        | version + model | UNTESTED                               |
+//! | loadwallet                         | version + model |                                        |
+//! | lockunspent                        | returns boolean |                                        |
+//! | removeprunedfunds                  | returns nothing |                                        |
+//! | rescanblockchain                   | version + model | UNTESTED                               |
+//! | restorewallet                      | version + model | TODO                                   |
+//! | send                               | version + model | TODO                                   |
+//! | sendall                            | version + model | TODO                                   |
+//! | sendmany                           | version + model | UNTESTED                               |
+//! | sendtoaddress                      | version + model |                                        |
+//! | sethdseed                          | returns nothing |                                        |
+//! | setlabel                           | returns nothing |                                        |
+//! | settxfee                           | returns boolean |                                        |
+//! | setwalletflag                      | version         | TODO                                   |
+//! | signmessage                        | version + model | UNTESTED                               |
+//! | signrawtransactionwithwallet       | version + model |                                        |
+//! | simulaterawtransaction             | version + model | TODO                                   |
+//! | unloadwallet                       | returns nothing |                                        |
+//! | upgradewallet                      | version         | TODO                                   |
+//! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
+//! | walletdisplayaddress               | version + model | TODO                                   |
+//! | walletlock                         | returns nothing |                                        |
+//! | walletpassphrase                   | returns nothing |                                        |
+//! | walletpassphrasechange             | returns nothing |                                        |
+//! | walletprocesspsbt                  | version + model | UNTESTED                               |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Zmq == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getzmqnotifications                | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getzmqnotifications                | version         | UNTESTED                               |
 //!
 //! </details>
 

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -9,225 +9,234 @@
 //!
 //! ### Method name and implementation status
 //!
-//! Every JSON-RPC method supported by this version of Bitcoin Core is listed below along with its
-//! current implementation status.
+//! Every JSON-RPC method supported by this version of Bitcoin Core is listed below along with the
+//! type it returns and any implementation notes.
+//!
+//! Key to 'Returns' column:
+//!
+//! * version: method returns a version specific type but has no model type.
+//! * version + model: method returns a version specific type and can be converted to a model type.
+//! * returns foo: method returns a foo (e.g. string, boolean, or nothing).
+//! * omitted: method intentionally unsupported with no plans of adding support.
+//!
+//! If a method has UNTESTED then there is no integration test yet for it.
 //!
 //! <details>
 //! <summary> Methods from the == Blockchain == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getbestblockhash                   | done            |
-//! | getblock                           | done            |
-//! | getblockchaininfo                  | done            |
-//! | getblockcount                      | done            |
-//! | getblockfilter                     | done            |
-//! | getblockfrompeer                   | todo            |
-//! | getblockhash                       | done            |
-//! | getblockheader                     | done            |
-//! | getblockstats                      | done            |
-//! | getchaintips                       | done            |
-//! | getchaintxstats                    | done            |
-//! | getdeploymentinfo                  | todo            |
-//! | getdifficulty                      | done            |
-//! | getmempoolancestors                | done (untested) |
-//! | getmempooldescendants              | done (untested) |
-//! | getmempoolentry                    | done            |
-//! | getmempoolinfo                     | done            |
-//! | getrawmempool                      | done            |
-//! | gettxout                           | done            |
-//! | gettxoutproof                      | done            |
-//! | gettxoutsetinfo                    | done            |
-//! | gettxspendingprevout               | todo            |
-//! | preciousblock                      | done            |
-//! | pruneblockchain                    | omitted         |
-//! | savemempool                        | omitted         |
-//! | scanblocks                         | todo            |
-//! | scantxoutset                       | omitted         |
-//! | verifychain                        | omitted         |
-//! | verifytxoutproof                   | done            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getbestblockhash                   | version + model |                                        |
+//! | getblock                           | version + model | Includes additional 'verbose' type     |
+//! | getblockchaininfo                  | version + model |                                        |
+//! | getblockcount                      | version + model |                                        |
+//! | getblockfilter                     | version         |                                        |
+//! | getblockfrompeer                   | version + model | TODO                                   |
+//! | getblockhash                       | version + model |                                        |
+//! | getblockheader                     | version + model | Includes additional 'verbose' type     |
+//! | getblockstats                      | version + model |                                        |
+//! | getchaintips                       | version + model |                                        |
+//! | getchaintxstats                    | version + model |                                        |
+//! | getdeploymentinfo                  | version + model | TODO                                   |
+//! | getdifficulty                      | version + model |                                        |
+//! | getmempoolancestors                | version + model | UNTESTED (incl. verbose type)          |
+//! | getmempooldescendants              | version + model | UNTESTED (incl. verbose type)          |
+//! | getmempoolentry                    | version + model |                                        |
+//! | getmempoolinfo                     | version + model |                                        |
+//! | getrawmempool                      | version + model | Includes additional 'verbose' type     |
+//! | gettxout                           | version + model |                                        |
+//! | gettxoutproof                      | returns string  |                                        |
+//! | gettxoutsetinfo                    | version + model |                                        |
+//! | gettxspendingprevout               | version + model | TODO                                   |
+//! | preciousblock                      | returns nothing |                                        |
+//! | pruneblockchain                    | returns numeric |                                        |
+//! | savemempool                        | returns nothing |                                        |
+//! | scanblocks                         | version + model | TODO                                   |
+//! | scantxoutset                       | omitted         | API marked as experimental             |
+//! | verifychain                        | returns boolean |                                        |
+//! | verifytxoutproof                   | version + model |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Control == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getmemoryinfo                      | done            |
-//! | getrpcinfo                         | done            |
-//! | help                               | done            |
-//! | logging                            | done            |
-//! | stop                               | done            |
-//! | uptime                             | done            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getmemoryinfo                      | version         |                                        |
+//! | getrpcinfo                         | version + model |                                        |
+//! | help                               | returns string  |                                        |
+//! | logging                            | version         |                                        |
+//! | stop                               | returns string  |                                        |
+//! | uptime                             | returns numeric |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Mining == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getblocktemplate                   | done            |
-//! | getmininginfo                      | done            |
-//! | getnetworkhashps                   | done            |
-//! | prioritisetransaction              | done            |
-//! | submitblock                        | done (untested) |
-//! | submitheader                       | todo            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getblocktemplate                   | version + model |                                        |
+//! | getmininginfo                      | version         |                                        |
+//! | getnetworkhashps                   | returns boolean |                                        |
+//! | prioritisetransaction              | returns boolean |                                        |
+//! | submitblock                        | returns nothing |                                        |
+//! | submitheader                       | return nothing  | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Network == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | addnode                            | omitted         |
-//! | clearbanned                        | omitted         |
-//! | disconnectnode                     | omitted         |
-//! | getaddednodeinfo                   | done            |
-//! | getconnectioncount                 | omitted         |
-//! | getnettotals                       | done            |
-//! | getnetworkinfo                     | done            |
-//! | getnodeaddresses                   | todo            |
-//! | getpeerinfo                        | done            |
-//! | listbanned                         | omitted         |
-//! | ping                               | omitted         |
-//! | setban                             | omitted         |
-//! | setnetworkactive                   | omitted         |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | addnode                            | returns nothing |                                        |
+//! | clearbanned                        | returns nothing |                                        |
+//! | disconnectnode                     | returns nothing |                                        |
+//! | getaddednodeinfo                   | version         |                                        |
+//! | getconnectioncount                 | returns numeric |                                        |
+//! | getnettotals                       | version         |                                        |
+//! | getnetworkinfo                     | version + model |                                        |
+//! | getnodeaddresses                   | version         | TODO                                   |
+//! | getpeerinfo                        | version         |                                        |
+//! | listbanned                         | returns string  |                                        |
+//! | ping                               | returns nothing |                                        |
+//! | setban                             | returns nothing |                                        |
+//! | setnetworkactive                   | returns nothing |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Rawtransactions == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | analyzepsbt                        | done            |
-//! | combinepsbt                        | done            |
-//! | combinerawtransaction              | done            |
-//! | converttopsbt                      | done            |
-//! | createpsbt                         | done            |
-//! | createrawtransaction               | done            |
-//! | decodepsbt                         | done            |
-//! | decoderawtransaction               | done            |
-//! | decodescript                       | done            |
-//! | finalizepsbt                       | done (untested) |
-//! | fundrawtransaction                 | done            |
-//! | getrawtransaction                  | done            |
-//! | joinpsbts                          | done (untested) |
-//! | sendrawtransaction                 | done            |
-//! | signrawtransactionwithkey          | done            |
-//! | testmempoolaccept                  | done (untested) |
-//! | utxoupdatepsbt                     | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | analyzepsbt                        | version + model |                                        |
+//! | combinepsbt                        | version + model |                                        |
+//! | combinerawtransaction              | version + model |                                        |
+//! | converttopsbt                      | version + model |                                        |
+//! | createpsbt                         | version + model |                                        |
+//! | createrawtransaction               | version + model |                                        |
+//! | decodepsbt                         | version + model |                                        |
+//! | decoderawtransaction               | version + model |                                        |
+//! | decodescript                       | version + model |                                        |
+//! | finalizepsbt                       | version + model | UNTESTED                               |
+//! | fundrawtransaction                 | version + model |                                        |
+//! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
+//! | joinpsbts                          | version + model | UNTESTED                               |
+//! | sendrawtransaction                 | version + model |                                        |
+//! | signrawtransactionwithkey          | version + model |                                        |
+//! | testmempoolaccept                  | version + model | UNTESTED                               |
+//! | utxoupdatepsbt                     | version + model | UNTESTED                               |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Signer == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | enumeratesigners                   | todo            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | enumeratesigners                   | version + model | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Util == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | createmultisig                     | omitted         |
-//! | deriveaddresses                    | todo            |
-//! | estimatesmartfee                   | omitted         |
-//! | getdescriptorinfo                  | todo            |
-//! | getindexinfo                       | todo            |
-//! | signmessagewithprivkey             | omitted         |
-//! | validateaddress                    | omitted         |
-//! | verifymessage                      | omitted         |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | createmultisig                     | version + model | TODO                                   |
+//! | deriveaddresses                    | version + model | TODO                                   |
+//! | estimatesmartfee                   | returns nothing | TODO                                   |
+//! | getdescriptorinfo                  | version         | TODO                                   |
+//! | getindexinfo                       | version         | TODO                                   |
+//! | signmessagewithprivkey             | returns string  | TODO                                   |
+//! | validateaddress                    | version + model | TODO                                   |
+//! | verifymessage                      | returns boolean | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Wallet == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | abandontransaction                 | omitted         |
-//! | abortrescan                        | omitted         |
-//! | addmultisigaddress                 | done (untested) |
-//! | backupwallet                       | omitted         |
-//! | bumpfee                            | done            |
-//! | createwallet                       | done            |
-//! | dumpprivkey                        | done            |
-//! | dumpwallet                         | done            |
-//! | encryptwallet                      | omitted         |
-//! | getaddressesbylabel                | done            |
-//! | getaddressinfo                     | done (untested) |
-//! | getbalance                         | done            |
-//! | getbalances                        | done            |
-//! | getnewaddress                      | done            |
-//! | getrawchangeaddress                | done            |
-//! | getreceivedbyaddress               | done            |
-//! | getreceivedbylabel                 | todo            |
-//! | gettransaction                     | done            |
-//! | getunconfirmedbalance              | done (untested) |
-//! | getwalletinfo                      | done (untested) |
-//! | importaddress                      | omitted         |
-//! | importdescriptors                  | todo            |
-//! | importmulti                        | omitted         |
-//! | importprivkey                      | omitted         |
-//! | importprunedfunds                  | omitted         |
-//! | importpubkey                       | omitted         |
-//! | importwallet                       | omitted         |
-//! | keypoolrefill                      | omitted         |
-//! | listaddressgroupings               | done (untested) |
-//! | listdescriptors                    | todo            |
-//! | listlabels                         | done (untested) |
-//! | listlockunspent                    | done (untested) |
-//! | migratewallet                      | todo            |
-//! | newkeypool                         | todo            |
-//! | psbtbumpfee                        | todo            |
-//! | listreceivedbyaddress              | done (untested) |
-//! | listreceivedbylabel                | todo            |
-//! | listsinceblock                     | done (untested) |
-//! | listtransactions                   | done (untested) |
-//! | listunspent                        | done (untested) |
-//! | listwalletdir                      | todo            |
-//! | listwallets                        | done (untested) |
-//! | loadwallet                         | done            |
-//! | lockunspent                        | omitted         |
-//! | removeprunedfunds                  | omitted         |
-//! | rescanblockchain                   | done (untested) |
-//! | restorewallet                      | todo            |
-//! | send                               | todo            |
-//! | sendall                            | todo            |
-//! | sendmany                           | done (untested) |
-//! | sendtoaddress                      | done            |
-//! | sethdseed                          | omitted         |
-//! | setlabel                           | todo            |
-//! | settxfee                           | omitted         |
-//! | setwalletflag                      | todo            |
-//! | signmessage                        | done (untested) |
-//! | signrawtransactionwithwallet       | done (untested) |
-//! | simulaterawtransaction             | todo            |
-//! | unloadwallet                       | done            |
-//! | upgradewallet                      | todo            |
-//! | walletcreatefundedpsbt             | done (untested) |
-//! | walletdisplayaddress               | todo            |
-//! | walletlock                         | omitted         |
-//! | walletpassphrase                   | omitted         |
-//! | walletpassphrasechange             | omitted         |
-//! | walletprocesspsbt                  | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | abandontransaction                 | returns nothing |                                        |
+//! | abortrescan                        | returns nothing |                                        |
+//! | addmultisigaddress                 | version + model | UNTESTED                               |
+//! | backupwallet                       | returns nothing |                                        |
+//! | bumpfee                            | version + model |                                        |
+//! | createwallet                       | version + model |                                        |
+//! | dumpprivkey                        | version + model |                                        |
+//! | dumpwallet                         | version + model |                                        |
+//! | encryptwallet                      | returns nothing |                                        |
+//! | getaddressesbylabel                | version + model |                                        |
+//! | getaddressinfo                     | version + model | UNTESTED                               |
+//! | getbalance                         | version + model |                                        |
+//! | getbalances                        | version + model |                                        |
+//! | getnewaddress                      | version + model |                                        |
+//! | getrawchangeaddress                | version + model |                                        |
+//! | getreceivedbyaddress               | version + model | TODO                                   |
+//! | getreceivedbylabel                 | version + model | TODO                                   |
+//! | gettransaction                     | version + model |                                        |
+//! | getunconfirmedbalance              | version + model | UNTESTED                               |
+//! | getwalletinfo                      | version + model | UNTESTED                               |
+//! | importaddress                      | returns nothing |                                        |
+//! | importdescriptors                  | version         | TODO                                   |
+//! | importmulti                        | returns nothing |                                        |
+//! | importprivkey                      | returns nothing |                                        |
+//! | importprunedfunds                  | returns nothing |                                        |
+//! | importpubkey                       | returns nothing |                                        |
+//! | importwallet                       | returns nothing |                                        |
+//! | keypoolrefill                      | returns nothing |                                        |
+//! | listaddressgroupings               | version + model | UNTESTED                               |
+//! | listdescriptors                    | version + model | TODO                                   |
+//! | listlabels                         | version + model | UNTESTED                               |
+//! | listlockunspent                    | version + model | UNTESTED                               |
+//! | migratewallet                      | version + model | TODO                                   |
+//! | newkeypool                         | version + model | TODO                                   |
+//! | psbtbumpfee                        | version + model | TODO                                   |
+//! | listreceivedbyaddress              | version + model | UNTESTED                               |
+//! | listreceivedbylabel                | version + model | TODO                                   |
+//! | listsinceblock                     | version + model | UNTESTED                               |
+//! | listtransactions                   | version + model | UNTESTED                               |
+//! | listunspent                        | version + model | UNTESTED                               |
+//! | listwalletdir                      | version         | TODO                                   |
+//! | listwallets                        | version + model | UNTESTED                               |
+//! | loadwallet                         | version + model |                                        |
+//! | lockunspent                        | returns boolean |                                        |
+//! | removeprunedfunds                  | returns nothing |                                        |
+//! | rescanblockchain                   | version + model | UNTESTED                               |
+//! | restorewallet                      | version + model | TODO                                   |
+//! | send                               | version + model | TODO                                   |
+//! | sendall                            | version + model | TODO                                   |
+//! | sendmany                           | version + model | UNTESTED                               |
+//! | sendtoaddress                      | version + model |                                        |
+//! | sethdseed                          | returns nothing |                                        |
+//! | setlabel                           | returns nothing |                                        |
+//! | settxfee                           | returns boolean |                                        |
+//! | setwalletflag                      | version         | TODO                                   |
+//! | signmessage                        | version + model | UNTESTED                               |
+//! | signrawtransactionwithwallet       | version + model |                                        |
+//! | simulaterawtransaction             | version + model | TODO                                   |
+//! | unloadwallet                       | returns nothing |                                        |
+//! | upgradewallet                      | version         | TODO                                   |
+//! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
+//! | walletdisplayaddress               | version + model | TODO                                   |
+//! | walletlock                         | returns nothing |                                        |
+//! | walletpassphrase                   | returns nothing |                                        |
+//! | walletpassphrasechange             | returns nothing |                                        |
+//! | walletprocesspsbt                  | version + model | UNTESTED                               |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Zmq == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getzmqnotifications                | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getzmqnotifications                | version         | UNTESTED                               |
 //!
 //! </details>
 

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -9,233 +9,242 @@
 //!
 //! ### Method name and implementation status
 //!
-//! Every JSON-RPC method supported by this version of Bitcoin Core is listed below along with its
-//! current implementation status.
+//! Every JSON-RPC method supported by this version of Bitcoin Core is listed below along with the
+//! type it returns and any implementation notes.
+//!
+//! Key to 'Returns' column:
+//!
+//! * version: method returns a version specific type but has no model type.
+//! * version + model: method returns a version specific type and can be converted to a model type.
+//! * returns foo: method returns a foo (e.g. string, boolean, or nothing).
+//! * omitted: method intentionally unsupported with no plans of adding support.
+//!
+//! If a method has UNTESTED then there is no integration test yet for it.
 //!
 //! <details>
 //! <summary> Methods from the == Blockchain == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | dumptxoutset                       | todo            |
-//! | getbestblockhash                   | done            |
-//! | getblock                           | done            |
-//! | getblockchaininfo                  | done            |
-//! | getblockcount                      | done            |
-//! | getblockfilter                     | done            |
-//! | getblockfrompeer                   | todo            |
-//! | getblockhash                       | done            |
-//! | getblockheader                     | done            |
-//! | getblockstats                      | done            |
-//! | getchainstates                     | todo            |
-//! | getchaintips                       | done            |
-//! | getchaintxstats                    | done            |
-//! | getdeploymentinfo                  | todo            |
-//! | getdifficulty                      | done            |
-//! | getmempoolancestors                | done (untested) |
-//! | getmempooldescendants              | done (untested) |
-//! | getmempoolentry                    | done            |
-//! | getmempoolinfo                     | done            |
-//! | getrawmempool                      | done            |
-//! | gettxout                           | done            |
-//! | gettxoutproof                      | done            |
-//! | gettxoutsetinfo                    | done            |
-//! | gettxspendingprevout               | todo            |
-//! | importmempool                      | todo            |
-//! | loadtxoutset                       | todo            |
-//! | preciousblock                      | done            |
-//! | pruneblockchain                    | omitted         |
-//! | savemempool                        | omitted         |
-//! | scanblocks                         | todo            |
-//! | scantxoutset                       | omitted         |
-//! | verifychain                        | omitted         |
-//! | verifytxoutproof                   | done            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | dumptxoutset                       | version + model | TODO                                   |
+//! | getbestblockhash                   | version + model |                                        |
+//! | getblock                           | version + model | Includes additional 'verbose' type     |
+//! | getblockchaininfo                  | version + model |                                        |
+//! | getblockcount                      | version + model |                                        |
+//! | getblockfilter                     | version         |                                        |
+//! | getblockfrompeer                   | version + model | TODO                                   |
+//! | getblockhash                       | version + model |                                        |
+//! | getblockheader                     | version + model | Includes additional 'verbose' type     |
+//! | getblockstats                      | version + model |                                        |
+//! | getchainstates                     | version + model | TODO                                   |
+//! | getchaintips                       | version + model |                                        |
+//! | getchaintxstats                    | version + model |                                        |
+//! | getdeploymentinfo                  | version + model | TODO                                   |
+//! | getdifficulty                      | version + model |                                        |
+//! | getmempoolancestors                | version + model | UNTESTED (incl. verbose type)          |
+//! | getmempooldescendants              | version + model | UNTESTED (incl. verbose type)          |
+//! | getmempoolentry                    | version + model |                                        |
+//! | getmempoolinfo                     | version + model |                                        |
+//! | getrawmempool                      | version + model | Includes additional 'verbose' type     |
+//! | gettxout                           | version + model |                                        |
+//! | gettxoutproof                      | returns string  |                                        |
+//! | gettxoutsetinfo                    | version + model |                                        |
+//! | gettxspendingprevout               | version + model | TODO                                   |
+//! | importmempool                      | version + model | TODO                                   |
+//! | loadtxoutset                      | version + model | TODO                                   |
+//! | preciousblock                      | returns nothing |                                        |
+//! | pruneblockchain                    | returns numeric |                                        |
+//! | savemempool                        | returns nothing |                                        |
+//! | scanblocks                         | version + model | TODO                                   |
+//! | scantxoutset                       | omitted         | API marked as experimental             |
+//! | verifychain                        | returns boolean |                                        |
+//! | verifytxoutproof                   | version + model |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Control == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getmemoryinfo                      | done            |
-//! | getrpcinfo                         | done            |
-//! | help                               | done            |
-//! | logging                            | done            |
-//! | stop                               | done            |
-//! | uptime                             | done            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getmemoryinfo                      | version         |                                        |
+//! | getrpcinfo                         | version + model |                                        |
+//! | help                               | returns string  |                                        |
+//! | logging                            | version         |                                        |
+//! | stop                               | returns string  |                                        |
+//! | uptime                             | returns numeric |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Mining == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getblocktemplate                   | done            |
-//! | getmininginfo                      | done            |
-//! | getnetworkhashps                   | done            |
-//! | getprioritisedtransactions         | done            |
-//! | prioritisetransaction              | done            |
-//! | submitblock                        | done (untested) |
-//! | submitheader                       | todo            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getblocktemplate                   | version + model |                                        |
+//! | getmininginfo                      | version         |                                        |
+//! | getnetworkhashps                   | returns boolean |                                        |
+//! | getprioritisedtransactions         | version + model | TODO                                   |
+//! | prioritisetransaction              | returns boolean |                                        |
+//! | submitblock                        | returns nothing |                                        |
+//! | submitheader                       | return nothing  | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Network == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | addnode                            | omitted         |
-//! | clearbanned                        | omitted         |
-//! | disconnectnode                     | omitted         |
-//! | getaddednodeinfo                   | done            |
-//! | getaddrmaninfo                     | todo            |
-//! | getconnectioncount                 | omitted         |
-//! | getnettotals                       | done            |
-//! | getnetworkinfo                     | done            |
-//! | getnodeaddresses                   | todo            |
-//! | getpeerinfo                        | done            |
-//! | listbanned                         | omitted         |
-//! | ping                               | omitted         |
-//! | setban                             | omitted         |
-//! | setnetworkactive                   | omitted         |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | addnode                            | returns nothing |                                        |
+//! | clearbanned                        | returns nothing |                                        |
+//! | disconnectnode                     | returns nothing |                                        |
+//! | getaddednodeinfo                   | version         |                                        |
+//! | getaddrmaninfo                     | version + model | TODO                                   |
+//! | getconnectioncount                 | returns numeric |                                        |
+//! | getnettotals                       | version         |                                        |
+//! | getnetworkinfo                     | version + model |                                        |
+//! | getnodeaddresses                   | version         | TODO                                   |
+//! | getpeerinfo                        | version         |                                        |
+//! | listbanned                         | returns string  |                                        |
+//! | ping                               | returns nothing |                                        |
+//! | setban                             | returns nothing |                                        |
+//! | setnetworkactive                   | returns nothing |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Rawtransactions == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | analyzepsbt                        | done            |
-//! | combinepsbt                        | done            |
-//! | combinerawtransaction              | done            |
-//! | converttopsbt                      | done            |
-//! | createpsbt                         | done            |
-//! | createrawtransaction               | done            |
-//! | decodepsbt                         | done            |
-//! | decoderawtransaction               | done            |
-//! | decodescript                       | done            |
-//! | descriptorprocesspsbt              | done (untested) |
-//! | finalizepsbt                       | done (untested) |
-//! | fundrawtransaction                 | done            |
-//! | getrawtransaction                  | done            |
-//! | joinpsbts                          | done (untested) |
-//! | sendrawtransaction                 | done            |
-//! | signrawtransactionwithkey          | done            |
-//! | submitpackage                      | done (untested) |
-//! | testmempoolaccept                  | done (untested) |
-//! | utxoupdatepsbt                     | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | analyzepsbt                        | version + model |                                        |
+//! | combinepsbt                        | version + model |                                        |
+//! | combinerawtransaction              | version + model |                                        |
+//! | converttopsbt                      | version + model |                                        |
+//! | createpsbt                         | version + model |                                        |
+//! | createrawtransaction               | version + model |                                        |
+//! | decodepsbt                         | version + model |                                        |
+//! | descriptorprocesspsbt              | returns boolean |                                        |
+//! | decoderawtransaction               | version + model |                                        |
+//! | decodescript                       | version + model |                                        |
+//! | finalizepsbt                       | version + model | UNTESTED                               |
+//! | fundrawtransaction                 | version + model |                                        |
+//! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
+//! | joinpsbts                          | version + model | UNTESTED                               |
+//! | sendrawtransaction                 | version + model |                                        |
+//! | signrawtransactionwithkey          | version + model |                                        |
+//! | submitpackage                      | version + model |                                        |
+//! | testmempoolaccept                  | version + model | UNTESTED                               |
+//! | utxoupdatepsbt                     | version + model | UNTESTED                               |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Signer == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | enumeratesigners                   | todo            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | enumeratesigners                   | version + model | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Util == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | createmultisig                     | omitted         |
-//! | deriveaddresses                    | todo            |
-//! | estimatesmartfee                   | omitted         |
-//! | getdescriptorinfo                  | todo            |
-//! | getindexinfo                       | todo            |
-//! | signmessagewithprivkey             | omitted         |
-//! | validateaddress                    | omitted         |
-//! | verifymessage                      | omitted         |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | createmultisig                     | version + model | TODO                                   |
+//! | deriveaddresses                    | version + model | TODO                                   |
+//! | estimatesmartfee                   | returns nothing | TODO                                   |
+//! | getdescriptorinfo                  | version         | TODO                                   |
+//! | getindexinfo                       | version         | TODO                                   |
+//! | signmessagewithprivkey             | returns string  | TODO                                   |
+//! | validateaddress                    | version + model | TODO                                   |
+//! | verifymessage                      | returns boolean | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Wallet == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | abandontransaction                 | omitted         |
-//! | abortrescan                        | omitted         |
-//! | addmultisigaddress                 | done (untested) |
-//! | backupwallet                       | omitted         |
-//! | bumpfee                            | done            |
-//! | createwallet                       | done            |
-//! | dumpprivkey                        | done            |
-//! | dumpwallet                         | done            |
-//! | encryptwallet                      | omitted         |
-//! | getaddressesbylabel                | done            |
-//! | getaddressinfo                     | done (untested) |
-//! | getbalance                         | done            |
-//! | getbalances                        | done            |
-//! | getnewaddress                      | done            |
-//! | getrawchangeaddress                | done            |
-//! | getreceivedbyaddress               | done            |
-//! | getreceivedbylabel                 | todo            |
-//! | gettransaction                     | done            |
-//! | getunconfirmedbalance              | done (untested) |
-//! | getwalletinfo                      | done (untested) |
-//! | importaddress                      | omitted         |
-//! | importdescriptors                  | todo            |
-//! | importmulti                        | omitted         |
-//! | importprivkey                      | omitted         |
-//! | importprunedfunds                  | omitted         |
-//! | importpubkey                       | omitted         |
-//! | importwallet                       | omitted         |
-//! | keypoolrefill                      | omitted         |
-//! | listaddressgroupings               | done (untested) |
-//! | listdescriptors                    | todo            |
-//! | listlabels                         | done (untested) |
-//! | listlockunspent                    | done (untested) |
-//! | migratewallet                      | todo            |
-//! | newkeypool                         | todo            |
-//! | psbtbumpfee                        | todo            |
-//! | listreceivedbyaddress              | done (untested) |
-//! | listreceivedbylabel                | todo            |
-//! | listsinceblock                     | done (untested) |
-//! | listtransactions                   | done (untested) |
-//! | listunspent                        | done (untested) |
-//! | listwalletdir                      | todo            |
-//! | listwallets                        | done (untested) |
-//! | loadwallet                         | done            |
-//! | lockunspent                        | omitted         |
-//! | removeprunedfunds                  | omitted         |
-//! | rescanblockchain                   | done (untested) |
-//! | restorewallet                      | todo            |
-//! | send                               | todo            |
-//! | sendall                            | todo            |
-//! | sendmany                           | done (untested) |
-//! | sendtoaddress                      | done            |
-//! | sethdseed                          | omitted         |
-//! | setlabel                           | todo            |
-//! | settxfee                           | omitted         |
-//! | setwalletflag                      | todo            |
-//! | signmessage                        | done (untested) |
-//! | signrawtransactionwithwallet       | done (untested) |
-//! | simulaterawtransaction             | todo            |
-//! | unloadwallet                       | done            |
-//! | upgradewallet                      | todo            |
-//! | walletcreatefundedpsbt             | done (untested) |
-//! | walletdisplayaddress               | todo            |
-//! | walletlock                         | omitted         |
-//! | walletpassphrase                   | omitted         |
-//! | walletpassphrasechange             | omitted         |
-//! | walletprocesspsbt                  | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | abandontransaction                 | returns nothing |                                        |
+//! | abortrescan                        | returns nothing |                                        |
+//! | addmultisigaddress                 | version + model | UNTESTED                               |
+//! | backupwallet                       | returns nothing |                                        |
+//! | bumpfee                            | version + model |                                        |
+//! | createwallet                       | version + model |                                        |
+//! | dumpprivkey                        | version + model |                                        |
+//! | dumpwallet                         | version + model |                                        |
+//! | encryptwallet                      | returns nothing |                                        |
+//! | getaddressesbylabel                | version + model |                                        |
+//! | getaddressinfo                     | version + model | UNTESTED                               |
+//! | getbalance                         | version + model |                                        |
+//! | getbalances                        | version + model |                                        |
+//! | getnewaddress                      | version + model |                                        |
+//! | getrawchangeaddress                | version + model |                                        |
+//! | getreceivedbyaddress               | version + model | TODO                                   |
+//! | getreceivedbylabel                 | version + model | TODO                                   |
+//! | gettransaction                     | version + model |                                        |
+//! | getunconfirmedbalance              | version + model | UNTESTED                               |
+//! | getwalletinfo                      | version + model | UNTESTED                               |
+//! | importaddress                      | returns nothing |                                        |
+//! | importdescriptors                  | version         | TODO                                   |
+//! | importmulti                        | returns nothing |                                        |
+//! | importprivkey                      | returns nothing |                                        |
+//! | importprunedfunds                  | returns nothing |                                        |
+//! | importpubkey                       | returns nothing |                                        |
+//! | importwallet                       | returns nothing |                                        |
+//! | keypoolrefill                      | returns nothing |                                        |
+//! | listaddressgroupings               | version + model | UNTESTED                               |
+//! | listdescriptors                    | version + model | TODO                                   |
+//! | listlabels                         | version + model | UNTESTED                               |
+//! | listlockunspent                    | version + model | UNTESTED                               |
+//! | migratewallet                      | version + model | TODO                                   |
+//! | newkeypool                         | version + model | TODO                                   |
+//! | psbtbumpfee                        | version + model | TODO                                   |
+//! | listreceivedbyaddress              | version + model | UNTESTED                               |
+//! | listreceivedbylabel                | version + model | TODO                                   |
+//! | listsinceblock                     | version + model | UNTESTED                               |
+//! | listtransactions                   | version + model | UNTESTED                               |
+//! | listunspent                        | version + model | UNTESTED                               |
+//! | listwalletdir                      | version         | TODO                                   |
+//! | listwallets                        | version + model | UNTESTED                               |
+//! | loadwallet                         | version + model |                                        |
+//! | lockunspent                        | returns boolean |                                        |
+//! | removeprunedfunds                  | returns nothing |                                        |
+//! | rescanblockchain                   | version + model | UNTESTED                               |
+//! | restorewallet                      | version + model | TODO                                   |
+//! | send                               | version + model | TODO                                   |
+//! | sendall                            | version + model | TODO                                   |
+//! | sendmany                           | version + model | UNTESTED                               |
+//! | sendtoaddress                      | version + model |                                        |
+//! | sethdseed                          | returns nothing |                                        |
+//! | setlabel                           | returns nothing |                                        |
+//! | settxfee                           | returns boolean |                                        |
+//! | setwalletflag                      | version         | TODO                                   |
+//! | signmessage                        | version + model | UNTESTED                               |
+//! | signrawtransactionwithwallet       | version + model |                                        |
+//! | simulaterawtransaction             | version + model | TODO                                   |
+//! | unloadwallet                       | returns nothing |                                        |
+//! | upgradewallet                      | version         | TODO                                   |
+//! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
+//! | walletdisplayaddress               | version + model | TODO                                   |
+//! | walletlock                         | returns nothing |                                        |
+//! | walletpassphrase                   | returns nothing |                                        |
+//! | walletpassphrasechange             | returns nothing |                                        |
+//! | walletprocesspsbt                  | version + model | UNTESTED                               |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Zmq == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getzmqnotifications                | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getzmqnotifications                | version         | UNTESTED                               |
 //!
 //! </details>
 

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -9,233 +9,242 @@
 //!
 //! ### Method name and implementation status
 //!
-//! Every JSON-RPC method supported by this version of Bitcoin Core is listed below along with its
-//! current implementation status.
+//! Every JSON-RPC method supported by this version of Bitcoin Core is listed below along with the
+//! type it returns and any implementation notes.
+//!
+//! Key to 'Returns' column:
+//!
+//! * version: method returns a version specific type but has no model type.
+//! * version + model: method returns a version specific type and can be converted to a model type.
+//! * returns foo: method returns a foo (e.g. string, boolean, or nothing).
+//! * omitted: method intentionally unsupported with no plans of adding support.
+//!
+//! If a method has UNTESTED then there is no integration test yet for it.
 //!
 //! <details>
 //! <summary> Methods from the == Blockchain == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | dumptxoutset                       | todo            |
-//! | getbestblockhash                   | done            |
-//! | getblock                           | done            |
-//! | getblockchaininfo                  | done            |
-//! | getblockcount                      | done            |
-//! | getblockfilter                     | done            |
-//! | getblockfrompeer                   | todo            |
-//! | getblockhash                       | done            |
-//! | getblockheader                     | done            |
-//! | getblockstats                      | done            |
-//! | getchainstates                     | todo            |
-//! | getchaintips                       | done            |
-//! | getchaintxstats                    | done            |
-//! | getdeploymentinfo                  | todo            |
-//! | getdifficulty                      | done            |
-//! | getmempoolancestors                | done (untested) |
-//! | getmempooldescendants              | done (untested) |
-//! | getmempoolentry                    | done            |
-//! | getmempoolinfo                     | done            |
-//! | getrawmempool                      | done            |
-//! | gettxout                           | done            |
-//! | gettxoutproof                      | done            |
-//! | gettxoutsetinfo                    | done            |
-//! | gettxspendingprevout               | todo            |
-//! | importmempool                      | todo            |
-//! | loadtxoutset                       | todo            |
-//! | preciousblock                      | done            |
-//! | pruneblockchain                    | omitted         |
-//! | savemempool                        | omitted         |
-//! | scanblocks                         | todo            |
-//! | scantxoutset                       | omitted         |
-//! | verifychain                        | omitted         |
-//! | verifytxoutproof                   | done            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | dumptxoutset                       | version + model | TODO                                   |
+//! | getbestblockhash                   | version + model |                                        |
+//! | getblock                           | version + model | Includes additional 'verbose' type     |
+//! | getblockchaininfo                  | version + model |                                        |
+//! | getblockcount                      | version + model |                                        |
+//! | getblockfilter                     | version         |                                        |
+//! | getblockfrompeer                   | version + model | TODO                                   |
+//! | getblockhash                       | version + model |                                        |
+//! | getblockheader                     | version + model | Includes additional 'verbose' type     |
+//! | getblockstats                      | version + model |                                        |
+//! | getchainstates                     | version + model | TODO                                   |
+//! | getchaintips                       | version + model |                                        |
+//! | getchaintxstats                    | version + model |                                        |
+//! | getdeploymentinfo                  | version + model | TODO                                   |
+//! | getdifficulty                      | version + model |                                        |
+//! | getmempoolancestors                | version + model | UNTESTED (incl. verbose type)          |
+//! | getmempooldescendants              | version + model | UNTESTED (incl. verbose type)          |
+//! | getmempoolentry                    | version + model |                                        |
+//! | getmempoolinfo                     | version + model |                                        |
+//! | getrawmempool                      | version + model | Includes additional 'verbose' type     |
+//! | gettxout                           | version + model |                                        |
+//! | gettxoutproof                      | returns string  |                                        |
+//! | gettxoutsetinfo                    | version + model |                                        |
+//! | gettxspendingprevout               | version + model | TODO                                   |
+//! | importmempool                      | version + model | TODO                                   |
+//! | loadtxoutset                      | version + model | TODO                                   |
+//! | preciousblock                      | returns nothing |                                        |
+//! | pruneblockchain                    | returns numeric |                                        |
+//! | savemempool                        | returns nothing |                                        |
+//! | scanblocks                         | version + model | TODO                                   |
+//! | scantxoutset                       | omitted         | API marked as experimental             |
+//! | verifychain                        | returns boolean |                                        |
+//! | verifytxoutproof                   | version + model |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Control == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getmemoryinfo                      | done            |
-//! | getrpcinfo                         | done            |
-//! | help                               | done            |
-//! | logging                            | done            |
-//! | stop                               | done            |
-//! | uptime                             | done            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getmemoryinfo                      | version         |                                        |
+//! | getrpcinfo                         | version + model |                                        |
+//! | help                               | returns string  |                                        |
+//! | logging                            | version         |                                        |
+//! | stop                               | returns string  |                                        |
+//! | uptime                             | returns numeric |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Mining == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getblocktemplate                   | done            |
-//! | getmininginfo                      | done            |
-//! | getnetworkhashps                   | done            |
-//! | getprioritisedtransactions         | done            |
-//! | prioritisetransaction              | done            |
-//! | submitblock                        | done (untested) |
-//! | submitheader                       | todo            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getblocktemplate                   | version + model |                                        |
+//! | getmininginfo                      | version         |                                        |
+//! | getnetworkhashps                   | returns boolean |                                        |
+//! | getprioritisedtransactions         | version + model | TODO                                   |
+//! | prioritisetransaction              | returns boolean |                                        |
+//! | submitblock                        | returns nothing |                                        |
+//! | submitheader                       | return nothing  | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Network == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | addnode                            | omitted         |
-//! | clearbanned                        | omitted         |
-//! | disconnectnode                     | omitted         |
-//! | getaddednodeinfo                   | done            |
-//! | getaddrmaninfo                     | todo            |
-//! | getconnectioncount                 | omitted         |
-//! | getnettotals                       | done            |
-//! | getnetworkinfo                     | done            |
-//! | getnodeaddresses                   | todo            |
-//! | getpeerinfo                        | done            |
-//! | listbanned                         | omitted         |
-//! | ping                               | omitted         |
-//! | setban                             | omitted         |
-//! | setnetworkactive                   | omitted         |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | addnode                            | returns nothing |                                        |
+//! | clearbanned                        | returns nothing |                                        |
+//! | disconnectnode                     | returns nothing |                                        |
+//! | getaddednodeinfo                   | version         |                                        |
+//! | getaddrmaninfo                     | version + model | TODO                                   |
+//! | getconnectioncount                 | returns numeric |                                        |
+//! | getnettotals                       | version         |                                        |
+//! | getnetworkinfo                     | version + model |                                        |
+//! | getnodeaddresses                   | version         | TODO                                   |
+//! | getpeerinfo                        | version         |                                        |
+//! | listbanned                         | returns string  |                                        |
+//! | ping                               | returns nothing |                                        |
+//! | setban                             | returns nothing |                                        |
+//! | setnetworkactive                   | returns nothing |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Rawtransactions == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | analyzepsbt                        | done            |
-//! | combinepsbt                        | done            |
-//! | combinerawtransaction              | done            |
-//! | converttopsbt                      | done            |
-//! | createpsbt                         | done            |
-//! | createrawtransaction               | done            |
-//! | decodepsbt                         | done            |
-//! | decoderawtransaction               | done            |
-//! | decodescript                       | done            |
-//! | descriptorprocesspsbt              | done (untested) |
-//! | finalizepsbt                       | done (untested) |
-//! | fundrawtransaction                 | done            |
-//! | getrawtransaction                  | done            |
-//! | joinpsbts                          | done (untested) |
-//! | sendrawtransaction                 | done            |
-//! | signrawtransactionwithkey          | done            |
-//! | submitpackage                      | done (untested) |
-//! | testmempoolaccept                  | done (untested) |
-//! | utxoupdatepsbt                     | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | analyzepsbt                        | version + model |                                        |
+//! | combinepsbt                        | version + model |                                        |
+//! | combinerawtransaction              | version + model |                                        |
+//! | converttopsbt                      | version + model |                                        |
+//! | createpsbt                         | version + model |                                        |
+//! | createrawtransaction               | version + model |                                        |
+//! | decodepsbt                         | version + model |                                        |
+//! | descriptorprocesspsbt              | returns boolean |                                        |
+//! | decoderawtransaction               | version + model |                                        |
+//! | decodescript                       | version + model |                                        |
+//! | finalizepsbt                       | version + model | UNTESTED                               |
+//! | fundrawtransaction                 | version + model |                                        |
+//! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
+//! | joinpsbts                          | version + model | UNTESTED                               |
+//! | sendrawtransaction                 | version + model |                                        |
+//! | signrawtransactionwithkey          | version + model |                                        |
+//! | submitpackage                      | version + model |                                        |
+//! | testmempoolaccept                  | version + model | UNTESTED                               |
+//! | utxoupdatepsbt                     | version + model | UNTESTED                               |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Signer == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | enumeratesigners                   | todo            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | enumeratesigners                   | version + model | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Util == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | createmultisig                     | omitted         |
-//! | deriveaddresses                    | todo            |
-//! | estimatesmartfee                   | omitted         |
-//! | getdescriptorinfo                  | todo            |
-//! | getindexinfo                       | todo            |
-//! | signmessagewithprivkey             | omitted         |
-//! | validateaddress                    | omitted         |
-//! | verifymessage                      | omitted         |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | createmultisig                     | version + model | TODO                                   |
+//! | deriveaddresses                    | version + model | TODO                                   |
+//! | estimatesmartfee                   | returns nothing | TODO                                   |
+//! | getdescriptorinfo                  | version         | TODO                                   |
+//! | getindexinfo                       | version         | TODO                                   |
+//! | signmessagewithprivkey             | returns string  | TODO                                   |
+//! | validateaddress                    | version + model | TODO                                   |
+//! | verifymessage                      | returns boolean | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Wallet == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | abandontransaction                 | omitted         |
-//! | abortrescan                        | omitted         |
-//! | addmultisigaddress                 | done (untested) |
-//! | backupwallet                       | omitted         |
-//! | bumpfee                            | done            |
-//! | createwallet                       | done            |
-//! | dumpprivkey                        | done            |
-//! | dumpwallet                         | done            |
-//! | encryptwallet                      | omitted         |
-//! | getaddressesbylabel                | done            |
-//! | getaddressinfo                     | done (untested) |
-//! | getbalance                         | done            |
-//! | getbalances                        | done            |
-//! | getnewaddress                      | done            |
-//! | getrawchangeaddress                | done            |
-//! | getreceivedbyaddress               | done            |
-//! | getreceivedbylabel                 | todo            |
-//! | gettransaction                     | done            |
-//! | getunconfirmedbalance              | done (untested) |
-//! | getwalletinfo                      | done (untested) |
-//! | importaddress                      | omitted         |
-//! | importdescriptors                  | todo            |
-//! | importmulti                        | omitted         |
-//! | importprivkey                      | omitted         |
-//! | importprunedfunds                  | omitted         |
-//! | importpubkey                       | omitted         |
-//! | importwallet                       | omitted         |
-//! | keypoolrefill                      | omitted         |
-//! | listaddressgroupings               | done (untested) |
-//! | listdescriptors                    | todo            |
-//! | listlabels                         | done (untested) |
-//! | listlockunspent                    | done (untested) |
-//! | migratewallet                      | todo            |
-//! | newkeypool                         | todo            |
-//! | psbtbumpfee                        | todo            |
-//! | listreceivedbyaddress              | done (untested) |
-//! | listreceivedbylabel                | todo            |
-//! | listsinceblock                     | done (untested) |
-//! | listtransactions                   | done (untested) |
-//! | listunspent                        | done (untested) |
-//! | listwalletdir                      | todo            |
-//! | listwallets                        | done (untested) |
-//! | loadwallet                         | done            |
-//! | lockunspent                        | omitted         |
-//! | removeprunedfunds                  | omitted         |
-//! | rescanblockchain                   | done (untested) |
-//! | restorewallet                      | todo            |
-//! | send                               | todo            |
-//! | sendall                            | todo            |
-//! | sendmany                           | done (untested) |
-//! | sendtoaddress                      | done            |
-//! | sethdseed                          | omitted         |
-//! | setlabel                           | todo            |
-//! | settxfee                           | omitted         |
-//! | setwalletflag                      | todo            |
-//! | signmessage                        | done (untested) |
-//! | signrawtransactionwithwallet       | done (untested) |
-//! | simulaterawtransaction             | todo            |
-//! | unloadwallet                       | done            |
-//! | upgradewallet                      | todo            |
-//! | walletcreatefundedpsbt             | done (untested) |
-//! | walletdisplayaddress               | todo            |
-//! | walletlock                         | omitted         |
-//! | walletpassphrase                   | omitted         |
-//! | walletpassphrasechange             | omitted         |
-//! | walletprocesspsbt                  | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | abandontransaction                 | returns nothing |                                        |
+//! | abortrescan                        | returns nothing |                                        |
+//! | addmultisigaddress                 | version + model | UNTESTED                               |
+//! | backupwallet                       | returns nothing |                                        |
+//! | bumpfee                            | version + model |                                        |
+//! | createwallet                       | version + model |                                        |
+//! | dumpprivkey                        | version + model |                                        |
+//! | dumpwallet                         | version + model |                                        |
+//! | encryptwallet                      | returns nothing |                                        |
+//! | getaddressesbylabel                | version + model |                                        |
+//! | getaddressinfo                     | version + model | UNTESTED                               |
+//! | getbalance                         | version + model |                                        |
+//! | getbalances                        | version + model |                                        |
+//! | getnewaddress                      | version + model |                                        |
+//! | getrawchangeaddress                | version + model |                                        |
+//! | getreceivedbyaddress               | version + model | TODO                                   |
+//! | getreceivedbylabel                 | version + model | TODO                                   |
+//! | gettransaction                     | version + model |                                        |
+//! | getunconfirmedbalance              | version + model | UNTESTED                               |
+//! | getwalletinfo                      | version + model | UNTESTED                               |
+//! | importaddress                      | returns nothing |                                        |
+//! | importdescriptors                  | version         | TODO                                   |
+//! | importmulti                        | returns nothing |                                        |
+//! | importprivkey                      | returns nothing |                                        |
+//! | importprunedfunds                  | returns nothing |                                        |
+//! | importpubkey                       | returns nothing |                                        |
+//! | importwallet                       | returns nothing |                                        |
+//! | keypoolrefill                      | returns nothing |                                        |
+//! | listaddressgroupings               | version + model | UNTESTED                               |
+//! | listdescriptors                    | version + model | TODO                                   |
+//! | listlabels                         | version + model | UNTESTED                               |
+//! | listlockunspent                    | version + model | UNTESTED                               |
+//! | migratewallet                      | version + model | TODO                                   |
+//! | newkeypool                         | version + model | TODO                                   |
+//! | psbtbumpfee                        | version + model | TODO                                   |
+//! | listreceivedbyaddress              | version + model | UNTESTED                               |
+//! | listreceivedbylabel                | version + model | TODO                                   |
+//! | listsinceblock                     | version + model | UNTESTED                               |
+//! | listtransactions                   | version + model | UNTESTED                               |
+//! | listunspent                        | version + model | UNTESTED                               |
+//! | listwalletdir                      | version         | TODO                                   |
+//! | listwallets                        | version + model | UNTESTED                               |
+//! | loadwallet                         | version + model |                                        |
+//! | lockunspent                        | returns boolean |                                        |
+//! | removeprunedfunds                  | returns nothing |                                        |
+//! | rescanblockchain                   | version + model | UNTESTED                               |
+//! | restorewallet                      | version + model | TODO                                   |
+//! | send                               | version + model | TODO                                   |
+//! | sendall                            | version + model | TODO                                   |
+//! | sendmany                           | version + model | UNTESTED                               |
+//! | sendtoaddress                      | version + model |                                        |
+//! | sethdseed                          | returns nothing |                                        |
+//! | setlabel                           | returns nothing |                                        |
+//! | settxfee                           | returns boolean |                                        |
+//! | setwalletflag                      | version         | TODO                                   |
+//! | signmessage                        | version + model | UNTESTED                               |
+//! | signrawtransactionwithwallet       | version + model |                                        |
+//! | simulaterawtransaction             | version + model | TODO                                   |
+//! | unloadwallet                       | returns nothing |                                        |
+//! | upgradewallet                      | version         | TODO                                   |
+//! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
+//! | walletdisplayaddress               | version + model | TODO                                   |
+//! | walletlock                         | returns nothing |                                        |
+//! | walletpassphrase                   | returns nothing |                                        |
+//! | walletpassphrasechange             | returns nothing |                                        |
+//! | walletprocesspsbt                  | version + model | UNTESTED                               |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Zmq == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getzmqnotifications                | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getzmqnotifications                | version         | UNTESTED                               |
 //!
 //! </details>
 

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -9,235 +9,244 @@
 //!
 //! ### Method name and implementation status
 //!
-//! Every JSON-RPC method supported by this version of Bitcoin Core is listed below along with its
-//! current implementation status.
+//! Every JSON-RPC method supported by this version of Bitcoin Core is listed below along with the
+//! type it returns and any implementation notes.
+//!
+//! Key to 'Returns' column:
+//!
+//! * version: method returns a version specific type but has no model type.
+//! * version + model: method returns a version specific type and can be converted to a model type.
+//! * returns foo: method returns a foo (e.g. string, boolean, or nothing).
+//! * omitted: method intentionally unsupported with no plans of adding support.
+//!
+//! If a method has UNTESTED then there is no integration test yet for it.
 //!
 //! <details>
 //! <summary> Methods from the == Blockchain == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | dumptxoutset                       | todo            |
-//! | getbestblockhash                   | done            |
-//! | getblock                           | done            |
-//! | getblockchaininfo                  | done            |
-//! | getblockcount                      | done            |
-//! | getblockfilter                     | done            |
-//! | getblockfrompeer                   | todo            |
-//! | getblockhash                       | done            |
-//! | getblockheader                     | done            |
-//! | getblockstats                      | done            |
-//! | getchainstates                     | todo            |
-//! | getchaintips                       | done            |
-//! | getchaintxstats                    | done            |
-//! | getdeploymentinfo                  | todo            |
-//! | getdifficulty                      | done            |
-//! | getmempoolancestors                | done (untested) |
-//! | getmempooldescendants              | done (untested) |
-//! | getmempoolentry                    | done            |
-//! | getmempoolinfo                     | done            |
-//! | getrawmempool                      | done            |
-//! | gettxout                           | done            |
-//! | gettxoutproof                      | done            |
-//! | gettxoutsetinfo                    | done            |
-//! | gettxspendingprevout               | todo            |
-//! | importmempool                      | todo            |
-//! | loadtxoutset                       | todo            |
-//! | preciousblock                      | done            |
-//! | pruneblockchain                    | omitted         |
-//! | savemempool                        | omitted         |
-//! | scanblocks                         | todo            |
-//! | scantxoutset                       | omitted         |
-//! | verifychain                        | omitted         |
-//! | verifytxoutproof                   | done            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | dumptxoutset                       | version + model | TODO                                   |
+//! | getbestblockhash                   | version + model |                                        |
+//! | getblock                           | version + model | Includes additional 'verbose' type     |
+//! | getblockchaininfo                  | version + model |                                        |
+//! | getblockcount                      | version + model |                                        |
+//! | getblockfilter                     | version         |                                        |
+//! | getblockfrompeer                   | version + model | TODO                                   |
+//! | getblockhash                       | version + model |                                        |
+//! | getblockheader                     | version + model | Includes additional 'verbose' type     |
+//! | getblockstats                      | version + model |                                        |
+//! | getchainstates                     | version + model | TODO                                   |
+//! | getchaintips                       | version + model |                                        |
+//! | getchaintxstats                    | version + model |                                        |
+//! | getdeploymentinfo                  | version + model | TODO                                   |
+//! | getdifficulty                      | version + model |                                        |
+//! | getmempoolancestors                | version + model | UNTESTED (incl. verbose type)          |
+//! | getmempooldescendants              | version + model | UNTESTED (incl. verbose type)          |
+//! | getmempoolentry                    | version + model |                                        |
+//! | getmempoolinfo                     | version + model |                                        |
+//! | getrawmempool                      | version + model | Includes additional 'verbose' type     |
+//! | gettxout                           | version + model |                                        |
+//! | gettxoutproof                      | returns string  |                                        |
+//! | gettxoutsetinfo                    | version + model |                                        |
+//! | gettxspendingprevout               | version + model | TODO                                   |
+//! | importmempool                      | version + model | TODO                                   |
+//! | loadtxoutset                      | version + model | TODO                                   |
+//! | preciousblock                      | returns nothing |                                        |
+//! | pruneblockchain                    | returns numeric |                                        |
+//! | savemempool                        | returns nothing |                                        |
+//! | scanblocks                         | version + model | TODO                                   |
+//! | scantxoutset                       | omitted         | API marked as experimental             |
+//! | verifychain                        | returns boolean |                                        |
+//! | verifytxoutproof                   | version + model |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Control == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getmemoryinfo                      | done            |
-//! | getrpcinfo                         | done            |
-//! | help                               | done            |
-//! | logging                            | done            |
-//! | stop                               | done            |
-//! | uptime                             | done            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getmemoryinfo                      | version         |                                        |
+//! | getrpcinfo                         | version + model |                                        |
+//! | help                               | returns string  |                                        |
+//! | logging                            | version         |                                        |
+//! | stop                               | returns string  |                                        |
+//! | uptime                             | returns numeric |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Mining == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getblocktemplate                   | done            |
-//! | getmininginfo                      | done            |
-//! | getnetworkhashps                   | done            |
-//! | getprioritisedtransactions         | done            |
-//! | prioritisetransaction              | done            |
-//! | submitblock                        | done (untested) |
-//! | submitheader                       | todo            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getblocktemplate                   | version + model |                                        |
+//! | getmininginfo                      | version         |                                        |
+//! | getnetworkhashps                   | returns boolean |                                        |
+//! | getprioritisedtransactions         | version + model | TODO                                   |
+//! | prioritisetransaction              | returns boolean |                                        |
+//! | submitblock                        | returns nothing |                                        |
+//! | submitheader                       | return nothing  | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Network == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | addnode                            | omitted         |
-//! | clearbanned                        | omitted         |
-//! | disconnectnode                     | omitted         |
-//! | getaddednodeinfo                   | done            |
-//! | getaddrmaninfo                     | todo            |
-//! | getconnectioncount                 | omitted         |
-//! | getnettotals                       | done            |
-//! | getnetworkinfo                     | done            |
-//! | getnodeaddresses                   | todo            |
-//! | getpeerinfo                        | done            |
-//! | listbanned                         | omitted         |
-//! | ping                               | omitted         |
-//! | setban                             | omitted         |
-//! | setnetworkactive                   | omitted         |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | addnode                            | returns nothing |                                        |
+//! | clearbanned                        | returns nothing |                                        |
+//! | disconnectnode                     | returns nothing |                                        |
+//! | getaddednodeinfo                   | version         |                                        |
+//! | getaddrmaninfo                     | version + model | TODO                                   |
+//! | getconnectioncount                 | returns numeric |                                        |
+//! | getnettotals                       | version         |                                        |
+//! | getnetworkinfo                     | version + model |                                        |
+//! | getnodeaddresses                   | version         | TODO                                   |
+//! | getpeerinfo                        | version         |                                        |
+//! | listbanned                         | returns string  |                                        |
+//! | ping                               | returns nothing |                                        |
+//! | setban                             | returns nothing |                                        |
+//! | setnetworkactive                   | returns nothing |                                        |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Rawtransactions == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | analyzepsbt                        | done            |
-//! | combinepsbt                        | done            |
-//! | combinerawtransaction              | done            |
-//! | converttopsbt                      | done            |
-//! | createpsbt                         | done            |
-//! | createrawtransaction               | done            |
-//! | decodepsbt                         | done            |
-//! | decoderawtransaction               | done            |
-//! | decodescript                       | done            |
-//! | descriptorprocesspsbt              | done (untested) |
-//! | finalizepsbt                       | done (untested) |
-//! | fundrawtransaction                 | done            |
-//! | getrawtransaction                  | done            |
-//! | joinpsbts                          | done (untested) |
-//! | sendrawtransaction                 | done            |
-//! | signrawtransactionwithkey          | done            |
-//! | submitpackage                      | done (untested) |
-//! | testmempoolaccept                  | done (untested) |
-//! | utxoupdatepsbt                     | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | analyzepsbt                        | version + model |                                        |
+//! | combinepsbt                        | version + model |                                        |
+//! | combinerawtransaction              | version + model |                                        |
+//! | converttopsbt                      | version + model |                                        |
+//! | createpsbt                         | version + model |                                        |
+//! | createrawtransaction               | version + model |                                        |
+//! | decodepsbt                         | version + model |                                        |
+//! | descriptorprocesspsbt              | returns boolean |                                        |
+//! | decoderawtransaction               | version + model |                                        |
+//! | decodescript                       | version + model |                                        |
+//! | finalizepsbt                       | version + model | UNTESTED                               |
+//! | fundrawtransaction                 | version + model |                                        |
+//! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
+//! | joinpsbts                          | version + model | UNTESTED                               |
+//! | sendrawtransaction                 | version + model |                                        |
+//! | signrawtransactionwithkey          | version + model |                                        |
+//! | submitpackage                      | version + model |                                        |
+//! | testmempoolaccept                  | version + model | UNTESTED                               |
+//! | utxoupdatepsbt                     | version + model | UNTESTED                               |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Signer == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | enumeratesigners                   | todo            |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | enumeratesigners                   | version + model | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Util == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | createmultisig                     | omitted         |
-//! | deriveaddresses                    | todo            |
-//! | estimatesmartfee                   | omitted         |
-//! | getdescriptorinfo                  | todo            |
-//! | getindexinfo                       | todo            |
-//! | signmessagewithprivkey             | omitted         |
-//! | validateaddress                    | omitted         |
-//! | verifymessage                      | omitted         |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | createmultisig                     | version + model | TODO                                   |
+//! | deriveaddresses                    | version + model | TODO                                   |
+//! | estimatesmartfee                   | returns nothing | TODO                                   |
+//! | getdescriptorinfo                  | version         | TODO                                   |
+//! | getindexinfo                       | version         | TODO                                   |
+//! | signmessagewithprivkey             | returns string  | TODO                                   |
+//! | validateaddress                    | version + model | TODO                                   |
+//! | verifymessage                      | returns boolean | TODO                                   |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Wallet == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | abandontransaction                 | omitted         |
-//! | abortrescan                        | omitted         |
-//! | addmultisigaddress                 | done (untested) |
-//! | backupwallet                       | omitted         |
-//! | bumpfee                            | done            |
-//! | createwallet                       | done            |
-//! | createwalletdescriptor             | todo            |
-//! | dumpprivkey                        | done            |
-//! | dumpwallet                         | done            |
-//! | encryptwallet                      | omitted         |
-//! | getaddressesbylabel                | done            |
-//! | getaddressinfo                     | done (untested) |
-//! | getbalance                         | done            |
-//! | getbalances                        | done            |
-//! | gethdkeys                          | todo            |
-//! | getnewaddress                      | done            |
-//! | getrawchangeaddress                | done            |
-//! | getreceivedbyaddress               | done            |
-//! | getreceivedbylabel                 | todo            |
-//! | gettransaction                     | done            |
-//! | getunconfirmedbalance              | done (untested) |
-//! | getwalletinfo                      | done (untested) |
-//! | importaddress                      | omitted         |
-//! | importdescriptors                  | todo            |
-//! | importmulti                        | omitted         |
-//! | importprivkey                      | omitted         |
-//! | importprunedfunds                  | omitted         |
-//! | importpubkey                       | omitted         |
-//! | importwallet                       | omitted         |
-//! | keypoolrefill                      | omitted         |
-//! | listaddressgroupings               | done (untested) |
-//! | listdescriptors                    | todo            |
-//! | listlabels                         | done (untested) |
-//! | listlockunspent                    | done (untested) |
-//! | migratewallet                      | todo            |
-//! | newkeypool                         | todo            |
-//! | psbtbumpfee                        | todo            |
-//! | listreceivedbyaddress              | done (untested) |
-//! | listreceivedbylabel                | todo            |
-//! | listsinceblock                     | done (untested) |
-//! | listtransactions                   | done (untested) |
-//! | listunspent                        | done (untested) |
-//! | listwalletdir                      | todo            |
-//! | listwallets                        | done (untested) |
-//! | loadwallet                         | done            |
-//! | lockunspent                        | omitted         |
-//! | removeprunedfunds                  | omitted         |
-//! | rescanblockchain                   | done (untested) |
-//! | restorewallet                      | todo            |
-//! | send                               | todo            |
-//! | sendall                            | todo            |
-//! | sendmany                           | done (untested) |
-//! | sendtoaddress                      | done            |
-//! | sethdseed                          | omitted         |
-//! | setlabel                           | todo            |
-//! | settxfee                           | omitted         |
-//! | setwalletflag                      | todo            |
-//! | signmessage                        | done (untested) |
-//! | signrawtransactionwithwallet       | done (untested) |
-//! | simulaterawtransaction             | todo            |
-//! | unloadwallet                       | done            |
-//! | upgradewallet                      | todo            |
-//! | walletcreatefundedpsbt             | done (untested) |
-//! | walletdisplayaddress               | todo            |
-//! | walletlock                         | omitted         |
-//! | walletpassphrase                   | omitted         |
-//! | walletpassphrasechange             | omitted         |
-//! | walletprocesspsbt                  | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | abandontransaction                 | returns nothing |                                        |
+//! | abortrescan                        | returns nothing |                                        |
+//! | addmultisigaddress                 | version + model | UNTESTED                               |
+//! | backupwallet                       | returns nothing |                                        |
+//! | bumpfee                            | version + model |                                        |
+//! | createwallet                       | version + model |                                        |
+//! | createwalletdescriptor             | version + model | TODO                                   |
+//! | dumpprivkey                        | version + model |                                        |
+//! | dumpwallet                         | version + model |                                        |
+//! | encryptwallet                      | returns nothing |                                        |
+//! | getaddressesbylabel                | version + model |                                        |
+//! | getaddressinfo                     | version + model | UNTESTED                               |
+//! | getbalance                         | version + model |                                        |
+//! | getbalances                        | version + model |                                        |
+//! | gethdkeys                          | version + model | TODO                                   |
+//! | getnewaddress                      | version + model |                                        |
+//! | getrawchangeaddress                | version + model |                                        |
+//! | getreceivedbyaddress               | version + model | TODO                                   |
+//! | getreceivedbylabel                 | version + model | TODO                                   |
+//! | gettransaction                     | version + model |                                        |
+//! | getunconfirmedbalance              | version + model | UNTESTED                               |
+//! | getwalletinfo                      | version + model | UNTESTED                               |
+//! | importaddress                      | returns nothing |                                        |
+//! | importdescriptors                  | version         | TODO                                   |
+//! | importmulti                        | returns nothing |                                        |
+//! | importprivkey                      | returns nothing |                                        |
+//! | importprunedfunds                  | returns nothing |                                        |
+//! | importpubkey                       | returns nothing |                                        |
+//! | importwallet                       | returns nothing |                                        |
+//! | keypoolrefill                      | returns nothing |                                        |
+//! | listaddressgroupings               | version + model | UNTESTED                               |
+//! | listdescriptors                    | version + model | TODO                                   |
+//! | listlabels                         | version + model | UNTESTED                               |
+//! | listlockunspent                    | version + model | UNTESTED                               |
+//! | migratewallet                      | version + model | TODO                                   |
+//! | newkeypool                         | version + model | TODO                                   |
+//! | psbtbumpfee                        | version + model | TODO                                   |
+//! | listreceivedbyaddress              | version + model | UNTESTED                               |
+//! | listreceivedbylabel                | version + model | TODO                                   |
+//! | listsinceblock                     | version + model | UNTESTED                               |
+//! | listtransactions                   | version + model | UNTESTED                               |
+//! | listunspent                        | version + model | UNTESTED                               |
+//! | listwalletdir                      | version         | TODO                                   |
+//! | listwallets                        | version + model | UNTESTED                               |
+//! | loadwallet                         | version + model |                                        |
+//! | lockunspent                        | returns boolean |                                        |
+//! | removeprunedfunds                  | returns nothing |                                        |
+//! | rescanblockchain                   | version + model | UNTESTED                               |
+//! | restorewallet                      | version + model | TODO                                   |
+//! | send                               | version + model | TODO                                   |
+//! | sendall                            | version + model | TODO                                   |
+//! | sendmany                           | version + model | UNTESTED                               |
+//! | sendtoaddress                      | version + model |                                        |
+//! | sethdseed                          | returns nothing |                                        |
+//! | setlabel                           | returns nothing |                                        |
+//! | settxfee                           | returns boolean |                                        |
+//! | setwalletflag                      | version         | TODO                                   |
+//! | signmessage                        | version + model | UNTESTED                               |
+//! | signrawtransactionwithwallet       | version + model |                                        |
+//! | simulaterawtransaction             | version + model | TODO                                   |
+//! | unloadwallet                       | returns nothing |                                        |
+//! | upgradewallet                      | version         | TODO                                   |
+//! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
+//! | walletdisplayaddress               | version + model | TODO                                   |
+//! | walletlock                         | returns nothing |                                        |
+//! | walletpassphrase                   | returns nothing |                                        |
+//! | walletpassphrasechange             | returns nothing |                                        |
+//! | walletprocesspsbt                  | version + model | UNTESTED                               |
 //!
 //! </details>
 //!
 //! <details>
 //! <summary> Methods from the == Zmq == section </summary>
 //!
-//! | JSON-PRC Method Name               | Status          |
-//! |:-----------------------------------|:---------------:|
-//! | getzmqnotifications                | done (untested) |
+//! | JSON-PRC Method Name               | Returns         | Notes                                  |
+//! |:-----------------------------------|:---------------:|:--------------------------------------:|
+//! | getzmqnotifications                | version         | UNTESTED                               |
 //!
 //! </details>
 


### PR DESCRIPTION
The module docs in each version specific module (e.g. `types::v17`) are supposed to be the single source of truth for devs trying to work out which methods are supported and how.

Make an effort to better present the information.

Note that a bunch docs for methods marked as TODO may be incorrect re version vs version + model. This doesn't matter right now since they will be checked when implemented and also TODO implies no guarantees (in my mind anyway).

Note also issue #144. `verify` does not check the Returns column against the `Method` constructor type.

Close: #109
