### PR TITLE
Fix typo

### DIFF
--- a/verify/src/method/v19.rs
+++ b/verify/src/method/v19.rs
@@ -77,7 +77,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("decoderawtransaction", "decode_raw_transaction"),
     Method::new_nothing("decodescript", "decode_script"),
     Method::new_nothing("finalizepsbt", "finalize_psbt"),
-    Method::new_nothing("fundrawtransaction", "fund_raw_transaciton"),
+    Method::new_nothing("fundrawtransaction", "fund_raw_transaction"),
     Method::new_nothing("getrawtransaction", "get_raw_transaction"),
     Method::new_modelled("joinpsbts", "JoinPsbts", "join_psbts"),
     Method::new_modelled("sendrawtransaction", "SendRawTransaction", "send_raw_transaction"),

--- a/verify/src/method/v20.rs
+++ b/verify/src/method/v20.rs
@@ -78,7 +78,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("decoderawtransaction", "decode_raw_transaction"),
     Method::new_nothing("decodescript", "decode_script"),
     Method::new_nothing("finalizepsbt", "finalize_psbt"),
-    Method::new_nothing("fundrawtransaction", "fund_raw_transaciton"),
+    Method::new_nothing("fundrawtransaction", "fund_raw_transaction"),
     Method::new_nothing("getrawtransaction", "get_raw_transaction"),
     Method::new_modelled("joinpsbts", "JoinPsbts", "join_psbts"),
     Method::new_modelled("sendrawtransaction", "SendRawTransaction", "send_raw_transaction"),

--- a/verify/src/method/v21.rs
+++ b/verify/src/method/v21.rs
@@ -79,7 +79,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("decoderawtransaction", "decode_raw_transaction"),
     Method::new_nothing("decodescript", "decode_script"),
     Method::new_nothing("finalizepsbt", "finalize_psbt"),
-    Method::new_nothing("fundrawtransaction", "fund_raw_transaciton"),
+    Method::new_nothing("fundrawtransaction", "fund_raw_transaction"),
     Method::new_nothing("getrawtransaction", "get_raw_transaction"),
     Method::new_modelled("joinpsbts", "JoinPsbts", "join_psbts"),
     Method::new_modelled("sendrawtransaction", "SendRawTransaction", "send_raw_transaction"),

--- a/verify/src/method/v22.rs
+++ b/verify/src/method/v22.rs
@@ -79,7 +79,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("decoderawtransaction", "decode_raw_transaction"),
     Method::new_nothing("decodescript", "decode_script"),
     Method::new_nothing("finalizepsbt", "finalize_psbt"),
-    Method::new_nothing("fundrawtransaction", "fund_raw_transaciton"),
+    Method::new_nothing("fundrawtransaction", "fund_raw_transaction"),
     Method::new_nothing("getrawtransaction", "get_raw_transaction"),
     Method::new_modelled("joinpsbts", "JoinPsbts", "join_psbts"),
     Method::new_modelled("sendrawtransaction", "SendRawTransaction", "send_raw_transaction"),

--- a/verify/src/method/v23.rs
+++ b/verify/src/method/v23.rs
@@ -77,7 +77,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("decoderawtransaction", "decode_raw_transaction"),
     Method::new_nothing("decodescript", "decode_script"),
     Method::new_nothing("finalizepsbt", "finalize_psbt"),
-    Method::new_nothing("fundrawtransaction", "fund_raw_transaciton"),
+    Method::new_nothing("fundrawtransaction", "fund_raw_transaction"),
     Method::new_nothing("getrawtransaction", "get_raw_transaction"),
     Method::new_modelled("joinpsbts", "JoinPsbts", "join_psbts"),
     Method::new_modelled("sendrawtransaction", "SendRawTransaction", "send_raw_transaction"),

--- a/verify/src/method/v24.rs
+++ b/verify/src/method/v24.rs
@@ -78,7 +78,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("decoderawtransaction", "decode_raw_transaction"),
     Method::new_nothing("decodescript", "decode_script"),
     Method::new_nothing("finalizepsbt", "finalize_psbt"),
-    Method::new_nothing("fundrawtransaction", "fund_raw_transaciton"),
+    Method::new_nothing("fundrawtransaction", "fund_raw_transaction"),
     Method::new_nothing("getrawtransaction", "get_raw_transaction"),
     Method::new_modelled("joinpsbts", "JoinPsbts", "join_psbts"),
     Method::new_modelled("sendrawtransaction", "SendRawTransaction", "send_raw_transaction"),

