### PR TITLE
Update 'returns (std)' to 'version' for version methods

### DIFF
--- a/types/src/v17/mod.rs
+++ b/types/src/v17/mod.rs
@@ -45,10 +45,10 @@
 //! | gettxoutproof                      | returns string  |                                        |
 //! | gettxoutsetinfo                    | version + model |                                        |
 //! | preciousblock                      | returns nothing |                                        |
-//! | pruneblockchain                    | returns numeric |                                        |
+//! | pruneblockchain                    | version         |                                        |
 //! | savemempool                        | returns nothing |                                        |
 //! | scantxoutset                       | omitted         | API marked as experimental             |
-//! | verifychain                        | returns boolean |                                        |
+//! | verifychain                        | version         |                                        |
 //! | verifytxoutproof                   | version + model |                                        |
 //!
 //! </details>
@@ -98,7 +98,7 @@
 //! | clearbanned                        | returns nothing |                                        |
 //! | disconnectnode                     | returns nothing |                                        |
 //! | getaddednodeinfo                   | version         |                                        |
-//! | getconnectioncount                 | returns numeric |                                        |
+//! | getconnectioncount                 | version         |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
 //! | getpeerinfo                        | version         |                                        |

--- a/types/src/v18/mod.rs
+++ b/types/src/v18/mod.rs
@@ -45,10 +45,10 @@
 //! | gettxoutproof                      | returns string  |                                        |
 //! | gettxoutsetinfo                    | version + model |                                        |
 //! | preciousblock                      | returns nothing |                                        |
-//! | pruneblockchain                    | returns numeric |                                        |
+//! | pruneblockchain                    | version         |                                        |
 //! | savemempool                        | returns nothing |                                        |
 //! | scantxoutset                       | omitted         | API marked as experimental             |
-//! | verifychain                        | returns boolean |                                        |
+//! | verifychain                        | version         |                                        |
 //! | verifytxoutproof                   | version + model |                                        |
 //!
 //! </details>
@@ -100,7 +100,7 @@
 //! | clearbanned                        | returns nothing |                                        |
 //! | disconnectnode                     | returns nothing |                                        |
 //! | getaddednodeinfo                   | version         |                                        |
-//! | getconnectioncount                 | returns numeric |                                        |
+//! | getconnectioncount                 | version         |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
 //! | getnodeaddresses                   | version + model |                                        |

--- a/types/src/v19/mod.rs
+++ b/types/src/v19/mod.rs
@@ -46,10 +46,10 @@
 //! | gettxoutproof                      | returns string  |                                        |
 //! | gettxoutsetinfo                    | version + model |                                        |
 //! | preciousblock                      | returns nothing |                                        |
-//! | pruneblockchain                    | returns numeric |                                        |
+//! | pruneblockchain                    | version         |                                        |
 //! | savemempool                        | returns nothing |                                        |
 //! | scantxoutset                       | omitted         | API marked as experimental             |
-//! | verifychain                        | returns boolean |                                        |
+//! | verifychain                        | version         |                                        |
 //! | verifytxoutproof                   | version + model |                                        |
 //!
 //! </details>
@@ -100,7 +100,7 @@
 //! | clearbanned                        | returns nothing |                                        |
 //! | disconnectnode                     | returns nothing |                                        |
 //! | getaddednodeinfo                   | version         |                                        |
-//! | getconnectioncount                 | returns numeric |                                        |
+//! | getconnectioncount                 | version         |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
 //! | getnodeaddresses                   | version + model |                                        |

--- a/types/src/v20/mod.rs
+++ b/types/src/v20/mod.rs
@@ -46,10 +46,10 @@
 //! | gettxoutproof                      | returns string  |                                        |
 //! | gettxoutsetinfo                    | version + model |                                        |
 //! | preciousblock                      | returns nothing |                                        |
-//! | pruneblockchain                    | returns numeric |                                        |
+//! | pruneblockchain                    | version         |                                        |
 //! | savemempool                        | returns nothing |                                        |
 //! | scantxoutset                       | omitted         | API marked as experimental             |
-//! | verifychain                        | returns boolean |                                        |
+//! | verifychain                        | version         |                                        |
 //! | verifytxoutproof                   | version + model |                                        |
 //!
 //! </details>
@@ -101,7 +101,7 @@
 //! | clearbanned                        | returns nothing |                                        |
 //! | disconnectnode                     | returns nothing |                                        |
 //! | getaddednodeinfo                   | version         |                                        |
-//! | getconnectioncount                 | returns numeric |                                        |
+//! | getconnectioncount                 | version         |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
 //! | getnodeaddresses                   | version + model |                                        |

--- a/types/src/v21/mod.rs
+++ b/types/src/v21/mod.rs
@@ -46,10 +46,10 @@
 //! | gettxoutproof                      | returns string  |                                        |
 //! | gettxoutsetinfo                    | version + model |                                        |
 //! | preciousblock                      | returns nothing |                                        |
