### PR TITLE
Move TemplateRequest and TemplateRules into their proper module

### DIFF
--- a/client/src/client_sync/mod.rs
+++ b/client/src/client_sync/mod.rs
@@ -259,24 +259,3 @@ pub struct WalletCreateFundedPsbtInput {
     txid: Txid,
     vout: u32,
 }
-
-/// Arg for the `getblocktemplate` method.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-pub struct TemplateRequest {
-    /// A list of strings.
-    pub rules: Vec<TemplateRules>,
-}
-
-/// Client side supported softfork deployment.
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "lowercase")]
-pub enum TemplateRules {
-    /// SegWit v0 supported.
-    Segwit,
-    /// Signet supported.
-    Signet,
-    /// CSV supported.
-    Csv,
-    /// Taproot supported.
-    Taproot,
-}

--- a/client/src/client_sync/v17/mining.rs
+++ b/client/src/client_sync/v17/mining.rs
@@ -16,7 +16,7 @@ macro_rules! impl_client_v17__getblocktemplate {
         impl Client {
             pub fn get_block_template(
                 &self,
-                request: &$crate::client_sync::TemplateRequest,
+                request: &TemplateRequest,
             ) -> Result<GetBlockTemplate> {
                 self.call("getblocktemplate", &[into_json(request)?])
             }

--- a/client/src/client_sync/v17/mod.rs
+++ b/client/src/client_sync/v17/mod.rs
@@ -149,3 +149,26 @@ impl fmt::Display for AddressType {
         fmt::Display::fmt(s, f)
     }
 }
+
+/// Arg for the `getblocktemplate` method.
+///
+/// For Core versions 0.17 through to v28. For Core v29 and onwards use `v29::TemplateRequest`.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct TemplateRequest {
+    /// A list of strings.
+    pub rules: Vec<TemplateRules>,
+}
+
+/// Client side supported softfork deployment.
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TemplateRules {
+    /// SegWit v0 supported.
+    Segwit,
+    /// Signet supported.
+    Signet,
+    /// CSV supported.
+    Csv,
+    /// Taproot supported.
+    Taproot,
+}

--- a/client/src/client_sync/v18/mod.rs
+++ b/client/src/client_sync/v18/mod.rs
@@ -17,7 +17,10 @@ use crate::client_sync::into_json;
 use crate::types::v18::*;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
-pub use crate::client_sync::{v17::AddressType, WalletCreateFundedPsbtInput};
+pub use crate::client_sync::{
+    v17::{AddressType, TemplateRequest, TemplateRules},
+    WalletCreateFundedPsbtInput
+};
 
 crate::define_jsonrpc_minreq_client!("v18");
 crate::impl_client_check_expected_server_version!({ [180100] });

--- a/client/src/client_sync/v19/mod.rs
+++ b/client/src/client_sync/v19/mod.rs
@@ -17,7 +17,10 @@ use crate::client_sync::into_json;
 use crate::types::v19::*;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
-pub use crate::client_sync::{v17::AddressType, WalletCreateFundedPsbtInput};
+pub use crate::client_sync::{
+    v17::{AddressType, TemplateRequest, TemplateRules},
+    WalletCreateFundedPsbtInput
+};
 
 crate::define_jsonrpc_minreq_client!("v19");
 crate::impl_client_check_expected_server_version!({ [190100] });

--- a/client/src/client_sync/v20.rs
+++ b/client/src/client_sync/v20.rs
@@ -14,7 +14,10 @@ use crate::client_sync::into_json;
 use crate::types::v20::*;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
-pub use crate::client_sync::{v17::AddressType, WalletCreateFundedPsbtInput};
+pub use crate::client_sync::{
+    v17::{AddressType, TemplateRequest, TemplateRules},
+    WalletCreateFundedPsbtInput
+};
 
 crate::define_jsonrpc_minreq_client!("v20");
 crate::impl_client_check_expected_server_version!({ [200200] });

--- a/client/src/client_sync/v21/mod.rs
+++ b/client/src/client_sync/v21/mod.rs
@@ -16,7 +16,10 @@ use crate::client_sync::into_json;
 use crate::types::v21::*;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
-pub use crate::client_sync::{v17::AddressType, WalletCreateFundedPsbtInput};
+pub use crate::client_sync::{
+    v17::{AddressType, TemplateRequest, TemplateRules},
+    WalletCreateFundedPsbtInput
+};
 
 crate::define_jsonrpc_minreq_client!("v21");
 crate::impl_client_check_expected_server_version!({ [210200] });

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -17,7 +17,10 @@ use crate::client_sync::into_json;
 use crate::types::v22::*;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
-pub use crate::client_sync::{v17::AddressType, WalletCreateFundedPsbtInput};
+pub use crate::client_sync::{
+    v17::{AddressType, TemplateRequest, TemplateRules},
+    WalletCreateFundedPsbtInput
+};
 
 crate::define_jsonrpc_minreq_client!("v22");
 crate::impl_client_check_expected_server_version!({ [220100] });

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -17,7 +17,10 @@ use crate::client_sync::into_json;
 use crate::types::v23::*;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
