### PR TITLE
Implement getnodeaddresses method and test

### DIFF
--- a/client/src/client_sync/v18/mod.rs
+++ b/client/src/client_sync/v18/mod.rs
@@ -5,6 +5,7 @@
 //! We ignore option arguments unless they effect the shape of the returned JSON data.
 
 pub mod control;
+pub mod network;
 pub mod raw_transactions;
 
 use std::collections::BTreeMap;
@@ -74,6 +75,7 @@ crate::impl_client_v17__submitblock!();
 crate::impl_client_v17__getaddednodeinfo!();
 crate::impl_client_v17__getnettotals!();
 crate::impl_client_v17__getnetworkinfo!();
+crate::impl_client_v18__getnodeaddresses!();
 crate::impl_client_v17__getpeerinfo!();
 
 // == Rawtransactions ==

--- a/client/src/client_sync/v18/network.rs
+++ b/client/src/client_sync/v18/network.rs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Macros for implementing JSON-RPC methods on a client.
+//!
+//! Requires `Client` to be in scope.
+//!
+//! Specifically this is methods found under the `== Network ==` section of the
+//! API docs of Bitcoin Core `v0.18`.
+//!
+//! See, or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
+
+/// Implements Bitcoin Core JSON-RPC API method `getnodeaddresses`
+#[macro_export]
+macro_rules! impl_client_v18__getnodeaddresses {
+    () => {
+        impl Client {
+            pub fn get_node_addresses(&self) -> Result<GetNodeAddresses> {
+                self.call("getnodeaddresses", &[])
+            }
+        }
+    };
+}

--- a/client/src/client_sync/v19/mod.rs
+++ b/client/src/client_sync/v19/mod.rs
@@ -73,6 +73,7 @@ crate::impl_client_v17__submitblock!();
 crate::impl_client_v17__getaddednodeinfo!();
 crate::impl_client_v17__getnettotals!();
 crate::impl_client_v17__getnetworkinfo!();
+crate::impl_client_v18__getnodeaddresses!();
 crate::impl_client_v17__getpeerinfo!();
 
 // == Rawtransactions ==

--- a/client/src/client_sync/v20.rs
+++ b/client/src/client_sync/v20.rs
@@ -70,6 +70,7 @@ crate::impl_client_v17__submitblock!();
 crate::impl_client_v17__getaddednodeinfo!();
 crate::impl_client_v17__getnettotals!();
 crate::impl_client_v17__getnetworkinfo!();
+crate::impl_client_v18__getnodeaddresses!();
 crate::impl_client_v17__getpeerinfo!();
 
 // == Rawtransactions ==

--- a/client/src/client_sync/v21/mod.rs
+++ b/client/src/client_sync/v21/mod.rs
@@ -72,6 +72,7 @@ crate::impl_client_v17__submitblock!();
 crate::impl_client_v17__getaddednodeinfo!();
 crate::impl_client_v17__getnettotals!();
 crate::impl_client_v17__getnetworkinfo!();
+crate::impl_client_v18__getnodeaddresses!();
 crate::impl_client_v17__getpeerinfo!();
 
 // == Rawtransactions ==

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -73,6 +73,7 @@ crate::impl_client_v17__submitblock!();
 crate::impl_client_v17__getaddednodeinfo!();
 crate::impl_client_v17__getnettotals!();
 crate::impl_client_v17__getnetworkinfo!();
+crate::impl_client_v18__getnodeaddresses!();
 crate::impl_client_v17__getpeerinfo!();
 
 // == Rawtransactions ==

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -74,6 +74,7 @@ crate::impl_client_v17__submitblock!();
 crate::impl_client_v17__getaddednodeinfo!();
 crate::impl_client_v17__getnettotals!();
 crate::impl_client_v17__getnetworkinfo!();
+crate::impl_client_v18__getnodeaddresses!();
 crate::impl_client_v17__getpeerinfo!();
 
 // == Rawtransactions ==

