### PR TITLE
Give PR labler permission to edit the PR

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,6 +1,6 @@
 name: PR Labeler
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 jobs:


### PR DESCRIPTION
When triggered on pull_request the workflow has read only access to PR's from other forks.

Change the trigger to use the base repo's token and permissions.