### PR TITLE
Improve ListUnspent data handling: Fix deserialization & add into_model

### DIFF
--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -216,6 +216,22 @@ fn wallet__get_transaction__modelled() {
 }
 
 #[test]
+fn wallet__list_unspent__modelled() {
+    let node = match () {
+        #[cfg(feature = "v17")]
+        () => Node::with_wallet(Wallet::Default, &["-deprecatedrpc=accounts"]),
+        #[cfg(not(feature = "v17"))]
+        () => Node::with_wallet(Wallet::Default, &[]),
+    };
+
+    node.fund_wallet();
+
+    let json: ListUnspent = node.client.list_unspent().expect("listunspent");
+    let model: Result<mtype::ListUnspent, ListUnspentItemError> = json.into_model();
+    model.unwrap();
+}
+
+#[test]
 fn wallet__load_wallet__modelled() {
     create_load_unload_wallet();
 }

--- a/types/src/v17/mod.rs
+++ b/types/src/v17/mod.rs
@@ -187,7 +187,7 @@
 //! | listreceivedbyaddress              | version + model | UNTESTED                               |
 //! | listsinceblock                     | version + model | UNTESTED                               |
 //! | listtransactions                   | version + model | UNTESTED                               |
-//! | listunspent                        | version + model | UNTESTED                               |
+//! | listunspent                        | version + model |                                        |
 //! | listwallets                        | version + model | UNTESTED                               |
 //! | loadwallet                         | version + model |                                        |
 //! | lockunspent                        | returns boolean |                                        |

--- a/types/src/v17/wallet/into.rs
+++ b/types/src/v17/wallet/into.rs
@@ -622,6 +622,17 @@ impl ListTransactionsItem {
     }
 }
 
