### PR TITLE
Rename invalidateblock to invalidate_block for naming consistency

### DIFF
--- a/client/src/client_sync/v17/generating.rs
+++ b/client/src/client_sync/v17/generating.rs
@@ -37,14 +37,14 @@ macro_rules! impl_client_v17__generate {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `invalidateblock`
+/// Implements Bitcoin Core JSON-RPC API method `invalidate_block`
 // This method does not appear in the output of `bitcoin-cli help`.
 #[macro_export]
-macro_rules! impl_client_v17__invalidateblock {
+macro_rules! impl_client_v17__invalidate_block {
     () => {
         impl Client {
             pub fn invalidate_block(&self, hash: BlockHash) -> Result<()> {
-                match self.call("invalidateblock", &[into_json(hash)?]) {
+                match self.call("invalidate_block", &[into_json(hash)?]) {
                     Ok(serde_json::Value::Null) => Ok(()),
                     Ok(res) => Err(Error::Returned(res.to_string())),
                     Err(err) => Err(err.into()),

--- a/client/src/client_sync/v17/mod.rs
+++ b/client/src/client_sync/v17/mod.rs
@@ -61,7 +61,7 @@ crate::impl_client_v17__uptime!();
 // == Generating ==
 crate::impl_client_v17__generate_to_address!();
 crate::impl_client_v17__generate!();
-crate::impl_client_v17__invalidateblock!();
+crate::impl_client_v17__invalidate_block!();
 
 // == Mining ==
 crate::impl_client_v17__get_block_template!();

--- a/client/src/client_sync/v18/mod.rs
+++ b/client/src/client_sync/v18/mod.rs
@@ -65,7 +65,7 @@ crate::impl_client_v17__uptime!();
 // == Generating ==
 crate::impl_client_v17__generate_to_address!();
 crate::impl_client_v17__generate!();
-crate::impl_client_v17__invalidateblock!();
+crate::impl_client_v17__invalidate_block!();
 
 // == Mining ==
 crate::impl_client_v17__get_block_template!();

--- a/client/src/client_sync/v19/mod.rs
+++ b/client/src/client_sync/v19/mod.rs
@@ -63,7 +63,7 @@ crate::impl_client_v17__uptime!();
 
 // == Generating ==
 crate::impl_client_v17__generate_to_address!();
-crate::impl_client_v17__invalidateblock!();
+crate::impl_client_v17__invalidate_block!();
 
 // == Mining ==
 crate::impl_client_v17__get_block_template!();

--- a/client/src/client_sync/v20/mod.rs
+++ b/client/src/client_sync/v20/mod.rs
@@ -60,7 +60,7 @@ crate::impl_client_v17__uptime!();
 
 // == Generating ==
 crate::impl_client_v17__generate_to_address!();
-crate::impl_client_v17__invalidateblock!();
+crate::impl_client_v17__invalidate_block!();
 
 // == Mining ==
 crate::impl_client_v17__get_block_template!();

--- a/client/src/client_sync/v21/mod.rs
+++ b/client/src/client_sync/v21/mod.rs
@@ -62,7 +62,7 @@ crate::impl_client_v17__uptime!();
 
 // == Generating ==
 crate::impl_client_v17__generate_to_address!();
-crate::impl_client_v17__invalidateblock!();
+crate::impl_client_v17__invalidate_block!();
 
 // == Mining ==
 crate::impl_client_v17__get_block_template!();

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -62,7 +62,7 @@ crate::impl_client_v17__uptime!();
 
 // == Generating ==
 crate::impl_client_v17__generate_to_address!();
-crate::impl_client_v17__invalidateblock!();
+crate::impl_client_v17__invalidate_block!();
 
 // == Mining ==
 crate::impl_client_v17__get_block_template!();

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -64,7 +64,7 @@ crate::impl_client_v17__uptime!();
 
 // == Generating ==
 crate::impl_client_v17__generate_to_address!();
-crate::impl_client_v17__invalidateblock!();
+crate::impl_client_v17__invalidate_block!();
 
 // == Mining ==
 crate::impl_client_v17__get_block_template!();

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -61,7 +61,7 @@ crate::impl_client_v17__uptime!();
 
 // == Generating ==
 crate::impl_client_v17__generate_to_address!();
-crate::impl_client_v17__invalidateblock!();
+crate::impl_client_v17__invalidate_block!();
 
 // == Mining ==
 crate::impl_client_v17__get_block_template!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -61,7 +61,7 @@ crate::impl_client_v17__uptime!();
 
 // == Generating ==
 crate::impl_client_v17__generate_to_address!();
-crate::impl_client_v17__invalidateblock!();
+crate::impl_client_v17__invalidate_block!();
 
 // == Mining ==
 crate::impl_client_v17__get_block_template!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -65,7 +65,7 @@ crate::impl_client_v17__uptime!();
 
 // == Generating ==
 crate::impl_client_v17__generate_to_address!();
-crate::impl_client_v17__invalidateblock!();
+crate::impl_client_v17__invalidate_block!();
 
 // == Mining ==
 crate::impl_client_v17__get_block_template!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -61,7 +61,7 @@ crate::impl_client_v17__uptime!();
 
 // == Generating ==
 crate::impl_client_v17__generate_to_address!();
-crate::impl_client_v17__invalidateblock!();
+crate::impl_client_v17__invalidate_block!();
 
 // == Mining ==
 crate::impl_client_v17__get_block_template!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -63,7 +63,7 @@ crate::impl_client_v17__uptime!();
 
 // == Generating ==
 crate::impl_client_v17__generate_to_address!();
-crate::impl_client_v17__invalidateblock!();
+crate::impl_client_v17__invalidate_block!();
 
 // == Mining ==
 crate::impl_client_v17__get_block_template!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -63,7 +63,7 @@ crate::impl_client_v17__uptime!();
 
 // == Generating ==
 crate::impl_client_v17__generate_to_address!();
-crate::impl_client_v17__invalidateblock!();
+crate::impl_client_v17__invalidate_block!();
 
 // == Mining ==
 crate::impl_client_v17__get_block_template!();


### PR DESCRIPTION
### Fix missing underscore in `invalidate_block` client macro name

This PR addresses the inconsistent naming in the client macro for the `invalidateblock` RPC method. When we updated client macro names to use underscores, `invalidateblock` was missed, likely because it was missing from the Method list due to being undocumented in the Core docs.

Closes #215