--- a/verify/src/method/v25.rs
+++ b/verify/src/method/v25.rs
@@ -79,7 +79,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("decoderawtransaction", "decode_raw_transaction"),
     Method::new_nothing("decodescript", "decode_script"),
     Method::new_nothing("finalizepsbt", "finalize_psbt"),
-    Method::new_nothing("fundrawtransaction", "fund_raw_transaciton"),
+    Method::new_nothing("fundrawtransaction", "fund_raw_transaction"),
     Method::new_nothing("getrawtransaction", "get_raw_transaction"),
     Method::new_modelled("joinpsbts", "JoinPsbts", "join_psbts"),
     Method::new_modelled("sendrawtransaction", "SendRawTransaction", "send_raw_transaction"),

--- a/verify/src/method/v26.rs
+++ b/verify/src/method/v26.rs
@@ -85,7 +85,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("decodescript", "decode_script"),
     Method::new_modelled("descriptorprocesspsbt", "DescriptorProcessPsbt", "descriptor_process_psbt"),
     Method::new_nothing("finalizepsbt", "finalize_psbt"),
-    Method::new_nothing("fundrawtransaction", "fund_raw_transaciton"),
+    Method::new_nothing("fundrawtransaction", "fund_raw_transaction"),
     Method::new_nothing("getrawtransaction", "get_raw_transaction"),
     Method::new_modelled("joinpsbts", "JoinPsbts", "join_psbts"),
     Method::new_modelled("sendrawtransaction", "SendRawTransaction", "send_raw_transaction"),

--- a/verify/src/method/v27.rs
+++ b/verify/src/method/v27.rs
@@ -88,7 +88,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("decodescript", "decode_script"),
     Method::new_modelled("descriptorprocesspsbt", "DescriptorProcessPsbt", "descriptor_process_psbt"),
     Method::new_nothing("finalizepsbt", "finalize_psbt"),
-    Method::new_nothing("fundrawtransaction", "fund_raw_transaciton"),
+    Method::new_nothing("fundrawtransaction", "fund_raw_transaction"),
     Method::new_nothing("getrawtransaction", "get_raw_transaction"),
     Method::new_modelled("joinpsbts", "JoinPsbts", "join_psbts"),
     Method::new_modelled("sendrawtransaction", "SendRawTransaction", "send_raw_transaction"),

--- a/verify/src/method/v28.rs
+++ b/verify/src/method/v28.rs
@@ -88,7 +88,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("decodescript", "decode_script"),
     Method::new_modelled("descriptorprocesspsbt", "DescriptorProcessPsbt", "descriptor_process_psbt"),
     Method::new_nothing("finalizepsbt", "finalize_psbt"),
-    Method::new_nothing("fundrawtransaction", "fund_raw_transaciton"),
+    Method::new_nothing("fundrawtransaction", "fund_raw_transaction"),
     Method::new_nothing("getrawtransaction", "get_raw_transaction"),
     Method::new_modelled("joinpsbts", "JoinPsbts", "join_psbts"),
     Method::new_modelled("sendrawtransaction", "SendRawTransaction", "send_raw_transaction"),

--- a/verify/src/method/v29.rs
+++ b/verify/src/method/v29.rs
@@ -89,7 +89,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("decodescript", "decode_script"),
     Method::new_modelled("descriptorprocesspsbt", "DescriptorProcessPsbt", "descriptor_process_psbt"),
     Method::new_nothing("finalizepsbt", "finalize_psbt"),
-    Method::new_nothing("fundrawtransaction", "fund_raw_transaciton"),
+    Method::new_nothing("fundrawtransaction", "fund_raw_transaction"),
     Method::new_nothing("getrawtransaction", "get_raw_transaction"),
     Method::new_modelled("joinpsbts", "JoinPsbts", "join_psbts"),
     Method::new_modelled("sendrawtransaction", "SendRawTransaction", "send_raw_transaction"),


### PR DESCRIPTION
There was a typo in verify, found when renaming the macros using this list. To be honest I think I stared at it for an age before I saw the typo, the compiler was complaining but the macro was there! or so I thought.