--- a/client/src/client_sync/v24.rs
+++ b/client/src/client_sync/v24.rs
@@ -71,6 +71,7 @@ crate::impl_client_v17__submitblock!();
 crate::impl_client_v17__getaddednodeinfo!();
 crate::impl_client_v17__getnettotals!();
 crate::impl_client_v17__getnetworkinfo!();
+crate::impl_client_v18__getnodeaddresses!();
 crate::impl_client_v17__getpeerinfo!();
 
 // == Rawtransactions ==

--- a/client/src/client_sync/v25.rs
+++ b/client/src/client_sync/v25.rs
@@ -71,6 +71,7 @@ crate::impl_client_v17__submitblock!();
 crate::impl_client_v17__getaddednodeinfo!();
 crate::impl_client_v17__getnettotals!();
 crate::impl_client_v17__getnetworkinfo!();
+crate::impl_client_v18__getnodeaddresses!();
 crate::impl_client_v17__getpeerinfo!();
 
 // == Rawtransactions ==

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -76,6 +76,7 @@ crate::impl_client_v17__submitblock!();
 crate::impl_client_v17__getaddednodeinfo!();
 crate::impl_client_v17__getnettotals!();
 crate::impl_client_v17__getnetworkinfo!();
+crate::impl_client_v18__getnodeaddresses!();
 crate::impl_client_v17__getpeerinfo!();
 
 // == Rawtransactions ==

--- a/client/src/client_sync/v27.rs
+++ b/client/src/client_sync/v27.rs
@@ -72,6 +72,7 @@ crate::impl_client_v17__submitblock!();
 crate::impl_client_v17__getaddednodeinfo!();
 crate::impl_client_v17__getnettotals!();
 crate::impl_client_v17__getnetworkinfo!();
+crate::impl_client_v18__getnodeaddresses!();
 crate::impl_client_v17__getpeerinfo!();
 
 // == Rawtransactions ==

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -74,6 +74,7 @@ crate::impl_client_v17__submitblock!();
 crate::impl_client_v17__getaddednodeinfo!();
 crate::impl_client_v17__getnettotals!();
 crate::impl_client_v17__getnetworkinfo!();
+crate::impl_client_v18__getnodeaddresses!();
 crate::impl_client_v17__getpeerinfo!();
 
 // == Rawtransactions ==

--- a/integration_test/tests/network.rs
+++ b/integration_test/tests/network.rs
@@ -32,6 +32,20 @@ fn network__get_network_info__modelled() {
 }
 
 #[test]
