### PR TITLE
Remove stale comment

### DIFF
--- a/types/src/v17/network/mod.rs
+++ b/types/src/v17/network/mod.rs
@@ -3,9 +3,7 @@
 //! The JSON-RPC API for Bitcoin Core `v0.17` - network.
 //!
 //! Types for methods found under the `== Network ==` section of the API docs.
-//!
-/// These types do not implement `into_model` because apart from fee rate there is no additional
-/// `rust-bitcoin` types needed.
+
 mod error;
 mod into;
 


### PR DESCRIPTION
This comment is not true. `GetBlockcahinInfo` implements `into_model`. Furthermore the `///` after `//!` with no newline is weird.

Remove the comment all together.