### PR TITLE
run-bitcoind: Fix startup of Core nodes

### DIFF
--- a/contrib/run-bitcoind.sh
+++ b/contrib/run-bitcoind.sh
@@ -186,7 +186,7 @@ run_bitcoind() {
     echo "Starting bitcoind v${version_number} (alias: ${version})..."
     "$bitcoind" -regtest $fallback_fee_arg $block_filter_arg \
                 -datadir="${test_dir}/1" \
-                -port="${version_id}48" \
+                -bind="127.0.0.1:${version_id}48" \
                 -server=0 \
                 -printtoconsole=0 &
 

--- a/node/contrib/extra_tests.sh
+++ b/node/contrib/extra_tests.sh
@@ -32,7 +32,7 @@ main() {
 
     # But only run tests for the latest version. This is ok because we are mainly checking
     # MSRV and docs with this script. Integration test will check every Core version.
-    $cargo test --features=download,28_0
+    $cargo test --features=download,29_0
 }
 
 #


### PR DESCRIPTION
Core v28 introduced changes making node startup fail if bind fails. We fixed this in `node` in #46 but in `run-bitcoind.sh` we still use `-port`. This didn't cause any problems because we only pass the arg to one of the two nodes so port 18445 was available. When we try to add support for v29 things break.

Jamil was experiencing this problem (I think) while running v28 nodes but I don't know why.

Use `-bind` instead of `-port`.