### PR TITLE
Implement abandontransaction and test

### DIFF
--- a/client/src/client_sync/v17/mod.rs
+++ b/client/src/client_sync/v17/mod.rs
@@ -108,6 +108,7 @@ crate::impl_client_v17__validate_address!();
 crate::impl_client_v17__verify_message!();
 
 // == Wallet ==
+crate::impl_client_v17__abandon_transaction!();
 crate::impl_client_v17__add_multisig_address!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v17__create_wallet!();

--- a/client/src/client_sync/v17/wallet.rs
+++ b/client/src/client_sync/v17/wallet.rs
@@ -9,6 +9,22 @@
 //!
 //! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
 
+/// Implements Bitcoin Core JSON-RPC API method `abandontransaction`.
+#[macro_export]
+macro_rules! impl_client_v17__abandon_transaction {
+    () => {
+        impl Client {
+            pub fn abandon_transaction(&self, txid: Txid) -> Result<()> {
+                match self.call("abandontransaction", &[into_json(txid)?]) {
+                    Ok(serde_json::Value::Null) => Ok(()),
+                    Ok(res) => Err(Error::Returned(res.to_string())),
+                    Err(err) => Err(err.into()),
+                }
+            }
+        }
+    };
+}
+
 /// Implements Bitcoin Core JSON-RPC API method `addmultisigaddress`.
 #[macro_export]
 macro_rules! impl_client_v17__add_multisig_address {

--- a/client/src/client_sync/v18/mod.rs
+++ b/client/src/client_sync/v18/mod.rs
@@ -116,6 +116,7 @@ crate::impl_client_v17__validate_address!();
 crate::impl_client_v17__verify_message!();
 
 // == Wallet ==
+crate::impl_client_v17__abandon_transaction!();
 crate::impl_client_v17__add_multisig_address!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v17__create_wallet!();

--- a/client/src/client_sync/v19/mod.rs
+++ b/client/src/client_sync/v19/mod.rs
@@ -114,6 +114,7 @@ crate::impl_client_v17__validate_address!();
 crate::impl_client_v17__verify_message!();
 
 // == Wallet ==
+crate::impl_client_v17__abandon_transaction!();
 crate::impl_client_v17__add_multisig_address!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v17__create_wallet!();

--- a/client/src/client_sync/v20/mod.rs
+++ b/client/src/client_sync/v20/mod.rs
@@ -111,6 +111,7 @@ crate::impl_client_v17__validate_address!();
 crate::impl_client_v17__verify_message!();
 
 // == Wallet ==
+crate::impl_client_v17__abandon_transaction!();
 crate::impl_client_v17__add_multisig_address!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v17__create_wallet!();

--- a/client/src/client_sync/v21/mod.rs
+++ b/client/src/client_sync/v21/mod.rs
@@ -113,6 +113,7 @@ crate::impl_client_v17__validate_address!();
 crate::impl_client_v17__verify_message!();
 
 // == Wallet ==
+crate::impl_client_v17__abandon_transaction!();
 crate::impl_client_v17__add_multisig_address!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v17__create_wallet!();

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -113,6 +113,7 @@ crate::impl_client_v17__validate_address!();
 crate::impl_client_v17__verify_message!();
 
 // == Wallet ==
+crate::impl_client_v17__abandon_transaction!();
 crate::impl_client_v17__add_multisig_address!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v17__create_wallet!();

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -115,6 +115,7 @@ crate::impl_client_v17__validate_address!();
 crate::impl_client_v17__verify_message!();
 
 // == Wallet ==
+crate::impl_client_v17__abandon_transaction!();
 crate::impl_client_v17__add_multisig_address!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v23__create_wallet!();

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -112,6 +112,7 @@ crate::impl_client_v17__validate_address!();
 crate::impl_client_v17__verify_message!();
 
 // == Wallet ==
+crate::impl_client_v17__abandon_transaction!();
 crate::impl_client_v17__add_multisig_address!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v23__create_wallet!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -112,6 +112,7 @@ crate::impl_client_v17__validate_address!();
 crate::impl_client_v17__verify_message!();
 
 // == Wallet ==
+crate::impl_client_v17__abandon_transaction!();
 crate::impl_client_v17__add_multisig_address!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v23__create_wallet!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -118,6 +118,7 @@ crate::impl_client_v17__validate_address!();
 crate::impl_client_v17__verify_message!();
 
 // == Wallet ==
+crate::impl_client_v17__abandon_transaction!();
 crate::impl_client_v17__add_multisig_address!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v23__create_wallet!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -114,6 +114,7 @@ crate::impl_client_v17__validate_address!();
 crate::impl_client_v17__verify_message!();
 
 // == Wallet ==
+crate::impl_client_v17__abandon_transaction!();
 crate::impl_client_v17__add_multisig_address!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v23__create_wallet!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -116,6 +116,7 @@ crate::impl_client_v17__validate_address!();
 crate::impl_client_v17__verify_message!();
 
 // == Wallet ==
+crate::impl_client_v17__abandon_transaction!();
 crate::impl_client_v17__add_multisig_address!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v23__create_wallet!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -116,6 +116,7 @@ crate::impl_client_v17__validate_address!();
 crate::impl_client_v17__verify_message!();
 
 // == Wallet ==
+crate::impl_client_v17__abandon_transaction!();
 crate::impl_client_v17__add_multisig_address!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v23__create_wallet!();

--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -12,6 +12,31 @@ use node::{mtype,AddressType};
 use node::vtype::*;             // All the version specific types.
 
 #[test]
+fn wallet__abandon_transaction() {
+    let node = Node::with_wallet(Wallet::Default, &[]);
+
+    let mining_addr = node.client.new_address().expect("newaddress");
+    let json = node.client.generate_to_address(101, &mining_addr).expect("generatetoaddress");
+    let block_hashes = json.into_model();
+
+    let block_hash = block_hashes.expect("blockhash").0[0];
+
+    let dest_addr = node.client.new_address().expect("newaddress");
+    let amount = bitcoin::Amount::from_sat(1_000_000);
+
+    let txid = node
+        .client
+        .send_to_address_rbf(&dest_addr, amount)
+        .expect("sendtoaddressrbf")
+        .txid()
+        .expect("txid");
+
+    node.client.invalidate_block(block_hash).expect("invalidateblock");
+
+    node.client.abandon_transaction(txid).expect("abandontransaction");
+}
+
+#[test]
 #[cfg(feature = "TODO")]
 fn wallet__add_multisig_address__modelled() {
     let nrequired = 1; // 1-of-2 multisig.


### PR DESCRIPTION
The JSON-RPC method `abandontransaction` does return null. We want to test this to catch any changes in behavior in future Core versions.

This PR adds a client function that errors if the return value is anything other than `null`, along with an integration test that calls this function.

Ref: [#116](https://github.com/rust-bitcoin/corepc/pull/116)