### PR TITLE
PR labeler workflow: Change the case of the labels to match the repo

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -27,12 +27,12 @@ jobs:
             );
 
             const filePathsToLabels = {
-              'node/': 'c-node',
-              'client/': 'c-client',
-              'integration_test/': 'c-integration_test',
-              'jsonrpc/': 'c-jsonrpc',
-              'types/': 'c-types',
-              'verify/': 'c-verify'
+              'node/': 'C-node',
+              'client/': 'C-client',
+              'integration_test/': 'C-integration_test',
+              'jsonrpc/': 'C-jsonrpc',
+              'types/': 'C-types',
+              'verify/': 'C-verify'
             };
 
             const labelsToAdd = new Set();


### PR DESCRIPTION
The workflow file has a lower case `c` at the start of all the labels. Change to uppercase to match the labels in the repo.