### PR TITLE
Implement `submitheader` and test

### DIFF
--- a/client/src/client_sync/v18/mining.rs
+++ b/client/src/client_sync/v18/mining.rs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Macros for implementing JSON-RPC methods on a client.
+//!
+//! Specifically this is methods found under the `== Mining ==` section of the
+//! API docs of Bitcoin Core `v0.18`.
+//!
+//! All macros require `Client` to be in scope.
+//!
+//! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
+
+/// Implements Bitcoin Core JSON-RPC API method `submitheader`.
+#[macro_export]
+macro_rules! impl_client_v18__submit_header {
+    () => {
+        impl Client {
+            pub fn submit_header(&self, header: &bitcoin::block::Header) -> Result<()> {
+                let hexdata = bitcoin::consensus::encode::serialize_hex(header);
+                match self.call("submitheader", &[hexdata.into()]) {
+                    Ok(serde_json::Value::Null) => Ok(()),
+                    Ok(res) => Err(Error::Returned(res.to_string())),
+                    Err(err) => Err(err.into()),
+                }
+            }
+        }
+    };
+}

--- a/client/src/client_sync/v18/mod.rs
+++ b/client/src/client_sync/v18/mod.rs
@@ -5,6 +5,7 @@
 //! We ignore option arguments unless they effect the shape of the returned JSON data.
 
 pub mod control;
+pub mod mining;
 pub mod network;
 pub mod raw_transactions;
 pub mod util;
@@ -74,6 +75,7 @@ crate::impl_client_v17__get_mining_info!();
 crate::impl_client_v17__get_network_hashes_per_second!();
 crate::impl_client_v17__prioritise_transaction!();
 crate::impl_client_v17__submit_block!();
+crate::impl_client_v18__submit_header!();
 
 // == Network ==
 crate::impl_client_v17__add_node!();

--- a/client/src/client_sync/v19/mod.rs
+++ b/client/src/client_sync/v19/mod.rs
@@ -71,6 +71,7 @@ crate::impl_client_v17__get_mining_info!();
 crate::impl_client_v17__get_network_hashes_per_second!();
 crate::impl_client_v17__prioritise_transaction!();
 crate::impl_client_v17__submit_block!();
+crate::impl_client_v18__submit_header!();
 
 // == Network ==
 crate::impl_client_v17__add_node!();

--- a/client/src/client_sync/v20/mod.rs
+++ b/client/src/client_sync/v20/mod.rs
@@ -68,6 +68,7 @@ crate::impl_client_v17__get_mining_info!();
 crate::impl_client_v17__get_network_hashes_per_second!();
 crate::impl_client_v17__prioritise_transaction!();
 crate::impl_client_v17__submit_block!();
+crate::impl_client_v18__submit_header!();
 
 // == Network ==
 crate::impl_client_v17__add_node!();

--- a/client/src/client_sync/v21/mod.rs
+++ b/client/src/client_sync/v21/mod.rs
@@ -70,6 +70,7 @@ crate::impl_client_v17__get_mining_info!();
 crate::impl_client_v17__get_network_hashes_per_second!();
 crate::impl_client_v17__prioritise_transaction!();
 crate::impl_client_v17__submit_block!();
+crate::impl_client_v18__submit_header!();
 
 // == Network ==
 crate::impl_client_v17__add_node!();

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -70,6 +70,7 @@ crate::impl_client_v17__get_mining_info!();
 crate::impl_client_v17__get_network_hashes_per_second!();
 crate::impl_client_v17__prioritise_transaction!();
 crate::impl_client_v17__submit_block!();
+crate::impl_client_v18__submit_header!();
 
 // == Network ==
 crate::impl_client_v17__add_node!();

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -72,6 +72,7 @@ crate::impl_client_v17__get_mining_info!();
 crate::impl_client_v17__get_network_hashes_per_second!();
 crate::impl_client_v17__prioritise_transaction!();
 crate::impl_client_v17__submit_block!();
+crate::impl_client_v18__submit_header!();
 
 // == Network ==
 crate::impl_client_v17__add_node!();

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -69,6 +69,7 @@ crate::impl_client_v17__get_mining_info!();
 crate::impl_client_v17__get_network_hashes_per_second!();
 crate::impl_client_v17__prioritise_transaction!();
 crate::impl_client_v17__submit_block!();
+crate::impl_client_v18__submit_header!();
 
 // == Network ==
 crate::impl_client_v17__add_node!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -69,6 +69,7 @@ crate::impl_client_v17__get_mining_info!();
 crate::impl_client_v17__get_network_hashes_per_second!();
 crate::impl_client_v17__prioritise_transaction!();
 crate::impl_client_v17__submit_block!();
