### PR TITLE
Standardize version number format in docs

### DIFF
--- a/client/src/client_sync/v21/wallet.rs
+++ b/client/src/client_sync/v21/wallet.rs
@@ -3,7 +3,7 @@
 //! Macros for implementing JSON-RPC methods on a client.
 //!
 //! Specifically this is methods found under the `== Wallet ==` section of the
-//! API docs of Bitcoin Core `v21`.
+//! API docs of Bitcoin Core `v0.21`.
 //!
 //! All macros require `Client` to be in scope.
 //!

--- a/client/src/client_sync/v23/blockchain.rs
+++ b/client/src/client_sync/v23/blockchain.rs
@@ -3,7 +3,7 @@
 //! Macros for implementing JSON-RPC methods on a client.
 //!
 //! Specifically this is methods found under the `== Blockchain ==` section of the
-//! API docs of Bitcoin Core `v0.23`.
+//! API docs of Bitcoin Core `v23`.
 //!
 //! All macros require `Client` to be in scope.
 //!

--- a/client/src/client_sync/v26/blockchain.rs
+++ b/client/src/client_sync/v26/blockchain.rs
@@ -3,7 +3,7 @@
 //! Macros for implementing JSON-RPC methods on a client.
 //!
 //! Specifically this is methods found under the `== Blockchain ==` section of the
-//! API docs of Bitcoin Core `v0.26`.
+//! API docs of Bitcoin Core `v26`.
 //!
 //! All macros require `Client` to be in scope.
 //!

--- a/client/src/client_sync/v26/mining.rs
+++ b/client/src/client_sync/v26/mining.rs
@@ -3,7 +3,7 @@
 //! Macros for implementing JSON-RPC methods on a client.
 //!
 //! Specifically this is methods found under the `== Mining ==` section of the
-//! API docs of Bitcoin Core `v0.26`.
+//! API docs of Bitcoin Core `v26`.
 //!
 //! All macros require `Client` to be in scope.
 //!

--- a/integration_test/tests/generating.rs
+++ b/integration_test/tests/generating.rs
@@ -9,7 +9,7 @@ use node::vtype::*;             // All the version specific types.
 use node::mtype;
 
 #[test]
