### PR TITLE
Implement ping method and test

### DIFF
--- a/client/src/client_sync/v17/mod.rs
+++ b/client/src/client_sync/v17/mod.rs
@@ -79,6 +79,7 @@ crate::impl_client_v17__get_connection_count!();
 crate::impl_client_v17__get_net_totals!();
 crate::impl_client_v17__get_network_info!();
 crate::impl_client_v17__get_peer_info!();
+crate::impl_client_v17__ping!();
 crate::impl_client_v17__set_ban!();
 
 // == Rawtransactions ==

--- a/client/src/client_sync/v17/network.rs
+++ b/client/src/client_sync/v17/network.rs
@@ -119,6 +119,22 @@ macro_rules! impl_client_v17__get_peer_info {
     };
 }
 
+/// Implements Bitcoin Core JSON-RPC API method `ping`
+#[macro_export]
+macro_rules! impl_client_v17__ping {
+    () => {
+        impl Client {
+            pub fn ping(&self) -> Result<()> {
+                match self.call("ping", &[]) {
+                    Ok(serde_json::Value::Null) => Ok(()),
+                    Ok(res) => Err(Error::Returned(res.to_string())),
+                    Err(err) => Err(err.into()),
+                }
+            }
+        }
+    };
+}
+
 /// Implements Bitcoin Core JSON-RPC API method `setban`
 #[macro_export]
 macro_rules! impl_client_v17__set_ban {

--- a/client/src/client_sync/v18/mod.rs
+++ b/client/src/client_sync/v18/mod.rs
@@ -84,6 +84,7 @@ crate::impl_client_v17__get_net_totals!();
 crate::impl_client_v17__get_network_info!();
 crate::impl_client_v18__get_node_addresses!();
 crate::impl_client_v17__get_peer_info!();
+crate::impl_client_v17__ping!();
 crate::impl_client_v17__set_ban!();
 
 // == Rawtransactions ==

--- a/client/src/client_sync/v19/mod.rs
+++ b/client/src/client_sync/v19/mod.rs
@@ -82,6 +82,7 @@ crate::impl_client_v17__get_net_totals!();
 crate::impl_client_v17__get_network_info!();
 crate::impl_client_v18__get_node_addresses!();
 crate::impl_client_v17__get_peer_info!();
+crate::impl_client_v17__ping!();
 crate::impl_client_v17__set_ban!();
 
 // == Rawtransactions ==

--- a/client/src/client_sync/v20/mod.rs
+++ b/client/src/client_sync/v20/mod.rs
@@ -79,6 +79,7 @@ crate::impl_client_v17__get_net_totals!();
 crate::impl_client_v17__get_network_info!();
 crate::impl_client_v18__get_node_addresses!();
 crate::impl_client_v17__get_peer_info!();
+crate::impl_client_v17__ping!();
 crate::impl_client_v17__set_ban!();
 
 // == Rawtransactions ==

--- a/client/src/client_sync/v21/mod.rs
+++ b/client/src/client_sync/v21/mod.rs
@@ -81,6 +81,7 @@ crate::impl_client_v17__get_net_totals!();
 crate::impl_client_v17__get_network_info!();
 crate::impl_client_v18__get_node_addresses!();
 crate::impl_client_v17__get_peer_info!();
+crate::impl_client_v17__ping!();
 crate::impl_client_v17__set_ban!();
 
 // == Rawtransactions ==

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -81,6 +81,7 @@ crate::impl_client_v17__get_net_totals!();
 crate::impl_client_v17__get_network_info!();
 crate::impl_client_v18__get_node_addresses!();
 crate::impl_client_v17__get_peer_info!();
+crate::impl_client_v17__ping!();
 crate::impl_client_v17__set_ban!();
 
 // == Rawtransactions ==

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -83,6 +83,7 @@ crate::impl_client_v17__get_net_totals!();
 crate::impl_client_v17__get_network_info!();
 crate::impl_client_v18__get_node_addresses!();
 crate::impl_client_v17__get_peer_info!();
+crate::impl_client_v17__ping!();
 crate::impl_client_v17__set_ban!();
 
 // == Rawtransactions ==

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -80,6 +80,7 @@ crate::impl_client_v17__get_net_totals!();
 crate::impl_client_v17__get_network_info!();
 crate::impl_client_v18__get_node_addresses!();
 crate::impl_client_v17__get_peer_info!();
+crate::impl_client_v17__ping!();
 crate::impl_client_v17__set_ban!();
 
 // == Rawtransactions ==

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -80,6 +80,7 @@ crate::impl_client_v17__get_net_totals!();
 crate::impl_client_v17__get_network_info!();
 crate::impl_client_v18__get_node_addresses!();
 crate::impl_client_v17__get_peer_info!();
+crate::impl_client_v17__ping!();
 crate::impl_client_v17__set_ban!();
 
 // == Rawtransactions ==

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -85,6 +85,7 @@ crate::impl_client_v17__get_net_totals!();
 crate::impl_client_v17__get_network_info!();
 crate::impl_client_v18__get_node_addresses!();
 crate::impl_client_v17__get_peer_info!();
+crate::impl_client_v17__ping!();
 crate::impl_client_v17__set_ban!();
 
 // == Rawtransactions ==

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -81,6 +81,7 @@ crate::impl_client_v17__get_net_totals!();
 crate::impl_client_v17__get_network_info!();
 crate::impl_client_v18__get_node_addresses!();
 crate::impl_client_v17__get_peer_info!();
+crate::impl_client_v17__ping!();
 crate::impl_client_v17__set_ban!();
 
 // == Rawtransactions ==

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -83,6 +83,7 @@ crate::impl_client_v17__get_net_totals!();
 crate::impl_client_v17__get_network_info!();
 crate::impl_client_v18__get_node_addresses!();
 crate::impl_client_v17__get_peer_info!();
+crate::impl_client_v17__ping!();
 crate::impl_client_v17__set_ban!();
 
 // == Rawtransactions ==

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -83,6 +83,7 @@ crate::impl_client_v17__get_net_totals!();
 crate::impl_client_v17__get_network_info!();
 crate::impl_client_v18__get_node_addresses!();
 crate::impl_client_v17__get_peer_info!();
+crate::impl_client_v17__ping!();
 crate::impl_client_v17__set_ban!();
 
 // == Rawtransactions ==

--- a/integration_test/tests/network.rs
+++ b/integration_test/tests/network.rs
@@ -114,6 +114,12 @@ fn get_peer_info_three_node_network() {
 }
 
 #[test]
+fn network__ping() {
+    let node = Node::with_wallet(Wallet::None, &[]);
+    node.client.ping().expect("ping");
+}
+
+#[test]
 fn network__set_ban() {
     let node = Node::with_wallet(Wallet::None, &[]);
     let dummy_subnet = "192.0.2.3";


### PR DESCRIPTION
The JSON-RPC method `ping` does return null. We want to test this to catch any changes in behavior in future Core versions.

This PR adds a client function that errors if the return value is anything other than `null`, along with an integration test that calls this function.

Ref: [#116](https://github.com/rust-bitcoin/corepc/pull/116)