### PR TITLE
run-bitcoind: Add err function back in

### DIFF
--- a/contrib/run-bitcoind.sh
+++ b/contrib/run-bitcoind.sh
@@ -211,6 +211,12 @@ run_bitcoind() {
 say() {
     echo "run-bitcoind: $1"
 }
+
+err() {
+    echo "$1" >&2
+    exit 1
+}
+
 #
 # Main script
 #


### PR DESCRIPTION
This got deleted somehow and its still used. I was surprised that `shellcheck` does not find this, I would have thought a shell linter would have access to `$PATH` and be able to tell that the function does not exist. Anywho, add the function back in from a previous release.

Fix: #168