### PR TITLE
Remove redundant tmp file existence check in wallet integration test

### DIFF
--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -69,10 +69,6 @@ fn wallet__backup_wallet() {
     let node = Node::with_wallet(Wallet::Default, &[]);
     let file_path = integration_test::random_tmp_file();
 
-    if file_path.exists() {
-        fs::remove_file(&file_path).expect("removefile");
-    }
-
     node.client.backup_wallet(&file_path).expect("backupwallet");
     assert!(file_path.exists(), "Backup file should exist at destination");
     assert!(file_path.is_file(), "Backup destination should be a file");


### PR DESCRIPTION
This PR removes the redundant `if file_path.exists()` check before deleting a temporary file.

As pointed out during review of `backupwallet` integration test [here](https://github.com/rust-bitcoin/corepc/pull/247#discussion_r2148959542), the check is unnecessary.