-pub use crate::client_sync::WalletCreateFundedPsbtInput;
+pub use crate::client_sync::{
+    v17::{TemplateRequest, TemplateRules},
+    WalletCreateFundedPsbtInput
+};
 
 crate::define_jsonrpc_minreq_client!("v23");
 crate::impl_client_check_expected_server_version!({ [230200] });

--- a/client/src/client_sync/v24.rs
+++ b/client/src/client_sync/v24.rs
@@ -14,7 +14,10 @@ use crate::client_sync::into_json;
 use crate::types::v24::*;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
-pub use crate::client_sync::{v23::AddressType, WalletCreateFundedPsbtInput};
+pub use crate::client_sync::{
+    v17::{TemplateRequest, TemplateRules},
+    v23::AddressType, WalletCreateFundedPsbtInput
+};
 
 crate::define_jsonrpc_minreq_client!("v24");
 crate::impl_client_check_expected_server_version!({ [240200] });

--- a/client/src/client_sync/v25.rs
+++ b/client/src/client_sync/v25.rs
@@ -14,7 +14,10 @@ use crate::client_sync::into_json;
 use crate::types::v25::*;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
-pub use crate::client_sync::{v23::AddressType, WalletCreateFundedPsbtInput};
+pub use crate::client_sync::{
+    v17::{TemplateRequest, TemplateRules},
+    v23::AddressType, WalletCreateFundedPsbtInput
+};
 
 crate::define_jsonrpc_minreq_client!("v25");
 crate::impl_client_check_expected_server_version!({ [250200] });

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -18,7 +18,11 @@ use crate::client_sync::into_json;
 use crate::types::v26::*;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
-pub use crate::client_sync::{v23::AddressType, WalletCreateFundedPsbtInput};
+pub use crate::client_sync::{
+    v17::{TemplateRequest, TemplateRules},
+    v23::AddressType,
+    WalletCreateFundedPsbtInput
+};
 
 crate::define_jsonrpc_minreq_client!("v26");
 crate::impl_client_check_expected_server_version!({ [260000, 260100, 260200] });

--- a/client/src/client_sync/v27.rs
+++ b/client/src/client_sync/v27.rs
@@ -14,7 +14,10 @@ use crate::client_sync::into_json;
 use crate::types::v27::*;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
-pub use crate::client_sync::{v23::AddressType, WalletCreateFundedPsbtInput};
+pub use crate::client_sync::{
+    v17::{TemplateRequest, TemplateRules},
+    v23::AddressType, WalletCreateFundedPsbtInput
+};
 
 crate::define_jsonrpc_minreq_client!("v27");
 crate::impl_client_check_expected_server_version!({ [270000, 270100, 270200] });

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -16,7 +16,11 @@ use crate::client_sync::into_json;
 use crate::types::v28::*;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
-pub use crate::client_sync::{v23::AddressType, WalletCreateFundedPsbtInput};
+pub use crate::client_sync::{
+    v17::{TemplateRequest, TemplateRules},
+    v23::AddressType,
+    WalletCreateFundedPsbtInput
+};
 
 crate::define_jsonrpc_minreq_client!("v28");
 crate::impl_client_check_expected_server_version!({ [280000] });

--- a/integration_test/tests/mining.rs
+++ b/integration_test/tests/mining.rs
@@ -6,7 +6,7 @@
 
 use bitcoin::SignedAmount;
 use integration_test::{Node, NodeExt as _, Wallet};
-use node::client::client_sync::{TemplateRequest, TemplateRules};
+use node::{TemplateRequest, TemplateRules};
 use node::vtype::*;             // All the version specific types.
 use node::mtype;
 

--- a/node/src/client_versions.rs
+++ b/node/src/client_versions.rs
@@ -7,52 +7,52 @@
 #![allow(unused_imports)] // Not all users need the json types.
 
 #[cfg(feature = "28_0")]
-pub use corepc_client::{client_sync::v28::{Client, AddressType}, types::v28 as vtype};
+pub use corepc_client::{client_sync::v28::{Client, AddressType, TemplateRequest, TemplateRules}, types::v28 as vtype};
 
 #[cfg(all(feature = "27_2", not(feature = "28_0")))]
-pub use corepc_client::{client_sync::v27::{Client, AddressType}, types::v27 as vtype};
+pub use corepc_client::{client_sync::v27::{Client, AddressType, TemplateRequest, TemplateRules}, types::v27 as vtype};
 
 #[cfg(all(feature = "27_1", not(feature = "27_2")))]
-pub use corepc_client::{client_sync::v27::{Client, AddressType}, types::v27 as vtype};
+pub use corepc_client::{client_sync::v27::{Client, AddressType, TemplateRequest, TemplateRules}, types::v27 as vtype};
 
 #[cfg(all(feature = "27_0", not(feature = "27_1")))]
-pub use corepc_client::{client_sync::v27::{Client, AddressType}, types::v27 as vtype};
+pub use corepc_client::{client_sync::v27::{Client, AddressType, TemplateRequest, TemplateRules}, types::v27 as vtype};
 
 #[cfg(all(feature = "26_2", not(feature = "27_0")))]
