### PR TITLE
integration_test: Pause after node comes up

### DIFF
--- a/integration_test/src/lib.rs
+++ b/integration_test/src/lib.rs
@@ -69,7 +69,11 @@ impl NodeExt for Node {
             conf.args.push(arg);
         }
 
-        Node::with_conf(exe, &conf).expect("failed to create node")
+        let node = Node::with_conf(exe, &conf).expect("failed to create node");
+        // We are getting intermittent test fails.
+        // Just pause here to give the node time to sort itself out.
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        node
     }
 
     fn fund_wallet(&self) {


### PR DESCRIPTION
We are getting intermittent test failures stating that the node is not available. `node` already includes code that hits the RPC API after the node is up so this is a little surprising. However it doesn't hurt to try waiting a little still.

Just sleep for half a second after each node spins up and see if the intermittent failures go away.