### PR TITLE
Add model for getnodeaddresses

### DIFF
--- a/integration_test/tests/network.rs
+++ b/integration_test/tests/network.rs
@@ -37,10 +37,11 @@ fn network__get_network_info__modelled() {
 fn network__get_node_addresses() {
     let node = Node::with_wallet(Wallet::None, &[]);
     let json: GetNodeAddresses = node.client.get_node_addresses().expect("getnodeaddresses");
-    assert!(json.0.len() <= 2500);
-    if let Some(addr) = json.0.first() {
+    let res: Result<mtype::GetNodeAddresses, _> = json.into_model();
+    let model = res.expect("GetNodeAddresses into model");
+    assert!(model.0.len() <= 2500);
+    if let Some(addr) = model.0.first() {
         assert!(addr.port > 0);
-        assert!(!addr.address.is_empty());
         assert!(addr.time > 1231006505);
     }
 }

--- a/types/src/model/mod.rs
+++ b/types/src/model/mod.rs
@@ -34,7 +34,9 @@ pub use self::{
         BlockTemplateTransaction, GetBlockTemplate, GetPrioritisedTransactions,
         PrioritisedTransaction,
     },
-    network::{GetNetworkInfo, GetNetworkInfoAddress, GetNetworkInfoNetwork},
+    network::{
+        GetNetworkInfo, GetNetworkInfoAddress, GetNetworkInfoNetwork, GetNodeAddresses, NodeAddress,
+    },
     raw_transactions::{
         AnalyzePsbt, AnalyzePsbtInput, AnalyzePsbtInputMissing, CombinePsbt, CombineRawTransaction,
         ConvertToPsbt, CreatePsbt, CreateRawTransaction, DecodePsbt, DecodeRawTransaction,

--- a/types/src/model/network.rs
+++ b/types/src/model/network.rs
@@ -5,7 +5,8 @@
 //! These structs model the types returned by the JSON-RPC API but have concrete types
 //! and are not specific to a specific version of Bitcoin Core.
 
-use bitcoin::FeeRate;
+use bitcoin::address::NetworkUnchecked;
+use bitcoin::{Address, FeeRate};
 use serde::{Deserialize, Serialize};
 
 /// Models the result of JSON-RPC method `getnetworkinfo`.
@@ -63,4 +64,25 @@ pub struct GetNetworkInfoAddress {
     pub port: u16,
     /// Relative score.
     pub score: u32,
+}
+
+/// Result of JSON-RPC method `getnodeaddresses`.
+///
+/// > getnodeaddresses ( count )
+/// >
+/// > Return known addresses which can potentially be used to find new nodes in the network.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct GetNodeAddresses(pub Vec<NodeAddress>);
+
+/// An item from the list returned by the JSON-RPC method `getnodeaddresses`.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct NodeAddress {
+    /// Timestamp in seconds since epoch (Jan 1 1970 GMT) when the node was last seen.
+    pub time: u64,
+    /// The services offered.
+    pub services: u64,
+    /// The address of the node.
+    pub address: Address<NetworkUnchecked>,
+    /// The port of the node.
+    pub port: u16,
 }

--- a/types/src/v18/mod.rs
+++ b/types/src/v18/mod.rs
@@ -103,7 +103,7 @@
 //! | getconnectioncount                 | returns numeric |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
-//! | getnodeaddresses                   | version         |                                        |
+//! | getnodeaddresses                   | version + model |                                        |
 //! | getpeerinfo                        | version         |                                        |
 //! | listbanned                         | returns string  |                                        |
 //! | ping                               | returns nothing |                                        |

--- a/types/src/v18/network/into.rs
+++ b/types/src/v18/network/into.rs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: CC0-1.0
+
+use bitcoin::address::NetworkUnchecked;
+use bitcoin::{address, Address};
+
+use super::{GetNodeAddresses, NodeAddress};
+use crate::model;
+
+impl GetNodeAddresses {
+    /// Converts version specific type to a version nonspecific, more strongly typed type.
+    pub fn into_model(self) -> Result<model::GetNodeAddresses, address::ParseError> {
+        let nodes = self.0.into_iter().map(|n| n.into_model()).collect::<Result<_, _>>()?;
+        Ok(model::GetNodeAddresses(nodes))
+    }
+}
+
+impl NodeAddress {
+    /// Converts version specific type to a version nonspecific, more strongly typed type.
+    pub fn into_model(self) -> Result<model::NodeAddress, address::ParseError> {
+        let address = self.address.parse::<Address<NetworkUnchecked>>()?;
+        Ok(model::NodeAddress {
+            time: self.time,
+            services: self.services,
+            address,
+            port: self.port,
+        })
+    }
+}

--- a/types/src/v18/network/mod.rs
+++ b/types/src/v18/network/mod.rs
@@ -4,6 +4,8 @@
 //!
 //! Types for methods found under the `== Network ==` section of the API docs.
 
+mod into;
+
 use serde::{Deserialize, Serialize};
 
 /// Result of JSON-RPC method `getnodeaddresses`.

--- a/types/src/v19/mod.rs
+++ b/types/src/v19/mod.rs
@@ -103,7 +103,7 @@
 //! | getconnectioncount                 | returns numeric |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
-//! | getnodeaddresses                   | version         |                                        |
+//! | getnodeaddresses                   | version + model |                                        |
 //! | getpeerinfo                        | version         |                                        |
 //! | listbanned                         | returns string  |                                        |
 //! | ping                               | returns nothing |                                        |

--- a/types/src/v20/mod.rs
+++ b/types/src/v20/mod.rs
@@ -104,7 +104,7 @@
 //! | getconnectioncount                 | returns numeric |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
-//! | getnodeaddresses                   | version         |                                        |
+//! | getnodeaddresses                   | version + model |                                        |
 //! | getpeerinfo                        | version         |                                        |
 //! | listbanned                         | returns string  |                                        |
 //! | ping                               | returns nothing |                                        |

--- a/types/src/v21/mod.rs
+++ b/types/src/v21/mod.rs
@@ -105,7 +105,7 @@
 //! | getconnectioncount                 | returns numeric |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
-//! | getnodeaddresses                   | version         |                                        |
+//! | getnodeaddresses                   | version + model |                                        |
 //! | getpeerinfo                        | version         |                                        |
 //! | listbanned                         | returns string  |                                        |
 //! | ping                               | returns nothing |                                        |

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -105,7 +105,7 @@
 //! | getconnectioncount                 | returns numeric |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
-//! | getnodeaddresses                   | version         |                                        |
+//! | getnodeaddresses                   | version + model | TODO                                   |
 //! | getpeerinfo                        | version         |                                        |
 //! | listbanned                         | returns string  |                                        |
 //! | ping                               | returns nothing |                                        |

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -96,7 +96,7 @@
 //! | getconnectioncount                 | returns numeric |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
-//! | getnodeaddresses                   | version         |                                        |
+//! | getnodeaddresses                   | version + model | TODO                                   |
 //! | getpeerinfo                        | version         |                                        |
 //! | listbanned                         | returns string  |                                        |
 //! | ping                               | returns nothing |                                        |

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -97,7 +97,7 @@
 //! | getconnectioncount                 | returns numeric |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
-//! | getnodeaddresses                   | version         |                                        |
+//! | getnodeaddresses                   | version + model | TODO                                   ||
 //! | getpeerinfo                        | version         |                                        |
 //! | listbanned                         | returns string  |                                        |
 //! | ping                               | returns nothing |                                        |

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -98,7 +98,7 @@
 //! | getconnectioncount                 | returns numeric |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
-//! | getnodeaddresses                   | version         |                                        |
+//! | getnodeaddresses                   | version + model | TODO                                   |
 //! | getpeerinfo                        | version         |                                        |
 //! | listbanned                         | returns string  |                                        |
 //! | ping                               | returns nothing |                                        |

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -104,7 +104,7 @@
 //! | getconnectioncount                 | returns numeric |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
-//! | getnodeaddresses                   | version         |                                        |
+//! | getnodeaddresses                   | version + model | TODO                                   |
 //! | getpeerinfo                        | version         |                                        |
 //! | listbanned                         | returns string  |                                        |
 //! | ping                               | returns nothing |                                        |

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -104,7 +104,7 @@
 //! | getconnectioncount                 | returns numeric |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
-//! | getnodeaddresses                   | version         |                                        |
+//! | getnodeaddresses                   | version + model | TODO                                   |
 //! | getpeerinfo                        | version         |                                        |
 //! | listbanned                         | returns string  |                                        |
 //! | ping                               | returns nothing |                                        |

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -104,7 +104,7 @@
 //! | getconnectioncount                 | returns numeric |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
-//! | getnodeaddresses                   | version         |                                        |
+//! | getnodeaddresses                   | version + model | TODO                                   |
 //! | getpeerinfo                        | version         |                                        |
 //! | listbanned                         | returns string  |                                        |
 //! | ping                               | returns nothing |                                        |

--- a/verify/src/method/v18.rs
+++ b/verify/src/method/v18.rs
@@ -60,7 +60,7 @@ pub const METHODS: &[Method] = &[
     Method::new_numeric("getconnectioncount", "get_connection_count"),
     Method::new_no_model("getnettotals", "GetNetTotals", "get_net_totals"),
     Method::new_modelled("getnetworkinfo", "GetNetworkInfo", "get_network_info"),
-    Method::new_no_model("getnodeaddresses", "GetNodeAddresses", "get_node_addresses"),
+    Method::new_modelled("getnodeaddresses", "GetNodeAddresses", "get_node_addresses"),
     Method::new_no_model("getpeerinfo", "GetPeerInfo", "get_peer_info"),
     Method::new_string("listbanned", "list_banned"), // v17 docs seem wrong, says no return.
     Method::new_nothing("ping", "ping"),

--- a/verify/src/method/v19.rs
+++ b/verify/src/method/v19.rs
@@ -60,7 +60,7 @@ pub const METHODS: &[Method] = &[
     Method::new_numeric("getconnectioncount", "get_connection_count"),
     Method::new_no_model("getnettotals", "GetNetTotals", "get_net_totals"),
     Method::new_modelled("getnetworkinfo", "GetNetworkInfo", "get_network_info"),
-    Method::new_no_model("getnodeaddresses", "GetNodeAddresses", "get_node_addresses"),
+    Method::new_modelled("getnodeaddresses", "GetNodeAddresses", "get_node_addresses"),
     Method::new_no_model("getpeerinfo", "GetPeerInfo", "get_peer_info"),
     Method::new_string("listbanned", "list_banned"), // v17 docs seem wrong, says no return.
     Method::new_nothing("ping", "ping"),

--- a/verify/src/method/v20.rs
+++ b/verify/src/method/v20.rs
@@ -61,7 +61,7 @@ pub const METHODS: &[Method] = &[
     Method::new_numeric("getconnectioncount", "get_connection_count"),
     Method::new_no_model("getnettotals", "GetNetTotals", "get_net_totals"),
     Method::new_modelled("getnetworkinfo", "GetNetworkInfo", "get_network_info"),
-    Method::new_no_model("getnodeaddresses", "GetNodeAddresses", "get_node_addresses"),
+    Method::new_modelled("getnodeaddresses", "GetNodeAddresses", "get_node_addresses"),
     Method::new_no_model("getpeerinfo", "GetPeerInfo", "get_peer_info"),
     Method::new_string("listbanned", "list_banned"), // v17 docs seem wrong, says no return.
     Method::new_nothing("ping", "ping"),

--- a/verify/src/method/v21.rs
+++ b/verify/src/method/v21.rs
@@ -62,7 +62,7 @@ pub const METHODS: &[Method] = &[
     Method::new_numeric("getconnectioncount", "get_connection_count"),
     Method::new_no_model("getnettotals", "GetNetTotals", "get_net_totals"),
     Method::new_modelled("getnetworkinfo", "GetNetworkInfo", "get_network_info"),
-    Method::new_no_model("getnodeaddresses", "GetNodeAddresses", "get_node_addresses"),
+    Method::new_modelled("getnodeaddresses", "GetNodeAddresses", "get_node_addresses"),
     Method::new_no_model("getpeerinfo", "GetPeerInfo", "get_peer_info"),
     Method::new_string("listbanned", "list_banned"), // v17 docs seem wrong, says no return.
     Method::new_nothing("ping", "ping"),

--- a/verify/src/method/v22.rs
+++ b/verify/src/method/v22.rs
@@ -62,7 +62,7 @@ pub const METHODS: &[Method] = &[
     Method::new_numeric("getconnectioncount", "get_connection_count"),
     Method::new_no_model("getnettotals", "GetNetTotals", "get_net_totals"),
     Method::new_modelled("getnetworkinfo", "GetNetworkInfo", "get_network_info"),
-    Method::new_no_model("getnodeaddresses", "GetNodeAddresses", "get_node_addresses"),
+    Method::new_modelled("getnodeaddresses", "GetNodeAddresses", "get_node_addresses"),
     Method::new_no_model("getpeerinfo", "GetPeerInfo", "get_peer_info"),
     Method::new_string("listbanned", "list_banned"), // v17 docs seem wrong, says no return.
     Method::new_nothing("ping", "ping"),

--- a/verify/src/method/v23.rs
+++ b/verify/src/method/v23.rs
@@ -60,7 +60,7 @@ pub const METHODS: &[Method] = &[
     Method::new_numeric("getconnectioncount", "get_connection_count"),
     Method::new_no_model("getnettotals", "GetNetTotals", "get_net_totals"),
     Method::new_modelled("getnetworkinfo", "GetNetworkInfo", "get_network_info"),
-    Method::new_no_model("getnodeaddresses", "GetNodeAddresses", "get_node_addresses"),
+    Method::new_modelled("getnodeaddresses", "GetNodeAddresses", "get_node_addresses"),
     Method::new_no_model("getpeerinfo", "GetPeerInfo", "get_peer_info"),
     Method::new_string("listbanned", "list_banned"), // v17 docs seem wrong, says no return.
     Method::new_nothing("ping", "ping"),

--- a/verify/src/method/v24.rs
+++ b/verify/src/method/v24.rs
@@ -61,7 +61,7 @@ pub const METHODS: &[Method] = &[
     Method::new_numeric("getconnectioncount", "get_connection_count"),
     Method::new_no_model("getnettotals", "GetNetTotals", "get_net_totals"),
     Method::new_modelled("getnetworkinfo", "GetNetworkInfo", "get_network_info"),
-    Method::new_no_model("getnodeaddresses", "GetNodeAddresses", "get_node_addresses"),
+    Method::new_modelled("getnodeaddresses", "GetNodeAddresses", "get_node_addresses"),
     Method::new_no_model("getpeerinfo", "GetPeerInfo", "get_peer_info"),
     Method::new_string("listbanned", "list_banned"), // v17 docs seem wrong, says no return.
     Method::new_nothing("ping", "ping"),

--- a/verify/src/method/v25.rs
+++ b/verify/src/method/v25.rs
@@ -62,7 +62,7 @@ pub const METHODS: &[Method] = &[
     Method::new_numeric("getconnectioncount", "get_connection_count"),
     Method::new_no_model("getnettotals", "GetNetTotals", "get_net_totals"),
     Method::new_modelled("getnetworkinfo", "GetNetworkInfo", "get_network_info"),
-    Method::new_no_model("getnodeaddresses", "GetNodeAddresses", "get_node_addresses"),
+    Method::new_modelled("getnodeaddresses", "GetNodeAddresses", "get_node_addresses"),
     Method::new_no_model("getpeerinfo", "GetPeerInfo", "get_peer_info"),
     Method::new_string("listbanned", "list_banned"), // v17 docs seem wrong, says no return.
     Method::new_nothing("ping", "ping"),

--- a/verify/src/method/v26.rs
+++ b/verify/src/method/v26.rs
@@ -68,7 +68,7 @@ pub const METHODS: &[Method] = &[
     Method::new_numeric("getconnectioncount", "get_connection_count"),
     Method::new_no_model("getnettotals", "GetNetTotals", "get_net_totals"),
     Method::new_modelled("getnetworkinfo", "GetNetworkInfo", "get_network_info"),
-    Method::new_no_model("getnodeaddresses", "GetNodeAddresses", "get_node_addresses"),
+    Method::new_modelled("getnodeaddresses", "GetNodeAddresses", "get_node_addresses"),
     Method::new_no_model("getpeerinfo", "GetPeerInfo", "get_peer_info"),
     Method::new_string("listbanned", "list_banned"), // v17 docs seem wrong, says no return.
     Method::new_nothing("ping", "ping"),

--- a/verify/src/method/v27.rs
+++ b/verify/src/method/v27.rs
@@ -70,7 +70,7 @@ pub const METHODS: &[Method] = &[
     Method::new_numeric("getconnectioncount", "get_connection_count"),
     Method::new_no_model("getnettotals", "GetNetTotals", "get_net_totals"),
     Method::new_modelled("getnetworkinfo", "GetNetworkInfo", "get_network_info"),
-    Method::new_no_model("getnodeaddresses", "GetNodeAddresses", "get_node_addresses"),
+    Method::new_modelled("getnodeaddresses", "GetNodeAddresses", "get_node_addresses"),
     Method::new_no_model("getpeerinfo", "GetPeerInfo", "get_peer_info"),
     Method::new_string("listbanned", "list_banned"), // v17 docs seem wrong, says no return.
     Method::new_nothing("ping", "ping"),

--- a/verify/src/method/v28.rs
+++ b/verify/src/method/v28.rs
@@ -70,7 +70,7 @@ pub const METHODS: &[Method] = &[
     Method::new_numeric("getconnectioncount", "get_connection_count"),
     Method::new_no_model("getnettotals", "GetNetTotals", "get_net_totals"),
     Method::new_modelled("getnetworkinfo", "GetNetworkInfo", "get_network_info"),
-    Method::new_no_model("getnodeaddresses", "GetNodeAddresses", "get_node_addresses"),
+    Method::new_modelled("getnodeaddresses", "GetNodeAddresses", "get_node_addresses"),
     Method::new_no_model("getpeerinfo", "GetPeerInfo", "get_peer_info"),
     Method::new_string("listbanned", "list_banned"), // v17 docs seem wrong, says no return.
     Method::new_nothing("ping", "ping"),


### PR DESCRIPTION
GetNodeAddresses returns an Address.  Create a bitcoin::Address model for it and modify the test to use it.

Implement for v18 to v21. In v22 the return changes, label v22 to v28 as TODO.