### PR TITLE
Release tracking PR: `node`, `client`, and `types` - `v0.8.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -153,7 +153,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "corepc-client"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bitcoin",
  "corepc-types",
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-node"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-types"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bitcoin",
  "serde",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -153,7 +153,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "corepc-client"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bitcoin",
  "corepc-types",
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-node"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-types"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bitcoin",
  "serde",

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 0.8.0 2025-05-21
+
+- Add support for Bitcoin Core 29.0 [#131](https://github.com/rust-bitcoin/corepc/pull/131)
+- Add support for Bitcoin Core 28.1 [#184](https://github.com/rust-bitcoin/corepc/pull/184)
+- Add support for Bitcoin Core 0.17.2 [#128](https://github.com/rust-bitcoin/corepc/pull/128)
+- Remove unnecessary error variants [#127](https://github.com/rust-bitcoin/corepc/pull/127)
+- Move types to version specific module [#156](https://github.com/rust-bitcoin/corepc/pull/156)
+- Move `TemplateRequest` and `TemplateRules` into their proper module [#151](https://github.com/rust-bitcoin/corepc/pull/151)
+- Implement `pruneblock` method and test [#132](https://github.com/rust-bitcoin/corepc/pull/132)
+- Implement `savemempool` method and test [#148](https://github.com/rust-bitcoin/corepc/pull/148)
+- Implement `verifychain` method and test [#155](https://github.com/rust-bitcoin/corepc/pull/155)
+- Implement `getnodeaddresses` method and test [#154](https://github.com/rust-bitcoin/corepc/pull/154)
+
 # 0.7.0 2025-04-04
 
 - Fix unloadwallet method [#110](https://github.com/rust-bitcoin/corepc/pull/110)

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-client"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/corepc"
@@ -22,7 +22,7 @@ client-sync = ["jsonrpc"]
 
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false, features = ["std", "serde"] }
-types = { package = "corepc-types", version = "0.7.0", default-features = false, features = ["std"] }
+types = { package = "corepc-types", version = "0.8.0", default-features = false, features = ["std"] }
 log = "0.4"
 serde = { version = "1.0.103", default-features = false, features = [ "derive", "alloc" ] }
 serde_json = { version = "1.0.117" }

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -53,7 +53,7 @@ TODO = []                       # This is a dirty hack while writing the tests.
 
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false, features = ["std", "serde"] }
-node = { package = "corepc-node", version = "0.7.0", default-features = false }
+node = { package = "corepc-node", version = "0.8.0", default-features = false }
 rand = "0.8.5"
 env_logger = "0.9.0"
 

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.8.0 2025-05-21
+
+- Add support for Bitcoin Core 29.0 [#131](https://github.com/rust-bitcoin/corepc/pull/131)
+- Add support for Core version 28.1 [#184](https://github.com/rust-bitcoin/corepc/pull/184)
+- Add support for Bitcoin Core 0.17.2 [#128](https://github.com/rust-bitcoin/corepc/pull/128)
+- Upgrade `zip` in light of RUSTSEC-2020-0071 [#143](https://github.com/rust-bitcoin/corepc/pull/143)
+- Drop default features for `zip` [#130](https://github.com/rust-bitcoin/corepc/pull/130)
+
 # 0.7.1 2025-05-05
 
 - backport: bump zip in light of RUSTSEC-2020-0071 [#145](https://github.com/rust-bitcoin/corepc/pull/145)

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-node"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Riccardo Casatta <riccardo@casatta.it>", "Tobin C. Harding <me@tobin.cc>"]
 license = "MIT"
 repository = "https://github.com/rust-bitcoin/corepc"
@@ -13,7 +13,7 @@ rust-version = "1.63.0"
 exclude = ["tests", "contrib"]
 
 [dependencies]
-corepc-client = { version = "0.7.0", features = ["client-sync"] }
+corepc-client = { version = "0.8.0", features = ["client-sync"] }
 log = { version = "0.4", default-features = false }
 which = { version = "3.1.1", default-features = false }
 anyhow = { version = "1.0.66", default-features = false, features = ["std"] }

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 0.8.0 2025-05-21
+
+- doc: update docs for now explicit download feature flag [#177](https://github.com/rust-bitcoin/corepc/pull/177)
+- Implement all v17 util functions [#163](https://github.com/rust-bitcoin/corepc/pull/163)
+- Add support for Bitcoin Core 29.0 [#131](https://github.com/rust-bitcoin/corepc/pull/131)
+- Improve the version specific SSOT docs [#142](https://github.com/rust-bitcoin/corepc/pull/142)
+- Remove model for `dumpwallet` [#141](https://github.com/rust-bitcoin/corepc/pull/141)
+- Implement `pruneblock` method and test [#132](https://github.com/rust-bitcoin/corepc/pull/132)
+- Implement `savemempool` method and test [#148](https://github.com/rust-bitcoin/corepc/pull/148)
+- Implement `verifychain` method and test [#155](https://github.com/rust-bitcoin/corepc/pull/155)
+- Implement `getnodeaddresses` method and test [#154](https://github.com/rust-bitcoin/corepc/pull/154)
+- Change `signmessage` returned signature type [#179](https://github.com/rust-bitcoin/corepc/pull/179)
+- Add model for `getnodeaddresses` [#191](https://github.com/rust-bitcoin/corepc/pull/191)
+
 # 0.7.0 2025-04-04
 
 - Fix `{create,load}wallet` on `v25` [#108](https://github.com/rust-bitcoin/corepc/pull/108)

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-types"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/corepc"


### PR DESCRIPTION
In preparation for releasing all three crates bump the version to 0.8.0, add changelog entry, and update the lock files.