### PR TITLE
node: Bump version to 0.7.1

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-node"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-node"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -51,7 +51,7 @@ TODO = []                       # This is a dirty hack while writing the tests.
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false, features = ["std", "serde"] }
 client = { package = "corepc-client", version = "0.7.0", default-features = false, features = ["client-sync"] }
-node = { package = "corepc-node", version = "0.7.0", default-features = false, features = ["download"] }
+node = { package = "corepc-node", version = "0.7.1", default-features = false, features = ["download"] }
 rand = "0.8.5"
 env_logger = "0.9.0"
 

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.7.1 2025-05-05
+
+- backport: bump zip in light of RUSTSEC-2020-0071 [#145](https://github.com/rust-bitcoin/corepc/pull/145)
+
 # 0.7.0 2025-04-04
 
 - Retry initial client connections [#111](https://github.com/rust-bitcoin/corepc/pull/111)

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-node"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Riccardo Casatta <riccardo@casatta.it>", "Tobin C. Harding <me@tobin.cc>"]
 license = "MIT"
 repository = "https://github.com/rust-bitcoin/corepc"


### PR DESCRIPTION
In preparation for release bump the version, add a changelog entry, and update the lock files.

Release contains a single security patch.