### PR TITLE
PR Labeler workflow: Fix label name

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -29,7 +29,7 @@ jobs:
             const filePathsToLabels = {
               'node/': 'C-node',
               'client/': 'C-client',
-              'integration_test/': 'C-integration_test',
+              'integration_test/': 'C-integration-test',
               'jsonrpc/': 'C-jsonrpc',
               'types/': 'C-types',
               'verify/': 'C-verify'


### PR DESCRIPTION
The label name in the workflow had an `_` but should be a `-` to match the repo labels. This causes the workflow to fail if this tag is required.

Correct the name to use a -