+crate::impl_client_v18__submit_header!();
 
 // == Network ==
 crate::impl_client_v17__add_node!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -74,6 +74,7 @@ crate::impl_client_v17__get_network_hashes_per_second!();
 crate::impl_client_v26__get_prioritised_transactions!();
 crate::impl_client_v17__prioritise_transaction!();
 crate::impl_client_v17__submit_block!();
+crate::impl_client_v18__submit_header!();
 
 // == Network ==
 crate::impl_client_v17__add_node!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -70,6 +70,7 @@ crate::impl_client_v17__get_network_hashes_per_second!();
 crate::impl_client_v26__get_prioritised_transactions!();
 crate::impl_client_v17__prioritise_transaction!();
 crate::impl_client_v17__submit_block!();
+crate::impl_client_v18__submit_header!();
 
 // == Network ==
 crate::impl_client_v17__add_node!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -72,6 +72,7 @@ crate::impl_client_v17__get_network_hashes_per_second!();
 crate::impl_client_v26__get_prioritised_transactions!();
 crate::impl_client_v17__prioritise_transaction!();
 crate::impl_client_v17__submit_block!();
+crate::impl_client_v18__submit_header!();
 
 // == Network ==
 crate::impl_client_v17__add_node!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -72,6 +72,7 @@ crate::impl_client_v17__get_network_hashes_per_second!();
 crate::impl_client_v26__get_prioritised_transactions!();
 crate::impl_client_v17__prioritise_transaction!();
 crate::impl_client_v17__submit_block!();
+crate::impl_client_v18__submit_header!();
 
 // == Network ==
 crate::impl_client_v17__add_node!();

--- a/integration_test/tests/mining.rs
+++ b/integration_test/tests/mining.rs
@@ -211,4 +211,18 @@ fn mining__submit_block_with_dummy_coinbase(node: &Node, bt: &mtype::GetBlockTem
     let _ = node.client.submit_block(&block).expect("submitblock");
 }
 
-// TODO: submitheader "hexdata" (v0.18 onwards)
+#[cfg(not(feature = "v17"))]
+#[test]
+fn mining__submit_header() {
+    let node = Node::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+    node.mine_a_block();
+
+    let best_block = node.client.get_best_block_hash().expect("getbestblockhash").into_model().unwrap().0;
+    let mut header = node.client.get_block_header(&best_block).expect("getblockheader").into_model().unwrap().0;
+
+    // Change the nonce to ensure the header is different from the current tip.
+    header.nonce = header.nonce.wrapping_add(1);
+
+    let _ = node.client.submit_header(&header);
+}

--- a/types/src/v18/mod.rs
+++ b/types/src/v18/mod.rs
@@ -87,7 +87,7 @@
 //! | getnetworkhashps                   | returns boolean |                                        |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
-//! | submitheader                       | return nothing  | TODO                                   |
+//! | submitheader                       | returns nothing | TODO                                   |
 //!
 //! </details>
 //!

--- a/types/src/v18/mod.rs
+++ b/types/src/v18/mod.rs
@@ -87,7 +87,7 @@
 //! | getnetworkhashps                   | returns boolean |                                        |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
-//! | submitheader                       | returns nothing | TODO                                   |
+//! | submitheader                       | returns nothing |                                        |
 //!
 //! </details>
 //!

--- a/types/src/v19/mod.rs
+++ b/types/src/v19/mod.rs
@@ -87,7 +87,7 @@
 //! | getnetworkhashps                   | returns boolean |                                        |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
-//! | submitheader                       | return nothing  | TODO                                   |
+//! | submitheader                       | returns nothing | TODO                                   |
 //!
 //! </details>
 //!

--- a/types/src/v19/mod.rs
+++ b/types/src/v19/mod.rs
@@ -87,7 +87,7 @@
 //! | getnetworkhashps                   | returns boolean |                                        |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
-//! | submitheader                       | returns nothing | TODO                                   |
+//! | submitheader                       | returns nothing |                                        |
 //!
 //! </details>
 //!

--- a/types/src/v20/mod.rs
+++ b/types/src/v20/mod.rs
@@ -88,7 +88,7 @@
 //! | getnetworkhashps                   | returns boolean |                                        |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
-//! | submitheader                       | returns nothing | TODO                                   |
+//! | submitheader                       | returns nothing |                                        |
 //!
 //! </details>
 //!

--- a/types/src/v20/mod.rs
+++ b/types/src/v20/mod.rs
@@ -88,7 +88,7 @@
 //! | getnetworkhashps                   | returns boolean |                                        |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
-//! | submitheader                       | return nothing  | TODO                                   |
+//! | submitheader                       | returns nothing | TODO                                   |
 //!
 //! </details>
 //!

--- a/types/src/v21/mod.rs
+++ b/types/src/v21/mod.rs
@@ -89,7 +89,7 @@
 //! | getnetworkhashps                   | returns boolean |                                        |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
-//! | submitheader                       | return nothing  | TODO                                   |
+//! | submitheader                       | returns nothing | TODO                                   |
 //!
 //! </details>
 //!

