### PR TITLE
node: Copy point release notes

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.7.1 2025-05-05
+
+- backport: bump zip in light of RUSTSEC-2020-0071 [#145](https://github.com/rust-bitcoin/corepc/pull/145)
+
 # 0.7.0 2025-04-04
 
 - Retry initial client connections [#111](https://github.com/rust-bitcoin/corepc/pull/111)


### PR DESCRIPTION
We just did a point release. Copy the release notes to master (and pat myself on the back for remembering).