### PR TITLE
Implement importprivkey and test

### DIFF
--- a/client/src/client_sync/v17/mod.rs
+++ b/client/src/client_sync/v17/mod.rs
@@ -123,6 +123,7 @@ crate::impl_client_v17__get_received_by_address!();
 crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
+crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v17__list_lock_unspent!();

--- a/client/src/client_sync/v17/wallet.rs
+++ b/client/src/client_sync/v17/wallet.rs
@@ -243,6 +243,22 @@ macro_rules! impl_client_v17__get_wallet_info {
     };
 }
 
+/// Implements Bitcoin Core JSON-RPC API method `importprivkey`.
+#[macro_export]
+macro_rules! impl_client_v17__import_privkey {
+    () => {
+        impl Client {
+            pub fn import_privkey(&self, privkey: &bitcoin::PrivateKey) -> Result<()> {
+                match self.call("importprivkey", &[into_json(privkey)?]) {
+                    Ok(serde_json::Value::Null) => Ok(()),
+                    Ok(res) => Err(Error::Returned(res.to_string())),
+                    Err(err) => Err(err.into()),
+                }
+            }
+        }
+    };
+}
+
 /// Implements Bitcoin Core JSON-RPC API method `listaddressgroupings`.
 #[macro_export]
 macro_rules! impl_client_v17__list_address_groupings {

--- a/client/src/client_sync/v18/mod.rs
+++ b/client/src/client_sync/v18/mod.rs
@@ -134,6 +134,7 @@ crate::impl_client_v17__get_received_by_address!();
 crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
+crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v17__list_lock_unspent!();

--- a/client/src/client_sync/v19/mod.rs
+++ b/client/src/client_sync/v19/mod.rs
@@ -132,6 +132,7 @@ crate::impl_client_v17__get_received_by_address!();
 crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
+crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v17__list_lock_unspent!();

--- a/client/src/client_sync/v20/mod.rs
+++ b/client/src/client_sync/v20/mod.rs
@@ -129,6 +129,7 @@ crate::impl_client_v17__get_received_by_address!();
 crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
+crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v17__list_lock_unspent!();

--- a/client/src/client_sync/v21/mod.rs
+++ b/client/src/client_sync/v21/mod.rs
@@ -131,6 +131,7 @@ crate::impl_client_v17__get_received_by_address!();
 crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
+crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v17__list_lock_unspent!();

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -131,6 +131,7 @@ crate::impl_client_v17__get_received_by_address!();
 crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
+crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v17__list_lock_unspent!();

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -133,6 +133,7 @@ crate::impl_client_v17__get_received_by_address!();
 crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
+crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v17__list_lock_unspent!();

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -130,6 +130,7 @@ crate::impl_client_v17__get_received_by_address!();
 crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
+crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v17__list_lock_unspent!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -130,6 +130,7 @@ crate::impl_client_v17__get_received_by_address!();
 crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
+crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v17__list_lock_unspent!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -136,6 +136,7 @@ crate::impl_client_v17__get_received_by_address!();
 crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
+crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v17__list_lock_unspent!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -132,6 +132,7 @@ crate::impl_client_v17__get_received_by_address!();
 crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
+crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v17__list_lock_unspent!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -134,6 +134,7 @@ crate::impl_client_v17__get_received_by_address!();
 crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
+crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v17__list_lock_unspent!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -134,6 +134,7 @@ crate::impl_client_v17__get_received_by_address!();
 crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
+crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v17__list_lock_unspent!();

--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -6,7 +6,7 @@
 
 #[cfg(feature = "TODO")]
 use bitcoin::address::{Address, NetworkChecked};
-use bitcoin::Amount;
+use bitcoin::{Amount, PrivateKey};
 use integration_test::{Node, NodeExt as _, Wallet};
 use node::{mtype,AddressType};
 use node::vtype::*;             // All the version specific types.
@@ -238,6 +238,25 @@ fn wallet__get_transaction__modelled() {
     let json: GetTransaction = node.client.get_transaction(txid).expect("gettransaction");
     let model: Result<mtype::GetTransaction, GetTransactionError> = json.into_model();
     model.unwrap();
+}
+
+#[test]
+fn wallet__import_privkey() {
+    let node = match () {
+        #[cfg(feature = "v22_and_below")]
+        () => Node::with_wallet(Wallet::Default, &[]),
+        #[cfg(not(feature = "v22_and_below"))]
+        () => {
+            let node = Node::with_wallet(Wallet::None, &["-deprecatedrpc=create_bdb"]);
+            node.client.create_legacy_wallet("wallet_name").expect("createlegacywallet");
+            node
+        }
+    };
+
+    let privkey =
+        PrivateKey::from_wif("cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy").unwrap();
+
+    node.client.import_privkey(&privkey).expect("importprivkey");
 }
 
 #[test]


### PR DESCRIPTION
The JSON-RPC method `importprivkey` does return null. We want to test this to catch any changes in behavior in future Core versions.

This PR adds a client function that errors if the return value is anything other than `null`, along with an integration test that calls this function.

Ref: [#116](https://github.com/rust-bitcoin/corepc/pull/116)