--- a/types/src/v21/mod.rs
+++ b/types/src/v21/mod.rs
@@ -89,7 +89,7 @@
 //! | getnetworkhashps                   | returns boolean |                                        |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
-//! | submitheader                       | returns nothing | TODO                                   |
+//! | submitheader                       | returns nothing |                                        |
 //!
 //! </details>
 //!

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -89,7 +89,7 @@
 //! | getnetworkhashps                   | returns boolean |                                        |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
-//! | submitheader                       | return nothing  | TODO                                   |
+//! | submitheader                       | returns nothing | TODO                                   |
 //!
 //! </details>
 //!

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -89,7 +89,7 @@
 //! | getnetworkhashps                   | returns boolean |                                        |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
-//! | submitheader                       | returns nothing | TODO                                   |
+//! | submitheader                       | returns nothing |                                        |
 //!
 //! </details>
 //!

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -80,7 +80,7 @@
 //! | getnetworkhashps                   | returns boolean |                                        |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
-//! | submitheader                       | returns nothing | TODO                                   |
+//! | submitheader                       | returns nothing |                                        |
 //!
 //! </details>
 //!

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -80,7 +80,7 @@
 //! | getnetworkhashps                   | returns boolean |                                        |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
-//! | submitheader                       | return nothing  | TODO                                   |
+//! | submitheader                       | returns nothing | TODO                                   |
 //!
 //! </details>
 //!

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -81,7 +81,7 @@
 //! | getnetworkhashps                   | returns boolean |                                        |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
-//! | submitheader                       | return nothing  | TODO                                   |
+//! | submitheader                       | returns nothing | TODO                                   |
 //!
 //! </details>
 //!

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -81,7 +81,7 @@
 //! | getnetworkhashps                   | returns boolean |                                        |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
-//! | submitheader                       | returns nothing | TODO                                   |
+//! | submitheader                       | returns nothing |                                        |
 //!
 //! </details>
 //!

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -82,7 +82,7 @@
 //! | getnetworkhashps                   | returns boolean |                                        |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
-//! | submitheader                       | returns nothing | TODO                                   |
+//! | submitheader                       | returns nothing |                                        |
 //!
 //! </details>
 //!

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -82,7 +82,7 @@
 //! | getnetworkhashps                   | returns boolean |                                        |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
-//! | submitheader                       | return nothing  | TODO                                   |
+//! | submitheader                       | returns nothing | TODO                                   |
 //!
 //! </details>
 //!

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -87,7 +87,7 @@
 //! | getprioritisedtransactions         | version + model | TODO                                   |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
-//! | submitheader                       | return nothing  | TODO                                   |
+//! | submitheader                       | returns nothing | TODO                                   |
 //!
 //! </details>
 //!

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -87,7 +87,7 @@
 //! | getprioritisedtransactions         | version + model | TODO                                   |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
-//! | submitheader                       | returns nothing | TODO                                   |
+//! | submitheader                       | returns nothing |                                        |
 //!
 //! </details>
 //!

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -87,7 +87,7 @@
 //! | getprioritisedtransactions         | version + model | TODO                                   |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
-//! | submitheader                       | return nothing  | TODO                                   |
+//! | submitheader                       | returns nothing | TODO                                   |
 //!
 //! </details>
 //!

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -87,7 +87,7 @@
 //! | getprioritisedtransactions         | version + model | TODO                                   |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
-//! | submitheader                       | returns nothing | TODO                                   |
+//! | submitheader                       | returns nothing |                                        |
 //!
 //! </details>
 //!

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -87,7 +87,7 @@
 //! | getprioritisedtransactions         | version + model | TODO                                   |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
-//! | submitheader                       | return nothing  | TODO                                   |
+//! | submitheader                       | returns nothing | TODO                                   |
 //!
 //! </details>
 //!

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -87,7 +87,7 @@
 //! | getprioritisedtransactions         | version + model | TODO                                   |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
-//! | submitheader                       | returns nothing | TODO                                   |
+//! | submitheader                       | returns nothing |                                        |
 //!
 //! </details>
 //!

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -88,7 +88,7 @@
 //! | getprioritisedtransactions         | version + model | TODO                                   |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
-//! | submitheader                       | returns nothing | TODO                                   |
+//! | submitheader                       | returns nothing |                                        |
 //!
 //! </details>
 //!

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -88,7 +88,7 @@
 //! | getprioritisedtransactions         | version + model | TODO                                   |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
-//! | submitheader                       | return nothing  | TODO                                   |
+//! | submitheader                       | returns nothing | TODO                                   |
 //!
 //! </details>
 //!


### PR DESCRIPTION
Add a test and client macro for `submitheader` for v18 and up. There are
no changes up to v29.

Correct the typo that said  `return nothing` to `returns nothing`