### PR TITLE
Implement backupwallet method and test

### DIFF
--- a/client/src/client_sync/v17/mod.rs
+++ b/client/src/client_sync/v17/mod.rs
@@ -111,6 +111,7 @@ crate::impl_client_v17__verify_message!();
 crate::impl_client_v17__abandon_transaction!();
 crate::impl_client_v17__abort_rescan!();
 crate::impl_client_v17__add_multisig_address!();
+crate::impl_client_v17__backup_wallet!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v17__create_wallet!();
 crate::impl_client_v17__dump_priv_key!();

--- a/client/src/client_sync/v17/wallet.rs
+++ b/client/src/client_sync/v17/wallet.rs
@@ -61,6 +61,22 @@ macro_rules! impl_client_v17__add_multisig_address {
 
 /// Implements Bitcoin Core JSON-RPC API method `bumpfee`.
 #[macro_export]
+macro_rules! impl_client_v17__backup_wallet {
+    () => {
+        impl Client {
+            pub fn backup_wallet(&self, destination: &Path) -> Result<()> {
+                match self.call("backupwallet", &[into_json(destination)?]) {
+                    Ok(serde_json::Value::Null) => Ok(()),
+                    Ok(res) => Err(Error::Returned(res.to_string())),
+                    Err(err) => Err(err.into()),
+                }
+            }
+        }
+    };
+}
+
+/// Implements Bitcoin Core JSON-RPC API method `bumpfee`.
+#[macro_export]
 macro_rules! impl_client_v17__bump_fee {
     () => {
         impl Client {

--- a/client/src/client_sync/v18/mod.rs
+++ b/client/src/client_sync/v18/mod.rs
@@ -125,6 +125,7 @@ crate::impl_client_v17__verify_message!();
 crate::impl_client_v17__abandon_transaction!();
 crate::impl_client_v17__abort_rescan!();
 crate::impl_client_v17__add_multisig_address!();
+crate::impl_client_v17__backup_wallet!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v17__create_wallet!();
 crate::impl_client_v17__dump_priv_key!();

--- a/client/src/client_sync/v19/mod.rs
+++ b/client/src/client_sync/v19/mod.rs
@@ -120,6 +120,7 @@ crate::impl_client_v17__verify_message!();
 crate::impl_client_v17__abandon_transaction!();
 crate::impl_client_v17__abort_rescan!();
 crate::impl_client_v17__add_multisig_address!();
+crate::impl_client_v17__backup_wallet!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v17__create_wallet!();
 crate::impl_client_v17__dump_priv_key!();

--- a/client/src/client_sync/v20/mod.rs
+++ b/client/src/client_sync/v20/mod.rs
@@ -117,6 +117,7 @@ crate::impl_client_v17__verify_message!();
 crate::impl_client_v17__abandon_transaction!();
 crate::impl_client_v17__abort_rescan!();
 crate::impl_client_v17__add_multisig_address!();
+crate::impl_client_v17__backup_wallet!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v17__create_wallet!();
 crate::impl_client_v17__dump_priv_key!();

--- a/client/src/client_sync/v21/mod.rs
+++ b/client/src/client_sync/v21/mod.rs
@@ -119,6 +119,7 @@ crate::impl_client_v17__verify_message!();
 crate::impl_client_v17__abandon_transaction!();
 crate::impl_client_v17__abort_rescan!();
 crate::impl_client_v17__add_multisig_address!();
+crate::impl_client_v17__backup_wallet!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v17__create_wallet!();
 crate::impl_client_v17__dump_priv_key!();

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -119,6 +119,7 @@ crate::impl_client_v17__verify_message!();
 crate::impl_client_v17__abandon_transaction!();
 crate::impl_client_v17__abort_rescan!();
 crate::impl_client_v17__add_multisig_address!();
+crate::impl_client_v17__backup_wallet!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v17__create_wallet!();
 crate::impl_client_v17__dump_priv_key!();

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -121,6 +121,7 @@ crate::impl_client_v17__verify_message!();
 crate::impl_client_v17__abandon_transaction!();
 crate::impl_client_v17__abort_rescan!();
 crate::impl_client_v17__add_multisig_address!();
+crate::impl_client_v17__backup_wallet!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v23__create_wallet!();
 crate::impl_client_v17__dump_priv_key!();

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -118,6 +118,7 @@ crate::impl_client_v17__verify_message!();
 crate::impl_client_v17__abandon_transaction!();
 crate::impl_client_v17__abort_rescan!();
 crate::impl_client_v17__add_multisig_address!();
+crate::impl_client_v17__backup_wallet!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v23__create_wallet!();
 crate::impl_client_v17__dump_priv_key!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -118,6 +118,7 @@ crate::impl_client_v17__verify_message!();
 crate::impl_client_v17__abandon_transaction!();
 crate::impl_client_v17__abort_rescan!();
 crate::impl_client_v17__add_multisig_address!();
+crate::impl_client_v17__backup_wallet!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v23__create_wallet!();
 crate::impl_client_v17__dump_priv_key!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -124,6 +124,7 @@ crate::impl_client_v17__verify_message!();
 crate::impl_client_v17__abandon_transaction!();
 crate::impl_client_v17__abort_rescan!();
 crate::impl_client_v17__add_multisig_address!();
+crate::impl_client_v17__backup_wallet!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v23__create_wallet!();
 crate::impl_client_v17__dump_priv_key!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -120,6 +120,7 @@ crate::impl_client_v17__verify_message!();
 crate::impl_client_v17__abandon_transaction!();
 crate::impl_client_v17__abort_rescan!();
 crate::impl_client_v17__add_multisig_address!();
+crate::impl_client_v17__backup_wallet!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v23__create_wallet!();
 crate::impl_client_v17__dump_priv_key!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -122,6 +122,7 @@ crate::impl_client_v17__verify_message!();
 crate::impl_client_v17__abandon_transaction!();
 crate::impl_client_v17__abort_rescan!();
 crate::impl_client_v17__add_multisig_address!();
+crate::impl_client_v17__backup_wallet!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v23__create_wallet!();
 crate::impl_client_v17__dump_priv_key!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -122,6 +122,7 @@ crate::impl_client_v17__verify_message!();
 crate::impl_client_v17__abandon_transaction!();
 crate::impl_client_v17__abort_rescan!();
 crate::impl_client_v17__add_multisig_address!();
+crate::impl_client_v17__backup_wallet!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v23__create_wallet!();
 crate::impl_client_v17__dump_priv_key!();

--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -10,6 +10,7 @@ use bitcoin::{Amount, PrivateKey};
 use integration_test::{Node, NodeExt as _, Wallet};
 use node::{mtype,AddressType};
 use node::vtype::*;             // All the version specific types.
+use std::fs;
 
 #[test]
 fn wallet__abandon_transaction() {
@@ -61,6 +62,22 @@ fn wallet__add_multisig_address__modelled() {
         .expect("addmultisigaddress");
     let model: Result<mtype::AddMultisigAddress, AddMultisigAddressError> = json.into_model();
     model.unwrap();
+}
+
+#[test]
+fn wallet__backup_wallet() {
+    let node = Node::with_wallet(Wallet::Default, &[]);
+    let file_path = integration_test::random_tmp_file();
+
+    if file_path.exists() {
+        fs::remove_file(&file_path).expect("removefile");
+    }
+
+    node.client.backup_wallet(&file_path).expect("backupwallet");
+    assert!(file_path.exists(), "Backup file should exist at destination");
+    assert!(file_path.is_file(), "Backup destination should be a file");
+
+    fs::remove_file(&file_path).expect("removefile");
 }
 
 #[test]


### PR DESCRIPTION
The JSON-RPC method `backupwallet` does return null. We want to test this to catch any changes in behavior in future Core versions.

This PR adds a client function that errors if the return value is anything other than `null`, along with an integration test that calls this function.

Ref: [#116](https://github.com/rust-bitcoin/corepc/pull/116)