### PR TITLE
Change `signmessage` returned signature type

### DIFF
--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -263,6 +263,23 @@ fn wallet__send_to_address__modelled() {
     model.unwrap();
 }
 
+#[test]
+fn wallet__sign_message__modelled() {
+    let node = Node::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+
+    let address = node.client.new_address_with_type(AddressType::Legacy).unwrap();
+    let message = "integration test message";
+
+    // Sign the message with the address key
+    let json: SignMessage = node
+        .client
+        .sign_message(&address, message)
+        .expect("signmessage");
+    let res: Result<mtype::SignMessage, _> = json.into_model();
+    let _ = res.expect("SignMessage into model");
+}
+
 fn create_load_unload_wallet() {
     let node = Node::with_wallet(Wallet::None, &[]);
 

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -17,7 +17,7 @@ default = ["std"]
 std = ["bitcoin/std"]
 
 [dependencies]
-bitcoin = { version = "0.32.0", default-features = false, features = ["serde", "base64"] }
+bitcoin = { version = "0.32.0", default-features = false, features = ["serde", "base64", "secp-recovery"] }
 serde = { version = "1.0.103", default-features = false, features = [ "derive", "alloc" ] }
 serde_json = { version = "1.0.117" }
 

--- a/types/src/model/wallet.rs
+++ b/types/src/model/wallet.rs
@@ -10,8 +10,8 @@ use alloc::collections::BTreeMap;
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::hashes::hash160;
 use bitcoin::{
-    bip32, ecdsa, Address, Amount, BlockHash, FeeRate, PrivateKey, Psbt, PublicKey, ScriptBuf,
-    SignedAmount, Transaction, Txid, WitnessProgram, WitnessVersion,
+    bip32, sign_message, Address, Amount, BlockHash, FeeRate, PrivateKey, Psbt, PublicKey,
+    ScriptBuf, SignedAmount, Transaction, Txid, WitnessProgram, WitnessVersion,
 };
 use serde::{Deserialize, Serialize};
 
@@ -622,8 +622,8 @@ pub struct SendToAddress {
 }
 
 /// Models the result of JSON-RPC method `signmessage`.
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-pub struct SignMessage(pub ecdsa::Signature);
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SignMessage(pub sign_message::MessageSignature);
 
 /// Models the result of JSON-RPC method `unloadwallet`.
 ///

--- a/types/src/v17/mod.rs
+++ b/types/src/v17/mod.rs
@@ -200,7 +200,7 @@
 //! | setaccount                         | returns nothing |                                        |
 //! | sethdseed                          | returns nothing |                                        |
 //! | settxfee                           | returns boolean |                                        |
-//! | signmessage                        | version + model | UNTESTED                               |
+//! | signmessage                        | version + model |                                        |
 //! | signrawtransactionwithwallet       | version + model |                                        |
 //! | unloadwallet                       | returns nothing |                                        |
 //! | walletcreatefundedpsbt             | version + model | UNTESTED                               |

--- a/types/src/v17/wallet/into.rs
+++ b/types/src/v17/wallet/into.rs
@@ -8,8 +8,8 @@ use bitcoin::hex::FromHex;
 use bitcoin::key::{self, PrivateKey, PublicKey};
 use bitcoin::psbt::PsbtParseError;
 use bitcoin::{
-    address, bip32, ecdsa, Address, Amount, BlockHash, Psbt, ScriptBuf, SignedAmount, Transaction,
-    Txid, WitnessProgram, WitnessVersion,
+    address, bip32, sign_message, Address, Amount, BlockHash, Psbt, ScriptBuf, SignedAmount,
+    Transaction, Txid, WitnessProgram, WitnessVersion,
 };
 
 // TODO: Use explicit imports?
@@ -695,8 +695,8 @@ impl SendToAddress {
 
 impl SignMessage {
     /// Converts version specific type to a version nonspecific, more strongly typed type.
-    pub fn into_model(self) -> Result<model::SignMessage, ecdsa::Error> {
-        let sig = self.0.parse::<ecdsa::Signature>()?;
+    pub fn into_model(self) -> Result<model::SignMessage, sign_message::MessageSignatureError> {
+        let sig = self.0.parse::<sign_message::MessageSignature>()?;
         Ok(model::SignMessage(sig))
     }
 }

--- a/types/src/v18/mod.rs
+++ b/types/src/v18/mod.rs
@@ -202,7 +202,7 @@
 //! | sethdseed                          | returns nothing |                                        |
 //! | setlabel                           | returns nothing |                                        |
 //! | settxfee                           | returns boolean |                                        |
-//! | signmessage                        | version + model | UNTESTED                               |
+//! | signmessage                        | version + model |                                        |
 //! | signrawtransactionwithwallet       | version + model |                                        |
 //! | unloadwallet                       | returns nothing |                                        |
 //! | walletcreatefundedpsbt             | version + model | UNTESTED                               |

--- a/types/src/v19/mod.rs
+++ b/types/src/v19/mod.rs
@@ -204,7 +204,7 @@
 //! | setlabel                           | returns nothing |                                        |
 //! | settxfee                           | returns boolean |                                        |
 //! | setwalletflag                      | version         | TODO                                   |
-//! | signmessage                        | version + model | UNTESTED                               |
+//! | signmessage                        | version + model |                                        |
 //! | signrawtransactionwithwallet       | version + model |                                        |
 //! | unloadwallet                       | returns nothing |                                        |
 //! | walletcreatefundedpsbt             | version + model | UNTESTED                               |

--- a/types/src/v20/mod.rs
+++ b/types/src/v20/mod.rs
@@ -205,7 +205,7 @@
 //! | setlabel                           | returns nothing |                                        |
 //! | settxfee                           | returns boolean |                                        |
 //! | setwalletflag                      | version         | TODO                                   |
-//! | signmessage                        | version + model | UNTESTED                               |
+//! | signmessage                        | version + model |                                        |
 //! | signrawtransactionwithwallet       | version + model |                                        |
 //! | unloadwallet                       | returns nothing |                                        |
 //! | walletcreatefundedpsbt             | version + model | UNTESTED                               |

--- a/types/src/v21/mod.rs
+++ b/types/src/v21/mod.rs
@@ -210,7 +210,7 @@
 //! | setlabel                           | returns nothing |                                        |
 //! | settxfee                           | returns boolean |                                        |
 //! | setwalletflag                      | version         | TODO                                   |
-//! | signmessage                        | version + model | UNTESTED                               |
+//! | signmessage                        | version + model |                                        |
 //! | signrawtransactionwithwallet       | version + model |                                        |
 //! | unloadwallet                       | returns nothing |                                        |
 //! | upgradewallet                      | version         | TODO                                   |

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -220,7 +220,7 @@
 //! | setlabel                           | returns nothing |                                        |
 //! | settxfee                           | returns boolean |                                        |
 //! | setwalletflag                      | version         | TODO                                   |
-//! | signmessage                        | version + model | UNTESTED                               |
+//! | signmessage                        | version + model |                                        |
 //! | signrawtransactionwithwallet       | version + model |                                        |
 //! | unloadwallet                       | returns nothing |                                        |
 //! | upgradewallet                      | version         | TODO                                   |

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -213,7 +213,7 @@
 //! | setlabel                           | returns nothing |                                        |
 //! | settxfee                           | returns boolean |                                        |
 //! | setwalletflag                      | version         | TODO                                   |
-//! | signmessage                        | version + model | UNTESTED                               |
+//! | signmessage                        | version + model |                                        |
 //! | signrawtransactionwithwallet       | version + model |                                        |
 //! | unloadwallet                       | returns nothing |                                        |
 //! | upgradewallet                      | version         | TODO                                   |

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -216,7 +216,7 @@
 //! | setlabel                           | returns nothing |                                        |
 //! | settxfee                           | returns boolean |                                        |
 //! | setwalletflag                      | version         | TODO                                   |
-//! | signmessage                        | version + model | UNTESTED                               |
+//! | signmessage                        | version + model |                                        |
 //! | signrawtransactionwithwallet       | version + model |                                        |
 //! | simulaterawtransaction             | version + model | TODO                                   |
 //! | unloadwallet                       | returns nothing |                                        |

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -217,7 +217,7 @@
 //! | setlabel                           | returns nothing |                                        |
 //! | settxfee                           | returns boolean |                                        |
 //! | setwalletflag                      | version         | TODO                                   |
-//! | signmessage                        | version + model | UNTESTED                               |
+//! | signmessage                        | version + model |                                        |
 //! | signrawtransactionwithwallet       | version + model |                                        |
 //! | simulaterawtransaction             | version + model | TODO                                   |
 //! | unloadwallet                       | returns nothing |                                        |

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -225,7 +225,7 @@
 //! | setlabel                           | returns nothing |                                        |
 //! | settxfee                           | returns boolean |                                        |
 //! | setwalletflag                      | version         | TODO                                   |
-//! | signmessage                        | version + model | UNTESTED                               |
+//! | signmessage                        | version + model |                                        |
 //! | signrawtransactionwithwallet       | version + model |                                        |
 //! | simulaterawtransaction             | version + model | TODO                                   |
 //! | unloadwallet                       | returns nothing |                                        |

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -225,7 +225,7 @@
 //! | setlabel                           | returns nothing |                                        |
 //! | settxfee                           | returns boolean |                                        |
 //! | setwalletflag                      | version         | TODO                                   |
-//! | signmessage                        | version + model | UNTESTED                               |
+//! | signmessage                        | version + model |                                        |
 //! | signrawtransactionwithwallet       | version + model |                                        |
 //! | simulaterawtransaction             | version + model | TODO                                   |
 //! | unloadwallet                       | returns nothing |                                        |

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -227,7 +227,7 @@
 //! | setlabel                           | returns nothing |                                        |
 //! | settxfee                           | returns boolean |                                        |
 //! | setwalletflag                      | version         | TODO                                   |
-//! | signmessage                        | version + model | UNTESTED                               |
+//! | signmessage                        | version + model |                                        |
 //! | signrawtransactionwithwallet       | version + model |                                        |
 //! | simulaterawtransaction             | version + model | TODO                                   |
 //! | unloadwallet                       | returns nothing |                                        |


### PR DESCRIPTION
Change the strong type of the returned signature to `MessageSignature` to match `signmessagewithprivkey` add a test for it and update the types tables.

Closes #176 