-//! | pruneblockchain                    | returns numeric |                                        |
+//! | pruneblockchain                    | version         |                                        |
 //! | savemempool                        | returns nothing |                                        |
 //! | scantxoutset                       | omitted         | API marked as experimental             |
-//! | verifychain                        | returns boolean |                                        |
+//! | verifychain                        | version         |                                        |
 //! | verifytxoutproof                   | version + model |                                        |
 //!
 //! </details>
@@ -102,7 +102,7 @@
 //! | clearbanned                        | returns nothing |                                        |
 //! | disconnectnode                     | returns nothing |                                        |
 //! | getaddednodeinfo                   | version         |                                        |
-//! | getconnectioncount                 | returns numeric |                                        |
+//! | getconnectioncount                 | version         |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
 //! | getnodeaddresses                   | version + model |                                        |

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -46,10 +46,10 @@
 //! | gettxoutproof                      | returns string  |                                        |
 //! | gettxoutsetinfo                    | version + model |                                        |
 //! | preciousblock                      | returns nothing |                                        |
-//! | pruneblockchain                    | returns numeric |                                        |
+//! | pruneblockchain                    | version         |                                        |
 //! | savemempool                        | returns nothing |                                        |
 //! | scantxoutset                       | omitted         | API marked as experimental             |
-//! | verifychain                        | returns boolean |                                        |
+//! | verifychain                        | version         |                                        |
 //! | verifytxoutproof                   | version + model |                                        |
 //!
 //! </details>
@@ -102,7 +102,7 @@
 //! | clearbanned                        | returns nothing |                                        |
 //! | disconnectnode                     | returns nothing |                                        |
 //! | getaddednodeinfo                   | version         |                                        |
-//! | getconnectioncount                 | returns numeric |                                        |
+//! | getconnectioncount                 | version         |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
 //! | getnodeaddresses                   | version + model |                                        |

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -48,10 +48,10 @@
 //! | gettxoutproof                      | returns string  |                                        |
 //! | gettxoutsetinfo                    | version + model |                                        |
 //! | preciousblock                      | returns nothing |                                        |
-//! | pruneblockchain                    | returns numeric |                                        |
+//! | pruneblockchain                    | version         |                                        |
 //! | savemempool                        | version         |                                        |
 //! | scantxoutset                       | omitted         | API marked as experimental             |
-//! | verifychain                        | returns boolean |                                        |
+//! | verifychain                        | version         |                                        |
 //! | verifytxoutproof                   | version + model |                                        |
 //!
 //! </details>
@@ -93,7 +93,7 @@
 //! | clearbanned                        | returns nothing |                                        |
 //! | disconnectnode                     | returns nothing |                                        |
 //! | getaddednodeinfo                   | version         |                                        |
-//! | getconnectioncount                 | returns numeric |                                        |
+//! | getconnectioncount                 | version         |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
 //! | getnodeaddresses                   | version + model |                                        |

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -49,10 +49,10 @@
 //! | gettxoutsetinfo                    | version + model |                                        |
 //! | gettxspendingprevout               | version + model | TODO                                   |
 //! | preciousblock                      | returns nothing |                                        |
-//! | pruneblockchain                    | returns numeric |                                        |
+//! | pruneblockchain                    | version         |                                        |
 //! | savemempool                        | version         |                                        |
 //! | scantxoutset                       | omitted         | API marked as experimental             |
-//! | verifychain                        | returns boolean |                                        |
+//! | verifychain                        | version         |                                        |
 //! | verifytxoutproof                   | version + model |                                        |
 //!
 //! </details>
@@ -94,7 +94,7 @@
 //! | clearbanned                        | returns nothing |                                        |
 //! | disconnectnode                     | returns nothing |                                        |
 //! | getaddednodeinfo                   | version         |                                        |
-//! | getconnectioncount                 | returns numeric |                                        |
+//! | getconnectioncount                 | version         |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
 //! | getnodeaddresses                   | version + model |                                        |

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -49,11 +49,11 @@
 //! | gettxoutsetinfo                    | version + model |                                        |
 //! | gettxspendingprevout               | version + model | TODO                                   |
 //! | preciousblock                      | returns nothing |                                        |
-//! | pruneblockchain                    | returns numeric |                                        |
+//! | pruneblockchain                    | version         |                                        |
 //! | savemempool                        | version         |                                        |
 //! | scanblocks                         | version + model | TODO                                   |
 //! | scantxoutset                       | omitted         | API marked as experimental             |
-//! | verifychain                        | returns boolean |                                        |
+//! | verifychain                        | version         |                                        |
 //! | verifytxoutproof                   | version + model |                                        |
 //!
 //! </details>
@@ -95,7 +95,7 @@
 //! | clearbanned                        | returns nothing |                                        |
 //! | disconnectnode                     | returns nothing |                                        |
 //! | getaddednodeinfo                   | version         |                                        |