+impl ListUnspent {
+    /// Converts version specific type to a version nonspecific, more strongly typed type.
+    pub fn into_model(self) -> Result<model::ListUnspent, ListUnspentItemError> {
+        self.0
+            .into_iter()
+            .map(|item| item.into_model())
+            .collect::<Result<Vec<_>, _>>()
+            .map(model::ListUnspent)
+    }
+}
+
 impl ListUnspentItem {
     /// Converts version specific type to a version nonspecific, more strongly typed type.
     pub fn into_model(self) -> Result<model::ListUnspentItem, ListUnspentItemError> {

--- a/types/src/v18/mod.rs
+++ b/types/src/v18/mod.rs
@@ -190,7 +190,7 @@
 //! | listreceivedbylabel                | version + model | TODO                                   |
 //! | listsinceblock                     | version + model | UNTESTED                               |
 //! | listtransactions                   | version + model | UNTESTED                               |
-//! | listunspent                        | version + model | UNTESTED                               |
+//! | listunspent                        | version + model |                                        |
 //! | listwalletdir                      | version         | TODO                                   |
 //! | listwallets                        | version + model | UNTESTED                               |
 //! | loadwallet                         | version + model |                                        |
@@ -226,6 +226,7 @@
 mod control;
 mod network;
 mod raw_transactions;
+mod wallet;
 
 #[doc(inline)]
 pub use self::{
@@ -235,6 +236,7 @@ pub use self::{
         AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
         AnalyzePsbtInputMissingError, JoinPsbts, UtxoUpdatePsbt,
     },
+    wallet::{ListUnspent, ListUnspentItem},
 };
 #[doc(inline)]
 pub use crate::v17::{
@@ -263,14 +265,14 @@ pub use crate::v17::{
     ListBanned, ListLabels, ListLockUnspent, ListLockUnspentItem, ListLockUnspentItemError,
     ListReceivedByAddress, ListReceivedByAddressError, ListReceivedByAddressItem, ListSinceBlock,
     ListSinceBlockError, ListSinceBlockTransaction, ListSinceBlockTransactionError,
-    ListTransactions, ListTransactionsItem, ListTransactionsItemError, ListUnspent,
-    ListUnspentItem, ListUnspentItemError, ListWallets, LoadWallet, Locked, Logging,
-    MapMempoolEntryError, MempoolAcceptance, MempoolEntry, MempoolEntryError, MempoolEntryFees,
-    MempoolEntryFeesError, PeerInfo, PruneBlockchain, PsbtInput, PsbtOutput, PsbtScript,
-    RawTransaction, RawTransactionError, RawTransactionInput, RawTransactionOutput,
-    RescanBlockchain, SendMany, SendRawTransaction, SendToAddress, SignFail, SignFailError,
-    SignMessage, SignMessageWithPrivKey, SignRawTransaction, SignRawTransactionError, Softfork,
-    SoftforkReject, TestMempoolAccept, TransactionCategory, UploadTarget, ValidateAddress,
-    ValidateAddressError, VerifyChain, VerifyMessage, VerifyTxOutProof, WalletCreateFundedPsbt,
-    WalletCreateFundedPsbtError, WalletProcessPsbt, WitnessUtxo,
+    ListTransactions, ListTransactionsItem, ListTransactionsItemError, ListUnspentItemError,
+    ListWallets, LoadWallet, Locked, Logging, MapMempoolEntryError, MempoolAcceptance,
+    MempoolEntry, MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, PeerInfo,
+    PruneBlockchain, PsbtInput, PsbtOutput, PsbtScript, RawTransaction, RawTransactionError,
+    RawTransactionInput, RawTransactionOutput, RescanBlockchain, SendMany, SendRawTransaction,
+    SendToAddress, SignFail, SignFailError, SignMessage, SignMessageWithPrivKey,
+    SignRawTransaction, SignRawTransactionError, Softfork, SoftforkReject, TestMempoolAccept,
+    TransactionCategory, UploadTarget, ValidateAddress, ValidateAddressError, VerifyChain,
+    VerifyMessage, VerifyTxOutProof, WalletCreateFundedPsbt, WalletCreateFundedPsbtError,
+    WalletProcessPsbt, WitnessUtxo,
 };

--- a/types/src/v18/wallet/into.rs
+++ b/types/src/v18/wallet/into.rs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: CC0-1.0
+
+use bitcoin::{Address, ScriptBuf, SignedAmount, Txid};
+
+// TODO: Use explicit imports?
+use super::*;
+use crate::model;
+use crate::v17::ListUnspentItemError;
+
+impl ListUnspent {
+    /// Converts version specific type to a version nonspecific, more strongly typed type.
+    pub fn into_model(self) -> Result<model::ListUnspent, ListUnspentItemError> {
+        self.0
+            .into_iter()
+            .map(|item| item.into_model())
+            .collect::<Result<Vec<_>, _>>()
+            .map(model::ListUnspent)
+    }
+}
+
+impl ListUnspentItem {
+    /// Converts version specific type to a version nonspecific, more strongly typed type.
+    pub fn into_model(self) -> Result<model::ListUnspentItem, ListUnspentItemError> {
+        use ListUnspentItemError as E;
+
+        let txid = self.txid.parse::<Txid>().map_err(E::Txid)?;
+        let vout = crate::to_u32(self.vout, "vout")?;
+        let address = self.address.parse::<Address<_>>().map_err(E::Address)?;
+        let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubkey)?;
+
+        let amount = SignedAmount::from_btc(self.amount).map_err(E::Amount)?;
+        let confirmations = crate::to_u32(self.confirmations, "confirmations")?;
+        let redeem_script = self
+            .redeem_script
+            .map(|hex| ScriptBuf::from_hex(&hex).map_err(E::RedeemScript))
+            .transpose()?;
+
+        Ok(model::ListUnspentItem {
+            txid,
+            vout,
+            address,
+            label: self.label,
+            script_pubkey,
+            amount,
+            confirmations,
+            redeem_script,
+            spendable: self.spendable,
+            solvable: self.solvable,
+            safe: self.safe,
+        })
+    }
+}

--- a/types/src/v18/wallet/mod.rs
+++ b/types/src/v18/wallet/mod.rs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! The JSON-RPC API for Bitcoin Core `v0.17` - wallet.
+//!
+//! Types for methods found under the `== Wallet ==` section of the API docs.
+
+mod into;
+
+use serde::{Deserialize, Serialize};
+
+/// Result of the JSON-RPC method `listunspent`.
+///
+/// > listunspent ( minconf maxconf  ["addresses",...] `[include_unsafe]` `[query_options]`)
+/// >
+/// > Returns array of unspent transaction outputs
+/// > with between minconf and maxconf (inclusive) confirmations.
+/// > Optionally filter to only include txouts paid to specified addresses.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct ListUnspent(pub Vec<ListUnspentItem>);
+
+/// Unspent transaction output, returned as part of `listunspent`.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct ListUnspentItem {
+    /// The transaction id.
+    pub txid: String,
+    /// The vout value.
+    pub vout: i64,
+    /// The bitcoin address of the transaction.
+    pub address: String,
+    /// The associated label, or "" for the default label.
+    pub label: String,
+    /// The script key.
+    #[serde(rename = "scriptPubKey")]
+    pub script_pubkey: String,
+    /// The transaction amount in BTC.
+    pub amount: f64,
+    /// The number of confirmations.
+    pub confirmations: i64,
+    /// The redeemScript if scriptPubKey is P2SH.
+    #[serde(rename = "redeemScript")]
+    pub redeem_script: Option<String>,
+    /// Whether we have the private keys to spend this output.
+    pub spendable: bool,
+    /// Whether we know how to spend this output, ignoring the lack of keys.
+    pub solvable: bool,
+    /// Whether this output is considered safe to spend. Unconfirmed transactions from outside keys
+    /// and unconfirmed replacement transactions are considered unsafe and are not eligible for
+    /// spending by fundrawtransaction and sendtoaddress.
+    pub safe: bool,
+}

--- a/types/src/v19/mod.rs
+++ b/types/src/v19/mod.rs
@@ -191,7 +191,7 @@
 //! | listreceivedbylabel                | version + model | TODO                                   |
 //! | listsinceblock                     | version + model | UNTESTED                               |
 //! | listtransactions                   | version + model | UNTESTED                               |
-//! | listunspent                        | version + model | UNTESTED                               |
+//! | listunspent                        | version + model |                                        |
 //! | listwalletdir                      | version         | TODO                                   |
 //! | listwallets                        | version + model | UNTESTED                               |
 //! | loadwallet                         | version + model |                                        |
@@ -264,17 +264,17 @@ pub use crate::v17::{
     ListLockUnspentItemError, ListReceivedByAddress, ListReceivedByAddressError,
     ListReceivedByAddressItem, ListSinceBlock, ListSinceBlockError, ListSinceBlockTransaction,
     ListSinceBlockTransactionError, ListTransactions, ListTransactionsItem,
-    ListTransactionsItemError, ListUnspent, ListUnspentItem, ListUnspentItemError, ListWallets,
-    LoadWallet, Locked, Logging, PeerInfo, PruneBlockchain, RawTransactionError,
-    RawTransactionInput, RawTransactionOutput, RescanBlockchain, SendMany, SendRawTransaction,
-    SendToAddress, SignMessage, SignMessageWithPrivKey, SignRawTransaction,
-    SignRawTransactionError, SoftforkReject, TestMempoolAccept, TransactionCategory, UploadTarget,
-    ValidateAddress, ValidateAddressError, VerifyChain, VerifyMessage, VerifyTxOutProof,
-    WalletCreateFundedPsbt, WalletCreateFundedPsbtError, WalletProcessPsbt, WitnessUtxo,
+    ListTransactionsItemError, ListUnspentItemError, ListWallets, LoadWallet, Locked, Logging,
+    PeerInfo, PruneBlockchain, RawTransactionError, RawTransactionInput, RawTransactionOutput,
+    RescanBlockchain, SendMany, SendRawTransaction, SendToAddress, SignMessage,
+    SignMessageWithPrivKey, SignRawTransaction, SignRawTransactionError, SoftforkReject,
+    TestMempoolAccept, TransactionCategory, UploadTarget, ValidateAddress, ValidateAddressError,
+    VerifyChain, VerifyMessage, VerifyTxOutProof, WalletCreateFundedPsbt,
+    WalletCreateFundedPsbtError, WalletProcessPsbt, WitnessUtxo,
 };
 #[doc(inline)]
 pub use crate::v18::{
     ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
-    AnalyzePsbtInputMissingError, GetNodeAddresses, GetRpcInfo, JoinPsbts, NodeAddress,
-    UtxoUpdatePsbt,
+    AnalyzePsbtInputMissingError, GetNodeAddresses, GetRpcInfo, JoinPsbts, ListUnspent,
+    ListUnspentItem, NodeAddress, UtxoUpdatePsbt,
 };

--- a/types/src/v20/mod.rs
+++ b/types/src/v20/mod.rs
@@ -192,7 +192,7 @@
 //! | listreceivedbylabel                | version + model | TODO                                   |
 //! | listsinceblock                     | version + model | UNTESTED                               |
 //! | listtransactions                   | version + model | UNTESTED                               |
-//! | listunspent                        | version + model | UNTESTED                               |
+//! | listunspent                        | version + model |                                        |
 //! | listwalletdir                      | version         | TODO                                   |
 //! | listwallets                        | version + model | UNTESTED                               |
 //! | loadwallet                         | version + model |                                        |
@@ -257,19 +257,18 @@ pub use crate::{
         ListLockUnspent, ListLockUnspentItem, ListLockUnspentItemError, ListReceivedByAddress,
         ListReceivedByAddressError, ListReceivedByAddressItem, ListSinceBlock, ListSinceBlockError,
         ListSinceBlockTransaction, ListSinceBlockTransactionError, ListTransactions,
-        ListTransactionsItem, ListTransactionsItemError, ListUnspent, ListUnspentItem,
-        ListUnspentItemError, ListWallets, LoadWallet, Locked, PeerInfo, PruneBlockchain,
-        RawTransactionError, RawTransactionInput, RawTransactionOutput, RescanBlockchain, SendMany,
-        SendRawTransaction, SendToAddress, SignMessage, SignMessageWithPrivKey, SignRawTransaction,
-        SignRawTransactionError, SoftforkReject, TestMempoolAccept, TransactionCategory,
-        UploadTarget, ValidateAddress, ValidateAddressError, VerifyChain, VerifyMessage,
-        VerifyTxOutProof, WalletCreateFundedPsbt, WalletCreateFundedPsbtError, WalletProcessPsbt,
-        WitnessUtxo,
+        ListTransactionsItem, ListTransactionsItemError, ListUnspentItemError, ListWallets,
+        LoadWallet, Locked, PeerInfo, PruneBlockchain, RawTransactionError, RawTransactionInput,
+        RawTransactionOutput, RescanBlockchain, SendMany, SendRawTransaction, SendToAddress,
+        SignMessage, SignMessageWithPrivKey, SignRawTransaction, SignRawTransactionError,
+        SoftforkReject, TestMempoolAccept, TransactionCategory, UploadTarget, ValidateAddress,
+        ValidateAddressError, VerifyChain, VerifyMessage, VerifyTxOutProof, WalletCreateFundedPsbt,
+        WalletCreateFundedPsbtError, WalletProcessPsbt, WitnessUtxo,
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
-        AnalyzePsbtInputMissingError, GetNodeAddresses, GetRpcInfo, JoinPsbts, NodeAddress,
-        UtxoUpdatePsbt,
+        AnalyzePsbtInputMissingError, GetNodeAddresses, GetRpcInfo, JoinPsbts, ListUnspent,
+        ListUnspentItem, NodeAddress, UtxoUpdatePsbt,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,

--- a/types/src/v21/mod.rs
+++ b/types/src/v21/mod.rs
@@ -196,7 +196,7 @@
 //! | listreceivedbylabel                | version + model | TODO                                   |
 //! | listsinceblock                     | version + model | UNTESTED                               |
 //! | listtransactions                   | version + model | UNTESTED                               |
-//! | listunspent                        | version + model | UNTESTED                               |
+//! | listunspent                        | version + model |                                        |
 //! | listwalletdir                      | version         | TODO                                   |
 //! | listwallets                        | version + model | UNTESTED                               |
 //! | loadwallet                         | version + model |                                        |
@@ -263,19 +263,18 @@ pub use crate::{
         ListLockUnspent, ListLockUnspentItem, ListLockUnspentItemError, ListReceivedByAddress,
         ListReceivedByAddressError, ListReceivedByAddressItem, ListSinceBlock, ListSinceBlockError,
         ListSinceBlockTransaction, ListSinceBlockTransactionError, ListTransactions,
-        ListTransactionsItem, ListTransactionsItemError, ListUnspent, ListUnspentItem,
-        ListUnspentItemError, ListWallets, LoadWallet, Locked, PeerInfo, PruneBlockchain,
-        RawTransactionError, RawTransactionInput, RawTransactionOutput, RescanBlockchain, SendMany,
-        SendRawTransaction, SendToAddress, SignMessage, SignMessageWithPrivKey, SignRawTransaction,
-        SignRawTransactionError, SoftforkReject, TestMempoolAccept, TransactionCategory,
-        UploadTarget, ValidateAddress, ValidateAddressError, VerifyChain, VerifyMessage,
-        VerifyTxOutProof, WalletCreateFundedPsbt, WalletCreateFundedPsbtError, WalletProcessPsbt,
-        WitnessUtxo,
+        ListTransactionsItem, ListTransactionsItemError, ListUnspentItemError, ListWallets,
+        LoadWallet, Locked, PeerInfo, PruneBlockchain, RawTransactionError, RawTransactionInput,
+        RawTransactionOutput, RescanBlockchain, SendMany, SendRawTransaction, SendToAddress,
+        SignMessage, SignMessageWithPrivKey, SignRawTransaction, SignRawTransactionError,
+        SoftforkReject, TestMempoolAccept, TransactionCategory, UploadTarget, ValidateAddress,
+        ValidateAddressError, VerifyChain, VerifyMessage, VerifyTxOutProof, WalletCreateFundedPsbt,
+        WalletCreateFundedPsbtError, WalletProcessPsbt, WitnessUtxo,
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
-        AnalyzePsbtInputMissingError, GetNodeAddresses, GetRpcInfo, JoinPsbts, NodeAddress,
-        UtxoUpdatePsbt,
+        AnalyzePsbtInputMissingError, GetNodeAddresses, GetRpcInfo, JoinPsbts, ListUnspent,
+        ListUnspentItem, NodeAddress, UtxoUpdatePsbt,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -206,7 +206,7 @@
 //! | listreceivedbylabel                | version + model | TODO                                   |
 //! | listsinceblock                     | version + model | UNTESTED                               |
 //! | listtransactions                   | version + model | UNTESTED                               |
-//! | listunspent                        | version + model | UNTESTED                               |
+//! | listunspent                        | version + model |                                        |
 //! | listwalletdir                      | version         | TODO                                   |
 //! | listwallets                        | version + model | UNTESTED                               |
 //! | loadwallet                         | version + model |                                        |
@@ -274,19 +274,18 @@ pub use crate::{
         ListLockUnspent, ListLockUnspentItem, ListLockUnspentItemError, ListReceivedByAddress,
         ListReceivedByAddressError, ListReceivedByAddressItem, ListSinceBlock, ListSinceBlockError,
         ListSinceBlockTransaction, ListSinceBlockTransactionError, ListTransactions,
-        ListTransactionsItem, ListTransactionsItemError, ListUnspent, ListUnspentItem,
-        ListUnspentItemError, ListWallets, LoadWallet, Locked, PeerInfo, PruneBlockchain,
-        RawTransactionError, RawTransactionInput, RawTransactionOutput, RescanBlockchain, SendMany,
-        SendRawTransaction, SendToAddress, SignMessage, SignMessageWithPrivKey, SignRawTransaction,
-        SignRawTransactionError, SoftforkReject, TestMempoolAccept, TransactionCategory,
-        UploadTarget, ValidateAddress, ValidateAddressError, VerifyChain, VerifyMessage,
-        VerifyTxOutProof, WalletCreateFundedPsbt, WalletCreateFundedPsbtError, WalletProcessPsbt,
-        WitnessUtxo,
+        ListTransactionsItem, ListTransactionsItemError, ListUnspentItemError, ListWallets,
+        LoadWallet, Locked, PeerInfo, PruneBlockchain, RawTransactionError, RawTransactionInput,
+        RawTransactionOutput, RescanBlockchain, SendMany, SendRawTransaction, SendToAddress,
+        SignMessage, SignMessageWithPrivKey, SignRawTransaction, SignRawTransactionError,
+        SoftforkReject, TestMempoolAccept, TransactionCategory, UploadTarget, ValidateAddress,
+        ValidateAddressError, VerifyChain, VerifyMessage, VerifyTxOutProof, WalletCreateFundedPsbt,
+        WalletCreateFundedPsbtError, WalletProcessPsbt, WitnessUtxo,
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
-        AnalyzePsbtInputMissingError, GetNodeAddresses, GetRpcInfo, JoinPsbts, NodeAddress,
-        UtxoUpdatePsbt,
+        AnalyzePsbtInputMissingError, GetNodeAddresses, GetRpcInfo, JoinPsbts, ListUnspent,
+        ListUnspentItem, NodeAddress, UtxoUpdatePsbt,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -198,7 +198,7 @@
 //! | listreceivedbylabel                | version + model | TODO                                   |
 //! | listsinceblock                     | version + model | UNTESTED                               |
 //! | listtransactions                   | version + model | UNTESTED                               |
-//! | listunspent                        | version + model | UNTESTED                               |
+//! | listunspent                        | version + model |                                        |
 //! | listwalletdir                      | version         | TODO                                   |
 //! | listwallets                        | version + model | UNTESTED                               |
 //! | loadwallet                         | version + model |                                        |
@@ -273,19 +273,18 @@ pub use crate::{
         ListLockUnspent, ListLockUnspentItem, ListLockUnspentItemError, ListReceivedByAddress,
         ListReceivedByAddressError, ListReceivedByAddressItem, ListSinceBlock, ListSinceBlockError,
         ListSinceBlockTransaction, ListSinceBlockTransactionError, ListTransactions,
-        ListTransactionsItem, ListTransactionsItemError, ListUnspent, ListUnspentItem,
-        ListUnspentItemError, ListWallets, LoadWallet, Locked, PeerInfo, PruneBlockchain,
-        RawTransactionError, RawTransactionInput, RawTransactionOutput, RescanBlockchain, SendMany,
-        SendRawTransaction, SendToAddress, SignMessage, SignMessageWithPrivKey, SignRawTransaction,
-        SignRawTransactionError, SoftforkReject, TestMempoolAccept, TransactionCategory,
-        UploadTarget, ValidateAddress, ValidateAddressError, VerifyChain, VerifyMessage,
-        VerifyTxOutProof, WalletCreateFundedPsbt, WalletCreateFundedPsbtError, WalletProcessPsbt,
-        WitnessUtxo,
+        ListTransactionsItem, ListTransactionsItemError, ListUnspentItemError, ListWallets,
+        LoadWallet, Locked, PeerInfo, PruneBlockchain, RawTransactionError, RawTransactionInput,
+        RawTransactionOutput, RescanBlockchain, SendMany, SendRawTransaction, SendToAddress,
+        SignMessage, SignMessageWithPrivKey, SignRawTransaction, SignRawTransactionError,
+        SoftforkReject, TestMempoolAccept, TransactionCategory, UploadTarget, ValidateAddress,
+        ValidateAddressError, VerifyChain, VerifyMessage, VerifyTxOutProof, WalletCreateFundedPsbt,
+        WalletCreateFundedPsbtError, WalletProcessPsbt, WitnessUtxo,
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
-        AnalyzePsbtInputMissingError, GetNodeAddresses, GetRpcInfo, JoinPsbts, NodeAddress,
-        UtxoUpdatePsbt,
+        AnalyzePsbtInputMissingError, GetNodeAddresses, GetRpcInfo, JoinPsbts, ListUnspent,
+        ListUnspentItem, NodeAddress, UtxoUpdatePsbt,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -200,7 +200,7 @@
 //! | listreceivedbylabel                | version + model | TODO                                   |
 //! | listsinceblock                     | version + model | UNTESTED                               |
 //! | listtransactions                   | version + model | UNTESTED                               |
-//! | listunspent                        | version + model | UNTESTED                               |
+//! | listunspent                        | version + model |                                        |
 //! | listwalletdir                      | version         | TODO                                   |
 //! | listwallets                        | version + model | UNTESTED                               |
 //! | loadwallet                         | version + model |                                        |
@@ -274,19 +274,18 @@ pub use crate::{
         ListLockUnspent, ListLockUnspentItem, ListLockUnspentItemError, ListReceivedByAddress,
         ListReceivedByAddressError, ListReceivedByAddressItem, ListSinceBlock, ListSinceBlockError,
         ListSinceBlockTransaction, ListSinceBlockTransactionError, ListTransactions,
-        ListTransactionsItem, ListTransactionsItemError, ListUnspent, ListUnspentItem,
-        ListUnspentItemError, ListWallets, LoadWallet, Locked, PeerInfo, PruneBlockchain,
-        RawTransactionError, RawTransactionInput, RawTransactionOutput, RescanBlockchain, SendMany,
-        SendRawTransaction, SendToAddress, SignMessage, SignMessageWithPrivKey, SignRawTransaction,
-        SignRawTransactionError, SoftforkReject, TestMempoolAccept, TransactionCategory,
-        UploadTarget, ValidateAddress, ValidateAddressError, VerifyChain, VerifyMessage,
-        VerifyTxOutProof, WalletCreateFundedPsbt, WalletCreateFundedPsbtError, WalletProcessPsbt,
-        WitnessUtxo,
+        ListTransactionsItem, ListTransactionsItemError, ListUnspentItemError, ListWallets,
+        LoadWallet, Locked, PeerInfo, PruneBlockchain, RawTransactionError, RawTransactionInput,
+        RawTransactionOutput, RescanBlockchain, SendMany, SendRawTransaction, SendToAddress,
+        SignMessage, SignMessageWithPrivKey, SignRawTransaction, SignRawTransactionError,
+        SoftforkReject, TestMempoolAccept, TransactionCategory, UploadTarget, ValidateAddress,
+        ValidateAddressError, VerifyChain, VerifyMessage, VerifyTxOutProof, WalletCreateFundedPsbt,
+        WalletCreateFundedPsbtError, WalletProcessPsbt, WitnessUtxo,
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
-        AnalyzePsbtInputMissingError, GetNodeAddresses, GetRpcInfo, JoinPsbts, NodeAddress,
-        UtxoUpdatePsbt,
+        AnalyzePsbtInputMissingError, GetNodeAddresses, GetRpcInfo, JoinPsbts, ListUnspent,
+        ListUnspentItem, NodeAddress, UtxoUpdatePsbt,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -201,7 +201,7 @@
 //! | listreceivedbylabel                | version + model | TODO                                   |
 //! | listsinceblock                     | version + model | UNTESTED                               |
 //! | listtransactions                   | version + model | UNTESTED                               |
-//! | listunspent                        | version + model | UNTESTED                               |
+//! | listunspent                        | version + model |                                        |
 //! | listwalletdir                      | version         | TODO                                   |
 //! | listwallets                        | version + model | UNTESTED                               |
 //! | loadwallet                         | version + model |                                        |
@@ -271,19 +271,18 @@ pub use crate::{
         ListLockUnspent, ListLockUnspentItem, ListLockUnspentItemError, ListReceivedByAddress,
         ListReceivedByAddressError, ListReceivedByAddressItem, ListSinceBlock, ListSinceBlockError,
         ListSinceBlockTransaction, ListSinceBlockTransactionError, ListTransactions,
-        ListTransactionsItem, ListTransactionsItemError, ListUnspent, ListUnspentItem,
-        ListUnspentItemError, ListWallets, Locked, PeerInfo, PruneBlockchain, RawTransactionError,
-        RawTransactionInput, RawTransactionOutput, RescanBlockchain, SendMany, SendRawTransaction,
-        SendToAddress, SignMessage, SignMessageWithPrivKey, SignRawTransaction,
-        SignRawTransactionError, SoftforkReject, TestMempoolAccept, TransactionCategory,
-        UploadTarget, ValidateAddress, ValidateAddressError, VerifyChain, VerifyMessage,
-        VerifyTxOutProof, WalletCreateFundedPsbt, WalletCreateFundedPsbtError, WalletProcessPsbt,
-        WitnessUtxo,
+        ListTransactionsItem, ListTransactionsItemError, ListUnspentItemError, ListWallets, Locked,
+        PeerInfo, PruneBlockchain, RawTransactionError, RawTransactionInput, RawTransactionOutput,
+        RescanBlockchain, SendMany, SendRawTransaction, SendToAddress, SignMessage,
+        SignMessageWithPrivKey, SignRawTransaction, SignRawTransactionError, SoftforkReject,
+        TestMempoolAccept, TransactionCategory, UploadTarget, ValidateAddress,
+        ValidateAddressError, VerifyChain, VerifyMessage, VerifyTxOutProof, WalletCreateFundedPsbt,
+        WalletCreateFundedPsbtError, WalletProcessPsbt, WitnessUtxo,
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
-        AnalyzePsbtInputMissingError, GetNodeAddresses, GetRpcInfo, JoinPsbts, NodeAddress,
-        UtxoUpdatePsbt,
+        AnalyzePsbtInputMissingError, GetNodeAddresses, GetRpcInfo, JoinPsbts, ListUnspent,
+        ListUnspentItem, NodeAddress, UtxoUpdatePsbt,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -209,7 +209,7 @@
 //! | listreceivedbylabel                | version + model | TODO                                   |
 //! | listsinceblock                     | version + model | UNTESTED                               |
 //! | listtransactions                   | version + model | UNTESTED                               |
-//! | listunspent                        | version + model | UNTESTED                               |
+//! | listunspent                        | version + model |                                        |
 //! | listwalletdir                      | version         | TODO                                   |
 //! | listwallets                        | version + model | UNTESTED                               |
 //! | loadwallet                         | version + model |                                        |
@@ -291,18 +291,18 @@ pub use crate::{
         ListLockUnspentItemError, ListReceivedByAddress, ListReceivedByAddressError,
         ListReceivedByAddressItem, ListSinceBlock, ListSinceBlockError, ListSinceBlockTransaction,
         ListSinceBlockTransactionError, ListTransactions, ListTransactionsItem,
-        ListTransactionsItemError, ListUnspent, ListUnspentItem, ListUnspentItemError, ListWallets,
-        Locked, PeerInfo, PruneBlockchain, RawTransactionError, RawTransactionInput,
-        RawTransactionOutput, RescanBlockchain, SendMany, SendRawTransaction, SendToAddress,
-        SignMessage, SignMessageWithPrivKey, SignRawTransaction, SignRawTransactionError,
-        SoftforkReject, TestMempoolAccept, TransactionCategory, UploadTarget, ValidateAddress,
+        ListTransactionsItemError, ListUnspentItemError, ListWallets, Locked, PeerInfo,
+        PruneBlockchain, RawTransactionError, RawTransactionInput, RawTransactionOutput,
+        RescanBlockchain, SendMany, SendRawTransaction, SendToAddress, SignMessage,
+        SignMessageWithPrivKey, SignRawTransaction, SignRawTransactionError, SoftforkReject,
+        TestMempoolAccept, TransactionCategory, UploadTarget, ValidateAddress,
         ValidateAddressError, VerifyChain, VerifyMessage, VerifyTxOutProof, WalletCreateFundedPsbt,
         WalletCreateFundedPsbtError, WalletProcessPsbt, WitnessUtxo,
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
-        AnalyzePsbtInputMissingError, GetNodeAddresses, GetRpcInfo, JoinPsbts, NodeAddress,
-        UtxoUpdatePsbt,
+        AnalyzePsbtInputMissingError, GetNodeAddresses, GetRpcInfo, JoinPsbts, ListUnspent,
+        ListUnspentItem, NodeAddress, UtxoUpdatePsbt,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -209,7 +209,7 @@
 //! | listreceivedbylabel                | version + model | TODO                                   |
 //! | listsinceblock                     | version + model | UNTESTED                               |
 //! | listtransactions                   | version + model | UNTESTED                               |
-//! | listunspent                        | version + model | UNTESTED                               |
+//! | listunspent                        | version + model |                                        |
 //! | listwalletdir                      | version         | TODO                                   |
 //! | listwallets                        | version + model | UNTESTED                               |
 //! | loadwallet                         | version + model |                                        |
@@ -275,18 +275,18 @@ pub use crate::{
         ListLockUnspentItemError, ListReceivedByAddress, ListReceivedByAddressError,
         ListReceivedByAddressItem, ListSinceBlock, ListSinceBlockError, ListSinceBlockTransaction,
         ListSinceBlockTransactionError, ListTransactions, ListTransactionsItem,
-        ListTransactionsItemError, ListUnspent, ListUnspentItem, ListUnspentItemError, ListWallets,
-        Locked, PeerInfo, PruneBlockchain, RawTransactionError, RawTransactionInput,
-        RawTransactionOutput, RescanBlockchain, SendMany, SendRawTransaction, SendToAddress,
-        SignMessage, SignMessageWithPrivKey, SignRawTransaction, SignRawTransactionError,
-        SoftforkReject, TestMempoolAccept, TransactionCategory, UploadTarget, ValidateAddress,
+        ListTransactionsItemError, ListUnspentItemError, ListWallets, Locked, PeerInfo,
+        PruneBlockchain, RawTransactionError, RawTransactionInput, RawTransactionOutput,
+        RescanBlockchain, SendMany, SendRawTransaction, SendToAddress, SignMessage,
+        SignMessageWithPrivKey, SignRawTransaction, SignRawTransactionError, SoftforkReject,
+        TestMempoolAccept, TransactionCategory, UploadTarget, ValidateAddress,
         ValidateAddressError, VerifyChain, VerifyMessage, VerifyTxOutProof, WalletCreateFundedPsbt,
         WalletCreateFundedPsbtError, WalletProcessPsbt, WitnessUtxo,
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
-        AnalyzePsbtInputMissingError, GetNodeAddresses, GetRpcInfo, JoinPsbts, NodeAddress,
-        UtxoUpdatePsbt,
+        AnalyzePsbtInputMissingError, GetNodeAddresses, GetRpcInfo, JoinPsbts, ListUnspent,
+        ListUnspentItem, NodeAddress, UtxoUpdatePsbt,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -211,7 +211,7 @@
 //! | listreceivedbylabel                | version + model | TODO                                   |
 //! | listsinceblock                     | version + model | UNTESTED                               |
 //! | listtransactions                   | version + model | UNTESTED                               |
-//! | listunspent                        | version + model | UNTESTED                               |
+//! | listunspent                        | version + model |                                        |
 //! | listwalletdir                      | version         | TODO                                   |
 //! | listwallets                        | version + model | UNTESTED                               |
 //! | loadwallet                         | version + model |                                        |
@@ -283,18 +283,18 @@ pub use crate::{
         ListReceivedByAddress, ListReceivedByAddressError, ListReceivedByAddressItem,
         ListSinceBlock, ListSinceBlockError, ListSinceBlockTransaction,
         ListSinceBlockTransactionError, ListTransactions, ListTransactionsItem,
-        ListTransactionsItemError, ListUnspent, ListUnspentItem, ListUnspentItemError, ListWallets,
-        Locked, PeerInfo, PruneBlockchain, RawTransactionError, RawTransactionInput,
-        RawTransactionOutput, RescanBlockchain, SendMany, SendRawTransaction, SendToAddress,
-        SignMessage, SignMessageWithPrivKey, SignRawTransaction, SignRawTransactionError,
-        SoftforkReject, TestMempoolAccept, TransactionCategory, UploadTarget, ValidateAddress,
+        ListTransactionsItemError, ListUnspentItemError, ListWallets, Locked, PeerInfo,
+        PruneBlockchain, RawTransactionError, RawTransactionInput, RawTransactionOutput,
+        RescanBlockchain, SendMany, SendRawTransaction, SendToAddress, SignMessage,
+        SignMessageWithPrivKey, SignRawTransaction, SignRawTransactionError, SoftforkReject,
+        TestMempoolAccept, TransactionCategory, UploadTarget, ValidateAddress,
         ValidateAddressError, VerifyChain, VerifyMessage, VerifyTxOutProof, WalletCreateFundedPsbt,
         WalletCreateFundedPsbtError, WalletProcessPsbt, WitnessUtxo,
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
-        AnalyzePsbtInputMissingError, GetNodeAddresses, GetRpcInfo, JoinPsbts, NodeAddress,
-        UtxoUpdatePsbt,
+        AnalyzePsbtInputMissingError, GetNodeAddresses, GetRpcInfo, JoinPsbts, ListUnspent,
+        ListUnspentItem, NodeAddress, UtxoUpdatePsbt,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -212,7 +212,7 @@
 //! | listreceivedbylabel                | version + model | TODO                                   |
 //! | listsinceblock                     | version + model | UNTESTED                               |
 //! | listtransactions                   | version + model | UNTESTED                               |
-//! | listunspent                        | version + model | UNTESTED                               |
+//! | listunspent                        | version + model |                                        |
 //! | listwalletdir                      | version         | TODO                                   |
 //! | listwallets                        | version + model | UNTESTED                               |
 //! | loadwallet                         | version + model |                                        |
@@ -294,18 +294,18 @@ pub use crate::{
         ListReceivedByAddress, ListReceivedByAddressError, ListReceivedByAddressItem,
         ListSinceBlock, ListSinceBlockError, ListSinceBlockTransaction,
         ListSinceBlockTransactionError, ListTransactions, ListTransactionsItem,
-        ListTransactionsItemError, ListUnspent, ListUnspentItem, ListUnspentItemError, ListWallets,
-        Locked, PeerInfo, PruneBlockchain, RawTransactionError, RawTransactionInput,
-        RawTransactionOutput, RescanBlockchain, SendMany, SendRawTransaction, SendToAddress,
-        SignMessage, SignMessageWithPrivKey, SignRawTransaction, SignRawTransactionError,
-        TestMempoolAccept, TransactionCategory, UploadTarget, ValidateAddress,
-        ValidateAddressError, VerifyChain, VerifyMessage, VerifyTxOutProof, WalletCreateFundedPsbt,
-        WalletCreateFundedPsbtError, WalletProcessPsbt, WitnessUtxo,
+        ListTransactionsItemError, ListUnspentItemError, ListWallets, Locked, PeerInfo,
+        PruneBlockchain, RawTransactionError, RawTransactionInput, RawTransactionOutput,
+        RescanBlockchain, SendMany, SendRawTransaction, SendToAddress, SignMessage,
+        SignMessageWithPrivKey, SignRawTransaction, SignRawTransactionError, TestMempoolAccept,
+        TransactionCategory, UploadTarget, ValidateAddress, ValidateAddressError, VerifyChain,
+        VerifyMessage, VerifyTxOutProof, WalletCreateFundedPsbt, WalletCreateFundedPsbtError,
+        WalletProcessPsbt, WitnessUtxo,
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
-        AnalyzePsbtInputMissingError, GetNodeAddresses, GetRpcInfo, JoinPsbts, NodeAddress,
-        UtxoUpdatePsbt,
+        AnalyzePsbtInputMissingError, GetNodeAddresses, GetRpcInfo, JoinPsbts, ListUnspent,
+        ListUnspentItem, NodeAddress, UtxoUpdatePsbt,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalances, GetBalancesMine,


### PR DESCRIPTION
While working on [#187](https://github.com/rust-bitcoin/corepc/issues/187), I wrote a test for the listunspent method to better understand the issue. The test timed out in my local environment, so I pushed it here to run in CI and confirm the behavior. I found that although the account field has been deprecated and is no longer included in the response, ListUnspentItem still expects it to be present, which causes a deserialization error.

While writing this test, I also discovered a related issue:
The into_model method is implemented for ListUnspentItem and ListUnspentItemError, but not for the top-level ListUnspent type. This makes it harder to convert the full response into a usable model and limits how we can work with the data.

Closes #187
Closes #189