### PR TITLE
Auto dismiss PR approvals on new commits

### DIFF
--- a/.github/workflows/dismiss-stale-approvals.yml
+++ b/.github/workflows/dismiss-stale-approvals.yml
@@ -1,0 +1,26 @@
+name: Dismiss stale pull request approvals
+
+on:
+  pull_request:
+    types: [
+        opened,
+        synchronize,
+        reopened,
+      ]
+
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
+jobs:
+  dismiss_stale_approvals:
+    name: Dismiss stale pull request approvals
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dismiss stale pull request approvals
+        uses: withgraphite/dismiss-stale-approvals@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          


### PR DESCRIPTION
Automatically dismisses stale PR approvals when new commits are pushed, ensuring reviews always reflect the latest changes. 
Fixes #245 