### PR TITLE
Enable the v28 `raw_transaction` module

### DIFF
--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -253,9 +253,18 @@
 mod blockchain;
 mod mining;
 mod network;
+mod raw_transactions;
 
 #[doc(inline)]
-pub use self::{blockchain::GetBlockchainInfo, mining::GetMiningInfo, network::GetNetworkInfo};
+pub use self::{
+    blockchain::GetBlockchainInfo,
+    mining::GetMiningInfo,
+    network::GetNetworkInfo,
+    raw_transactions::{
+        SubmitPackage, SubmitPackageError, SubmitPackageTxResult, SubmitPackageTxResultError,
+        SubmitPackageTxResultFees, SubmitPackageTxResultFeesError,
+    },
+};
 #[doc(inline)]
 pub use crate::{
     v17::{
@@ -313,8 +322,6 @@ pub use crate::{
     v26::{
         CreateWallet, DescriptorProcessPsbt, DescriptorProcessPsbtError,
         GetPrioritisedTransactions, GetTxOutSetInfo, GetTxOutSetInfoError, LoadWallet,
-        PrioritisedTransaction, SubmitPackage, SubmitPackageError, SubmitPackageTxResult,
-        SubmitPackageTxResultError, SubmitPackageTxResultFees, SubmitPackageTxResultFeesError,
-        UnloadWallet,
+        PrioritisedTransaction, UnloadWallet,
     },
 };

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -326,8 +326,10 @@ pub use crate::{
     v26::{
         CreateWallet, DescriptorProcessPsbt, DescriptorProcessPsbtError,
         GetPrioritisedTransactions, GetTxOutSetInfo, GetTxOutSetInfoError, LoadWallet,
-        PrioritisedTransaction, SubmitPackage, SubmitPackageError, SubmitPackageTxResult,
-        SubmitPackageTxResultError, SubmitPackageTxResultFees, SubmitPackageTxResultFeesError,
-        UnloadWallet,
+        PrioritisedTransaction, UnloadWallet,
+    },
+    v28::{
+        SubmitPackage, SubmitPackageError, SubmitPackageTxResult, SubmitPackageTxResultError,
+        SubmitPackageTxResultFees, SubmitPackageTxResultFeesError,
     },
 };


### PR DESCRIPTION
The module files were all there but the module was undeclared and unused, v26 was still being reexported in v28 and v29.

Declare the module and update the reexports.