+// Core version 18 onwards.
+#[cfg(not(feature = "v17"))]
+fn network__get_node_addresses() {
+    let node = Node::with_wallet(Wallet::None, &[]);
+    let json: GetNodeAddresses = node.client.get_node_addresses().expect("getnodeaddresses");
+    assert!(json.0.len() <= 2500);
+    if let Some(addr) = json.0.first() {
+        assert!(addr.port > 0);
+        assert!(!addr.address.is_empty());
+        assert!(addr.time > 1231006505);
+    }
+}
+
+#[test]
 fn network__get_peer_info() {
     get_peer_info_one_node_network();
     get_peer_info_three_node_network();

--- a/types/src/v18/mod.rs
+++ b/types/src/v18/mod.rs
@@ -103,7 +103,7 @@
 //! | getconnectioncount                 | returns numeric |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
-//! | getnodeaddresses                   | version         | TODO                                   |
+//! | getnodeaddresses                   | version         |                                        |
 //! | getpeerinfo                        | version         |                                        |
 //! | listbanned                         | returns string  |                                        |
 //! | ping                               | returns nothing |                                        |
@@ -224,11 +224,13 @@
 
 // JSON-RPC types by API section.
 mod control;
+mod network;
 mod raw_transactions;
 
 #[doc(inline)]
 pub use self::{
     control::{ActiveCommand, GetRpcInfo},
+    network::{GetNodeAddresses, NodeAddress},
     raw_transactions::{
         AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
         AnalyzePsbtInputMissingError, JoinPsbts, UtxoUpdatePsbt,

--- a/types/src/v18/network/mod.rs
+++ b/types/src/v18/network/mod.rs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! The JSON-RPC API for Bitcoin Core `v0.18` - network.
+//!
+//! Types for methods found under the `== Network ==` section of the API docs.
+
+use serde::{Deserialize, Serialize};
+
+/// Result of JSON-RPC method `getnodeaddresses`.
+///
+/// > getnodeaddresses ( count )
+/// >
+/// > Return known addresses which can potentially be used to find new nodes in the network.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct GetNodeAddresses(pub Vec<NodeAddress>);
+
+/// An item from the list returned by the JSON-RPC method `getnodeaddresses`.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct NodeAddress {
+    /// Timestamp in seconds since epoch (Jan 1 1970 GMT) when the node was last seen.
+    pub time: u64,
+    /// The services offered.
+    pub services: u64,
+    /// The address of the node.
+    pub address: String,
+    /// The port of the node.
+    pub port: u16,
+}

--- a/types/src/v19/mod.rs
+++ b/types/src/v19/mod.rs
@@ -103,7 +103,7 @@
 //! | getconnectioncount                 | returns numeric |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
-//! | getnodeaddresses                   | version         | TODO                                   |
+//! | getnodeaddresses                   | version         |                                        |
 //! | getpeerinfo                        | version         |                                        |
 //! | listbanned                         | returns string  |                                        |
 //! | ping                               | returns nothing |                                        |
@@ -275,4 +275,5 @@ pub use crate::v17::{
 pub use crate::v18::{
     ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
     AnalyzePsbtInputMissingError, GetRpcInfo, JoinPsbts, UtxoUpdatePsbt,
+    GetNodeAddresses, NodeAddress,
 };

--- a/types/src/v19/mod.rs
+++ b/types/src/v19/mod.rs
@@ -274,6 +274,6 @@ pub use crate::v17::{
 #[doc(inline)]
 pub use crate::v18::{
     ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
-    AnalyzePsbtInputMissingError, GetRpcInfo, JoinPsbts, UtxoUpdatePsbt,
-    GetNodeAddresses, NodeAddress,
+    AnalyzePsbtInputMissingError, GetNodeAddresses, GetRpcInfo, JoinPsbts, NodeAddress,
+    UtxoUpdatePsbt,
 };

--- a/types/src/v20/mod.rs
+++ b/types/src/v20/mod.rs
@@ -104,7 +104,7 @@
 //! | getconnectioncount                 | returns numeric |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
-//! | getnodeaddresses                   | version         | TODO                                   |
+//! | getnodeaddresses                   | version         |                                        |
 //! | getpeerinfo                        | version         |                                        |
 //! | listbanned                         | returns string  |                                        |
 //! | ping                               | returns nothing |                                        |
@@ -267,6 +267,7 @@ pub use crate::{
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
         AnalyzePsbtInputMissingError, GetRpcInfo, JoinPsbts, UtxoUpdatePsbt,
+        GetNodeAddresses, NodeAddress,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,

--- a/types/src/v20/mod.rs
+++ b/types/src/v20/mod.rs
@@ -266,8 +266,8 @@ pub use crate::{
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
-        AnalyzePsbtInputMissingError, GetRpcInfo, JoinPsbts, UtxoUpdatePsbt,
-        GetNodeAddresses, NodeAddress,
+        AnalyzePsbtInputMissingError, GetNodeAddresses, GetRpcInfo, JoinPsbts, NodeAddress,
+        UtxoUpdatePsbt,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,

--- a/types/src/v21/mod.rs
+++ b/types/src/v21/mod.rs
@@ -272,8 +272,8 @@ pub use crate::{
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
-        AnalyzePsbtInputMissingError, GetRpcInfo, JoinPsbts, UtxoUpdatePsbt,
-        GetNodeAddresses, NodeAddress,
+        AnalyzePsbtInputMissingError, GetNodeAddresses, GetRpcInfo, JoinPsbts, NodeAddress,
+        UtxoUpdatePsbt,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,

--- a/types/src/v21/mod.rs
+++ b/types/src/v21/mod.rs
@@ -105,7 +105,7 @@
 //! | getconnectioncount                 | returns numeric |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
-//! | getnodeaddresses                   | version         | TODO                                   |
+//! | getnodeaddresses                   | version         |                                        |
 //! | getpeerinfo                        | version         |                                        |
 //! | listbanned                         | returns string  |                                        |
 //! | ping                               | returns nothing |                                        |
@@ -273,6 +273,7 @@ pub use crate::{
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
         AnalyzePsbtInputMissingError, GetRpcInfo, JoinPsbts, UtxoUpdatePsbt,
+        GetNodeAddresses, NodeAddress,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -286,8 +286,8 @@ pub use crate::{
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
-        AnalyzePsbtInputMissingError, GetRpcInfo, JoinPsbts, UtxoUpdatePsbt,
-        GetNodeAddresses, NodeAddress,
+        AnalyzePsbtInputMissingError, GetNodeAddresses, GetRpcInfo, JoinPsbts, NodeAddress,
+        UtxoUpdatePsbt,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -105,7 +105,7 @@
 //! | getconnectioncount                 | returns numeric |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
-//! | getnodeaddresses                   | version         | TODO                                   |
+//! | getnodeaddresses                   | version         |                                        |
 //! | getpeerinfo                        | version         |                                        |
 //! | listbanned                         | returns string  |                                        |
 //! | ping                               | returns nothing |                                        |
@@ -287,6 +287,7 @@ pub use crate::{
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
         AnalyzePsbtInputMissingError, GetRpcInfo, JoinPsbts, UtxoUpdatePsbt,
+        GetNodeAddresses, NodeAddress,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -281,8 +281,8 @@ pub use crate::{
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
-        AnalyzePsbtInputMissingError, GetRpcInfo, JoinPsbts, UtxoUpdatePsbt,
-        GetNodeAddresses, NodeAddress,
+        AnalyzePsbtInputMissingError, GetNodeAddresses, GetRpcInfo, JoinPsbts, NodeAddress,
+        UtxoUpdatePsbt,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -96,7 +96,7 @@
 //! | getconnectioncount                 | returns numeric |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
-//! | getnodeaddresses                   | version         | TODO                                   |
+//! | getnodeaddresses                   | version         |                                        |
 //! | getpeerinfo                        | version         |                                        |
 //! | listbanned                         | returns string  |                                        |
 //! | ping                               | returns nothing |                                        |
@@ -282,6 +282,7 @@ pub use crate::{
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
         AnalyzePsbtInputMissingError, GetRpcInfo, JoinPsbts, UtxoUpdatePsbt,
+        GetNodeAddresses, NodeAddress,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -282,8 +282,8 @@ pub use crate::{
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
-        AnalyzePsbtInputMissingError, GetRpcInfo, JoinPsbts, UtxoUpdatePsbt,
-        GetNodeAddresses, NodeAddress,
+        AnalyzePsbtInputMissingError, GetNodeAddresses, GetRpcInfo, JoinPsbts, NodeAddress,
+        UtxoUpdatePsbt,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -97,7 +97,7 @@
 //! | getconnectioncount                 | returns numeric |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
-//! | getnodeaddresses                   | version         | TODO                                   |
+//! | getnodeaddresses                   | version         |                                        |
 //! | getpeerinfo                        | version         |                                        |
 //! | listbanned                         | returns string  |                                        |
 //! | ping                               | returns nothing |                                        |
@@ -283,6 +283,7 @@ pub use crate::{
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
         AnalyzePsbtInputMissingError, GetRpcInfo, JoinPsbts, UtxoUpdatePsbt,
+        GetNodeAddresses, NodeAddress,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -98,7 +98,7 @@
 //! | getconnectioncount                 | returns numeric |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
-//! | getnodeaddresses                   | version         | TODO                                   |
+//! | getnodeaddresses                   | version         |                                        |
 //! | getpeerinfo                        | version         |                                        |
 //! | listbanned                         | returns string  |                                        |
 //! | ping                               | returns nothing |                                        |
@@ -280,6 +280,7 @@ pub use crate::{
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
         AnalyzePsbtInputMissingError, GetRpcInfo, JoinPsbts, UtxoUpdatePsbt,
+        GetNodeAddresses, NodeAddress,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -279,8 +279,8 @@ pub use crate::{
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
-        AnalyzePsbtInputMissingError, GetRpcInfo, JoinPsbts, UtxoUpdatePsbt,
-        GetNodeAddresses, NodeAddress,
+        AnalyzePsbtInputMissingError, GetNodeAddresses, GetRpcInfo, JoinPsbts, NodeAddress,
+        UtxoUpdatePsbt,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -104,7 +104,7 @@
 //! | getconnectioncount                 | returns numeric |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
-//! | getnodeaddresses                   | version         | TODO                                   |
+//! | getnodeaddresses                   | version         |                                        |
 //! | getpeerinfo                        | version         |                                        |
 //! | listbanned                         | returns string  |                                        |
 //! | ping                               | returns nothing |                                        |
@@ -300,6 +300,7 @@ pub use crate::{
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
         AnalyzePsbtInputMissingError, GetRpcInfo, JoinPsbts, UtxoUpdatePsbt,
+        GetNodeAddresses, NodeAddress,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -299,8 +299,8 @@ pub use crate::{
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
-        AnalyzePsbtInputMissingError, GetRpcInfo, JoinPsbts, UtxoUpdatePsbt,
-        GetNodeAddresses, NodeAddress,
+        AnalyzePsbtInputMissingError, GetNodeAddresses, GetRpcInfo, JoinPsbts, NodeAddress,
+        UtxoUpdatePsbt,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -104,7 +104,7 @@
 //! | getconnectioncount                 | returns numeric |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
-//! | getnodeaddresses                   | version         | TODO                                   |
+//! | getnodeaddresses                   | version         |                                        |
 //! | getpeerinfo                        | version         |                                        |
 //! | listbanned                         | returns string  |                                        |
 //! | ping                               | returns nothing |                                        |
@@ -284,6 +284,7 @@ pub use crate::{
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
         AnalyzePsbtInputMissingError, GetRpcInfo, JoinPsbts, UtxoUpdatePsbt,
+        GetNodeAddresses, NodeAddress,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -283,8 +283,8 @@ pub use crate::{
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
-        AnalyzePsbtInputMissingError, GetRpcInfo, JoinPsbts, UtxoUpdatePsbt,
-        GetNodeAddresses, NodeAddress,
+        AnalyzePsbtInputMissingError, GetNodeAddresses, GetRpcInfo, JoinPsbts, NodeAddress,
+        UtxoUpdatePsbt,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -104,7 +104,7 @@
 //! | getconnectioncount                 | returns numeric |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
-//! | getnodeaddresses                   | version         | TODO                                   |
+//! | getnodeaddresses                   | version         |                                        |
 //! | getpeerinfo                        | version         |                                        |
 //! | listbanned                         | returns string  |                                        |
 //! | ping                               | returns nothing |                                        |
@@ -291,6 +291,7 @@ pub use crate::{
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
         AnalyzePsbtInputMissingError, GetRpcInfo, JoinPsbts, UtxoUpdatePsbt,
+        GetNodeAddresses, NodeAddress,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -290,8 +290,8 @@ pub use crate::{
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
-        AnalyzePsbtInputMissingError, GetRpcInfo, JoinPsbts, UtxoUpdatePsbt,
-        GetNodeAddresses, NodeAddress,
+        AnalyzePsbtInputMissingError, GetNodeAddresses, GetRpcInfo, JoinPsbts, NodeAddress,
+        UtxoUpdatePsbt,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,


### PR DESCRIPTION
Implement the `getnodeaddresses` method added in V18, including integration test and reexports in newer versions.