### PR TITLE
doc: update docs for now explicit download feature flag

### DIFF
--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -5,7 +5,6 @@
 # 0.7.0 2025-04-04
 
 - Retry initial client connections [#111](https://github.com/rust-bitcoin/corepc/pull/111)
-- 
 
 # 0.6.1 - 2025-03-11
 

--- a/node/README.md
+++ b/node/README.md
@@ -2,11 +2,10 @@
 
 Utility to run a regtest bitcoind process, useful in integration testing environment.
 
-When the auto-download feature is selected by activating one of the version feature, such as `25_1`
-for bitcoin core 25.1, starting a regtest node is as simple as that:
+When the auto-download feature is enabled, starting a regtest node is as simple as that:
 
 ```rust
-// the download feature is enabled whenever a specific version is enabled, for example `25_1` or `24_0_1`
+// the download feature must be enabled with a specific version, for example `25_1` or `24_0_1`
 #[cfg(feature = "download")]
 {
   let node = corepc_node::Node::from_downloaded().unwrap();

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -562,7 +562,7 @@ pub fn downloaded_exe_path() -> anyhow::Result<String> {
 /// Returns the daemon `bitcoind` executable with the following precedence:
 ///
 /// 1) If it's specified in the `BITCOIND_EXE` env var
-/// 2) If there is no env var but an auto-download feature such as `23_1` is enabled, returns the
+/// 2) If there is no env var but the auto-download feature is enabled, returns the
 ///    path of the downloaded executabled
 /// 3) If neither of the precedent are available, the `bitcoind` executable is searched in the `PATH`
 pub fn exe_path() -> anyhow::Result<String> {


### PR DESCRIPTION
I noticed with a recent upgrade that the `download` feature flag is no longer auto-enabled with a version selected. I believe that happened here: https://github.com/rust-bitcoin/corepc/pull/45

Just updating the docs here since it took me a second to realize.