-// The `generate` method was deprecated in Core v18 and was removed in v19.
+// The `generate` method was deprecated in Core v0.18 and was removed in v0.19.
 #[cfg(feature = "v17")]
 fn generating__generate__modelled() {
     const NBLOCKS: usize = 10;

--- a/integration_test/tests/mining.rs
+++ b/integration_test/tests/mining.rs
@@ -211,4 +211,4 @@ fn mining__submit_block_with_dummy_coinbase(node: &Node, bt: &mtype::GetBlockTem
     let _ = node.client.submit_block(&block).expect("submitblock");
 }
 
-// TODO: submitheader "hexdata" (v18 onwards)
+// TODO: submitheader "hexdata" (v0.18 onwards)

--- a/integration_test/tests/raw_transactions.rs
+++ b/integration_test/tests/raw_transactions.rs
@@ -13,7 +13,7 @@ use node::{mtype, Input, Output};
 use node::vtype::*;             // All the version specific types.
 
 #[test]
-#[cfg(not(feature = "v17"))]    // analyzepsbt was added in v18.
+#[cfg(not(feature = "v17"))]    // analyzepsbt was added in v0.18.
 fn raw_transactions__analyze_psbt__modelled() {
     let node = Node::with_wallet(Wallet::Default, &[]);
     node.fund_wallet();
@@ -427,7 +427,7 @@ fn raw_transactions__submit_package__modelled() {
 fn raw_transactions__test_mempool_accept__modelled() {}
 
 #[test]
-#[cfg(not(feature = "v17"))]    // utxoupdatepsbt was added in v18.
+#[cfg(not(feature = "v17"))]    // utxoupdatepsbt was added in v0.18.
 fn raw_transactions__utxo_update_psbt() {}
 
 // Manipulates raw transactions.
@@ -487,7 +487,7 @@ fn create_sign_send(node: &Node) {
 //
 // Calls the following RPC methods:
 // - create_raw_transaction
-// - sign_raw_transaction_with_key (sign_raw_transaction was deprecated in v17).
+// - sign_raw_transaction_with_key (sign_raw_transaction was deprecated in v0.17).
 // - send_raw_transaction
 //
 // TODO: Work out how to get a private key without using `dumpprivkey`.
@@ -544,7 +544,7 @@ fn create_sign_with_key_send(node: &Node) {
 //
 // Calls the following RPC methods:
 // - fund_raw_transaction
-// - sign_raw_transaction_with_wallet (sign_raw_transaction was deprecated in v17).
+// - sign_raw_transaction_with_wallet (sign_raw_transaction was deprecated in v0.17).
 // - send_raw_transaction
 fn create_fund_sign_send(node: &Node) {
     let (_addr, _tx, txid, _tx_out, vout) = create_utxo(node);

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -177,7 +177,7 @@ pub fn compact_size_decode(slice: &mut &[u8]) -> u64 {
 ///
 /// This is used by methods in the blockchain section and in the raw transaction section (i.e raw
 /// transaction and psbt methods). The shape changed in Core v22 but the new shape is fully
-/// backwards compatible so we only provide it not a v17 specific type. The `mtype::ScriptPubkey`
+/// backwards compatible so we only provide it not a v0.17 specific type. The `mtype::ScriptPubkey`
 /// mirrors this design (but with concrete `rust-bitcoin` types).
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct ScriptPubkey {

--- a/types/src/model/blockchain.rs
+++ b/types/src/model/blockchain.rs
@@ -407,7 +407,7 @@ pub struct MempoolEntry {
     pub ancestor_size: u32,
     /// Hash of serialized transaction, including witness data.
     pub wtxid: Wtxid,
-    /// (No docs in Core v17.)
+    /// (No docs in Core v0.17.)
     pub fees: MempoolEntryFees,
     /// Unconfirmed transactions used as inputs for this transaction (parent transaction id).
     pub depends: Vec<Txid>,
@@ -415,7 +415,7 @@ pub struct MempoolEntry {
     pub spent_by: Vec<Txid>,
 }
 
-/// (No docs in Core v17.)
+/// (No docs in Core v0.17.)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct MempoolEntryFees {
     /// Transaction fee in BTC.

--- a/types/src/psbt/mod.rs
+++ b/types/src/psbt/mod.rs
@@ -196,7 +196,7 @@ pub struct Bip32Deriv {
 }
 
 /// The key source data for a BIP-32 derivation.
-// In v17 the BIP-32 derivation for inputs is a map of pubkey to this type.
+// In v0.17 the BIP-32 derivation for inputs is a map of pubkey to this type.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct InputKeySource {
     /// The fingerprint of the master key.

--- a/types/src/v17/blockchain/mod.rs
+++ b/types/src/v17/blockchain/mod.rs
@@ -518,7 +518,7 @@ pub struct MempoolEntry {
     pub ancestor_fees: f64,
     /// Hash of serialized transaction, including witness data.
     pub wtxid: String,
-    /// (No docs in Core v17.)
+    /// (No docs in Core v0.17.)
     pub fees: MempoolEntryFees,
     /// Unconfirmed transactions used as inputs for this transaction (parent transaction id).
     pub depends: Vec<String>,
@@ -527,7 +527,7 @@ pub struct MempoolEntry {
     pub spent_by: Vec<String>,
 }
 
-/// (No docs in Core v17.)
+/// (No docs in Core v0.17.)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct MempoolEntryFees {
     /// Transaction fee in BTC.

--- a/types/src/v17/mining/mod.rs
+++ b/types/src/v17/mining/mod.rs
@@ -69,7 +69,7 @@ pub struct GetBlockTemplate {
     /// Maximum allowable input to coinbase transaction, including the generation award and transaction fees (in satoshis).
     #[serde(rename = "coinbasevalue")]
     pub coinbase_value: i64,
-    // This is in the docs but not actually returned (for v17 and v18 at least).
+    // This is in the docs but not actually returned (for v0.17 and v0.18 at least).
     // coinbase_txn: ???, // Also I don't know what the JSON object represents: `{ ... }`
     /// The hash target.
     pub target: String,

--- a/types/src/v17/raw_transactions/mod.rs
+++ b/types/src/v17/raw_transactions/mod.rs
@@ -163,7 +163,7 @@ pub struct PsbtInput {
     /// Hex-encoded witness data (if any).
     #[serde(rename = "final_scriptwitness")]
     pub final_script_witness: Option<Vec<String>>,
-    // `s/global/input`: this is a bug in the Core v17 docs.
+    // `s/global/input`: this is a bug in the Core v0.17 docs.
     /// The unknown global fields.
     pub unknown: Option<HashMap<String, String>>,
 }
@@ -200,7 +200,7 @@ pub struct DecodeRawTransaction(pub RawTransaction);
 /// >
 /// > Arguments:
 /// > 1. "hexstring"     (string) the hex encoded script
-// The docs on Core v17 appear to be way off what is actually returned.
+// The docs on Core v0.17 appear to be way off what is actually returned.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct DecodeScript {
     /// Script public key.

--- a/types/src/v19/blockchain/mod.rs
+++ b/types/src/v19/blockchain/mod.rs
@@ -225,7 +225,7 @@ pub struct MempoolEntry {
     pub ancestor_size: i64,
     /// Hash of serialized transaction, including witness data.
     pub wtxid: String,
-    /// (No docs in Core v19.)
+    /// (No docs in Core v0.19.)
     pub fees: MempoolEntryFees,
     /// Unconfirmed transactions used as inputs for this transaction (parent transaction id).
     pub depends: Vec<String>,
@@ -234,7 +234,7 @@ pub struct MempoolEntry {
     pub spent_by: Vec<String>,
 }
 
-/// (No docs in Core v19.)
+/// (No docs in Core v0.19.)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct MempoolEntryFees {
     /// Transaction fee in BTC.

--- a/types/src/v26/blockchain.rs
+++ b/types/src/v26/blockchain.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! The JSON-RPC API for Bitcoin Core `v0.26` - blockchain.
+//! The JSON-RPC API for Bitcoin Core `v26` - blockchain.
 //!
 //! Types for methods found under the `== Blockchain ==` section of the API docs.
 

--- a/types/src/v29/mining/mod.rs
+++ b/types/src/v29/mining/mod.rs
@@ -76,7 +76,7 @@ pub struct GetBlockTemplate {
     /// ID to include with a request to longpoll on an update to this template.
     #[serde(rename = "longpollid")]
     pub long_poll_id: String,
-    // This is in the docs but not actually returned (for v17 and v18 at least).
+    // This is in the docs but not actually returned (for v0.17 and v0.18 at least).
     // coinbase_txn: ???, // Also I don't know what the JSON object represents: `{ ... }`
     /// The hash target.
     pub target: String,

--- a/verify/src/lib.rs
+++ b/verify/src/lib.rs
@@ -19,15 +19,15 @@ use regex::Regex;
 /// Supported Bitcoin Core versions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Version {
-    /// Bitcoin Core v17.
+    /// Bitcoin Core v0.17.
     V17,
-    /// Bitcoin Core v18.
+    /// Bitcoin Core v0.18.
     V18,
-    /// Bitcoin Core v19.
+    /// Bitcoin Core v0.19.
     V19,
-    /// Bitcoin Core v20.
+    /// Bitcoin Core v0.20.
     V20,
-    /// Bitcoin Core v21.
+    /// Bitcoin Core v0.21.
     V21,
     /// Bitcoin Core v22.
     V22,

--- a/verify/src/method/v17.rs
+++ b/verify/src/method/v17.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! JSON RPC methods provided by Bitcoin Core v17.
+//! JSON RPC methods provided by Bitcoin Core v0.17.
 
 use super::Method;
 
-/// Data for the JSON RPC methods provided by Bitcoin Core v17.
+/// Data for the JSON RPC methods provided by Bitcoin Core v0.17.
 pub const METHODS: &[Method] = &[
     // blockchain
     Method::new_modelled("getbestblockhash", "GetBestBlockHash", "get_best_block_hash"),

--- a/verify/src/method/v18.rs
+++ b/verify/src/method/v18.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! JSON RPC methods provided by Bitcoin Core v18.
+//! JSON RPC methods provided by Bitcoin Core v0.18.
 
 use super::Method;
 
-/// Data for the JSON RPC methods provided by Bitcoin Core v18.
+/// Data for the JSON RPC methods provided by Bitcoin Core v0.18.
 pub const METHODS: &[Method] = &[
     // blockchain
     Method::new_modelled("getbestblockhash", "GetBestBlockHash", "get_best_block_hash"),

--- a/verify/src/method/v19.rs
+++ b/verify/src/method/v19.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! JSON RPC methods provided by Bitcoin Core v19.
+//! JSON RPC methods provided by Bitcoin Core v0.19.
 
 use super::Method;
 
-/// Data for the JSON RPC methods provided by Bitcoin Core v19.
+/// Data for the JSON RPC methods provided by Bitcoin Core v0.19.
 pub const METHODS: &[Method] = &[
     // blockchain
     Method::new_modelled("getbestblockhash", "GetBestBlockHash", "get_best_block_hash"),

--- a/verify/src/method/v20.rs
+++ b/verify/src/method/v20.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! JSON RPC methods provided by Bitcoin Core v20.
+//! JSON RPC methods provided by Bitcoin Core v0.20.
 
 use super::Method;
 
-/// Data for the JSON RPC methods provided by Bitcoin Core v20.
+/// Data for the JSON RPC methods provided by Bitcoin Core v0.20.
 pub const METHODS: &[Method] = &[
     // blockchain
     Method::new_modelled("getbestblockhash", "GetBestBlockHash", "get_best_block_hash"),

--- a/verify/src/method/v21.rs
+++ b/verify/src/method/v21.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! JSON RPC methods provided by Bitcoin Core v21.
+//! JSON RPC methods provided by Bitcoin Core v0.21.
 
 use super::Method;
 
-/// Data for the JSON RPC methods provided by Bitcoin Core v21.
+/// Data for the JSON RPC methods provided by Bitcoin Core v0.21.
 pub const METHODS: &[Method] = &[
     // blockchain
     Method::new_modelled("getbestblockhash", "GetBestBlockHash", "get_best_block_hash"),


### PR DESCRIPTION
There is a variation in the way the version numbers are written in the docs. Some are preceded by a 0 and some aren't. [Core](https://bitcoin.org/en/version-history) states the versions up to and including 21 with preceding 0, and for 22 and above without.

Change all version numbers in the text to be v0.17 - v0.21, and v22 - v29 to match core.