-//! | getconnectioncount                 | returns numeric |                                        |
+//! | getconnectioncount                 | version         |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
 //! | getnodeaddresses                   | version + model |                                        |

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -53,11 +53,11 @@
 //! | importmempool                      | version + model | TODO                                   |
 //! | loadtxoutset                       | version + model | TODO                                   |
 //! | preciousblock                      | returns nothing |                                        |
-//! | pruneblockchain                    | returns numeric |                                        |
+//! | pruneblockchain                    | version         |                                        |
 //! | savemempool                        | version         |                                        |
 //! | scanblocks                         | version + model | TODO                                   |
 //! | scantxoutset                       | omitted         | API marked as experimental             |
-//! | verifychain                        | returns boolean |                                        |
+//! | verifychain                        | version         |                                        |
 //! | verifytxoutproof                   | version + model |                                        |
 //!
 //! </details>
@@ -101,7 +101,7 @@
 //! | disconnectnode                     | returns nothing |                                        |
 //! | getaddednodeinfo                   | version         |                                        |
 //! | getaddrmaninfo                     | version + model | TODO                                   |
-//! | getconnectioncount                 | returns numeric |                                        |
+//! | getconnectioncount                 | version         |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
 //! | getnodeaddresses                   | version + model |                                        |

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -53,11 +53,11 @@
 //! | importmempool                      | version + model | TODO                                   |
 //! | loadtxoutset                       | version + model | TODO                                   |
 //! | preciousblock                      | returns nothing |                                        |
-//! | pruneblockchain                    | returns numeric |                                        |
+//! | pruneblockchain                    | version         |                                        |
 //! | savemempool                        | version         |                                        |
 //! | scanblocks                         | version + model | TODO                                   |
 //! | scantxoutset                       | omitted         | API marked as experimental             |
-//! | verifychain                        | returns boolean |                                        |
+//! | verifychain                        | version         |                                        |
 //! | verifytxoutproof                   | version + model |                                        |
 //!
 //! </details>
@@ -101,7 +101,7 @@
 //! | disconnectnode                     | returns nothing |                                        |
 //! | getaddednodeinfo                   | version         |                                        |
 //! | getaddrmaninfo                     | version + model | TODO                                   |
-//! | getconnectioncount                 | returns numeric |                                        |
+//! | getconnectioncount                 | version         |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
 //! | getnodeaddresses                   | version + model | TODO                                   |

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -53,11 +53,11 @@
 //! | importmempool                      | version + model | TODO                                   |
 //! | loadtxoutset                       | version + model | TODO                                   |
 //! | preciousblock                      | returns nothing |                                        |
-//! | pruneblockchain                    | returns numeric |                                        |
+//! | pruneblockchain                    | version         |                                        |
 //! | savemempool                        | version         |                                        |
 //! | scanblocks                         | version + model | TODO                                   |
 //! | scantxoutset                       | omitted         | API marked as experimental             |
-//! | verifychain                        | returns boolean |                                        |
+//! | verifychain                        | version         |                                        |
 //! | verifytxoutproof                   | version + model |                                        |
 //!
 //! </details>
@@ -101,7 +101,7 @@
 //! | disconnectnode                     | returns nothing |                                        |
 //! | getaddednodeinfo                   | version         |                                        |
 //! | getaddrmaninfo                     | version + model | TODO                                   |
-//! | getconnectioncount                 | returns numeric |                                        |
+//! | getconnectioncount                 | version         |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
 //! | getnodeaddresses                   | version + model |                                        |

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -54,11 +54,11 @@
 //! | importmempool                      | version + model | TODO                                   |
 //! | loadtxoutset                       | version + model | TODO                                   |
 //! | preciousblock                      | returns nothing |                                        |
-//! | pruneblockchain                    | returns numeric |                                        |
+//! | pruneblockchain                    | version         |                                        |
 //! | savemempool                        | version         |                                        |
 //! | scanblocks                         | version + model | TODO                                   |
 //! | scantxoutset                       | omitted         | API marked as experimental             |
-//! | verifychain                        | returns boolean |                                        |
+//! | verifychain                        | version         |                                        |
 //! | verifytxoutproof                   | version + model |                                        |
 //!
 //! </details>
@@ -102,7 +102,7 @@
 //! | disconnectnode                     | returns nothing |                                        |
 //! | getaddednodeinfo                   | version         |                                        |
 //! | getaddrmaninfo                     | version + model | TODO                                   |
-//! | getconnectioncount                 | returns numeric |                                        |
+//! | getconnectioncount                 | version         |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
 //! | getnodeaddresses                   | version + model |                                        |


### PR DESCRIPTION
This PR updates `returns (std)` to `version` for all methods that have been implemented to return a type which wraps a standard value.

Ref: #116