### PR TITLE
Reduce duplication using conditional initialization in addnode test

### DIFF
--- a/integration_test/tests/network.rs
+++ b/integration_test/tests/network.rs
@@ -10,23 +10,18 @@ use node::{AddNodeCommand, mtype, SetBanCommand};
 
 #[test]
 fn network__add_node() {
+    let node = match () {
+        #[cfg(feature = "v25_and_below")]
+        () => Node::with_wallet(Wallet::None, &[]),
+        #[cfg(not(feature = "v25_and_below"))]
+        () => Node::with_wallet(Wallet::None, &["-v2transport"]),
+    };
+
     let dummy_peer = "192.0.2.1:8333";
 
-    #[cfg(feature = "v25_and_below")]
-    {
-        let node = Node::with_wallet(Wallet::None, &[]);
-        node.client.add_node(dummy_peer, AddNodeCommand::OneTry).expect("addnode onetry");
-        node.client.add_node(dummy_peer, AddNodeCommand::Add).expect("addnode add");
-        node.client.add_node(dummy_peer, AddNodeCommand::Remove).expect("addnode remove");
-    }
-
-    #[cfg(not(feature = "v25_and_below"))]
-    {
-        let node = Node::with_wallet(Wallet::None, &["-v2transport"]);
-        node.client.add_node(dummy_peer, AddNodeCommand::OneTry).expect("addnode onetry");
-        node.client.add_node(dummy_peer, AddNodeCommand::Add).expect("addnode add");
-        node.client.add_node(dummy_peer, AddNodeCommand::Remove).expect("addnode remove");
-    }
+    node.client.add_node(dummy_peer, AddNodeCommand::OneTry).expect("addnode onetry");
+    node.client.add_node(dummy_peer, AddNodeCommand::Add).expect("addnode add");
+    node.client.add_node(dummy_peer, AddNodeCommand::Remove).expect("addnode remove");
 }
 
 #[test]


### PR DESCRIPTION
This is done to reduce the duplication of code in the add_node test. It is also done to maintain consistency with existing tests already using such approach.