-pub use corepc_client::{client_sync::v26::{Client, AddressType}, types::v26 as vtype};
+pub use corepc_client::{client_sync::v26::{Client, AddressType, TemplateRequest, TemplateRules}, types::v26 as vtype};
 
 #[cfg(all(feature = "26_1", not(feature = "26_2")))]
-pub use corepc_client::{client_sync::v26::{Client, AddressType}, types::v26 as vtype};
+pub use corepc_client::{client_sync::v26::{Client, AddressType, TemplateRequest, TemplateRules}, types::v26 as vtype};
 
 #[cfg(all(feature = "26_0", not(feature = "26_1")))]
-pub use corepc_client::{client_sync::v26::{Client, AddressType}, types::v26 as vtype};
+pub use corepc_client::{client_sync::v26::{Client, AddressType, TemplateRequest, TemplateRules}, types::v26 as vtype};
 
 #[cfg(all(feature = "25_2", not(feature = "26_0")))]
-pub use corepc_client::{client_sync::v25::{Client, AddressType}, types::v25 as vtype};
+pub use corepc_client::{client_sync::v25::{Client, AddressType, TemplateRequest, TemplateRules}, types::v25 as vtype};
 
 #[cfg(all(feature = "24_2", not(feature = "25_2")))]
-pub use corepc_client::{client_sync::v24::{Client, AddressType}, types::v24 as vtype};
+pub use corepc_client::{client_sync::v24::{Client, AddressType, TemplateRequest, TemplateRules}, types::v24 as vtype};
 
 #[cfg(all(feature = "23_2", not(feature = "24_2")))]
-pub use corepc_client::{client_sync::v23::{Client, AddressType}, types::v23 as vtype};
+pub use corepc_client::{client_sync::v23::{Client, AddressType, TemplateRequest, TemplateRules}, types::v23 as vtype};
 
 #[cfg(all(feature = "22_1", not(feature = "23_2")))]
-pub use corepc_client::{client_sync::v22::{Client, AddressType}, types::v22 as vtype};
+pub use corepc_client::{client_sync::v22::{Client, AddressType, TemplateRequest, TemplateRules}, types::v22 as vtype};
 
 #[cfg(all(feature = "0_21_2", not(feature = "22_1")))]
-pub use corepc_client::{client_sync::v21::{Client, AddressType}, types::v21 as vtype};
+pub use corepc_client::{client_sync::v21::{Client, AddressType, TemplateRequest, TemplateRules}, types::v21 as vtype};
 
 #[cfg(all(feature = "0_20_2", not(feature = "0_21_2")))]
-pub use corepc_client::{client_sync::v20::{Client, AddressType}, types::v20 as vtype};
+pub use corepc_client::{client_sync::v20::{Client, AddressType, TemplateRequest, TemplateRules}, types::v20 as vtype};
 
 #[cfg(all(feature = "0_19_1", not(feature = "0_20_2")))]
-pub use corepc_client::{client_sync::v19::{Client, AddressType}, types::v19 as vtype};
+pub use corepc_client::{client_sync::v19::{Client, AddressType, TemplateRequest, TemplateRules}, types::v19 as vtype};
 
 #[cfg(all(feature = "0_18_1", not(feature = "0_19_1")))]
-pub use corepc_client::{client_sync::v18::{Client, AddressType}, types::v18 as vtype};
+pub use corepc_client::{client_sync::v18::{Client, AddressType, TemplateRequest, TemplateRules}, types::v18 as vtype};
 
 #[cfg(all(feature = "0_17_2", not(feature = "0_18_1")))]
-pub use corepc_client::{client_sync::v17::{Client, AddressType}, types::v17 as vtype};
+pub use corepc_client::{client_sync::v17::{Client, AddressType, TemplateRequest, TemplateRules}, types::v17 as vtype};
 
 /// This is meaningless but we need it otherwise we can't get far enough into
 /// the build process to trigger the `compile_error!` in `./versions.rs`.
@@ -74,4 +74,4 @@ pub use corepc_client::{client_sync::v17::{Client, AddressType}, types::v17 as v
     not(feature = "0_18_1"),
     not(feature = "0_17_2"),
 ))]
-pub use corepc_client::{client_sync::v28::{Client, AddressType}, types::v28 as vtype};
+pub use corepc_client::{client_sync::v28::{Client, AddressType, TemplateRequest, TemplateRules}, types::v28 as vtype};

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -24,7 +24,7 @@ pub use {anyhow, serde_json, tempfile, which};
 #[doc(inline)]
 pub use self::{
     // Re-export `vtype` - the version specific types.
-    client_versions::{vtype, Client, AddressType},
+    client_versions::{vtype, Client, AddressType, TemplateRequest, TemplateRules},
     // Re-export the version string e.g., "28.0".
     versions::VERSION,
     // Re-export the model types as `mtype` to differentiate it from `vtype`.


### PR DESCRIPTION
This pull request moves the `TemplateRequest` struct and `TemplateRules` enum, into their appropriate module to improve code organization and maintainability.
