### PR TITLE
Fix v17 nework doc comment

### DIFF
--- a/types/src/v17/network/mod.rs
+++ b/types/src/v17/network/mod.rs
@@ -4,8 +4,9 @@
 //!
 //! Types for methods found under the `== Network ==` section of the API docs.
 //!
-/// These types do not implement `into_model` because apart from fee rate there is no additional
-/// `rust-bitcoin` types needed.
+//! These types do not implement `into_model` because apart from fee rate there is no additional
+//! `rust-bitcoin` types needed.
+
 mod error;
 mod into;
 


### PR DESCRIPTION
The module docs had a section at the end with `///`.

Change them to module level comment with a `//!`.