### PR TITLE
Implement importaddress method and test

### DIFF
--- a/client/src/client_sync/v17/mod.rs
+++ b/client/src/client_sync/v17/mod.rs
@@ -126,6 +126,7 @@ crate::impl_client_v17__get_received_by_address!();
 crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
+crate::impl_client_v17__import_address!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();

--- a/client/src/client_sync/v17/wallet.rs
+++ b/client/src/client_sync/v17/wallet.rs
@@ -269,6 +269,22 @@ macro_rules! impl_client_v17__get_wallet_info {
     };
 }
 
+/// Implements Bitcoin Core JSON-RPC API method `importaddress`.
+#[macro_export]
+macro_rules! impl_client_v17__import_address {
+    () => {
+        impl Client {
+            pub fn import_address(&self, address: &Address) -> Result<()> {
+                match self.call("importaddress", &[into_json(address)?]) {
+                    Ok(serde_json::Value::Null) => Ok(()),
+                    Ok(res) => Err(Error::Returned(res.to_string())),
+                    Err(err) => Err(err.into()),
+                }
+            }
+        }
+    };
+}
+
 /// Implements Bitcoin Core JSON-RPC API method `importprivkey`.
 #[macro_export]
 macro_rules! impl_client_v17__import_privkey {

--- a/client/src/client_sync/v18/mod.rs
+++ b/client/src/client_sync/v18/mod.rs
@@ -141,6 +141,7 @@ crate::impl_client_v18__get_received_by_label!();
 crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
+crate::impl_client_v17__import_address!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();

--- a/client/src/client_sync/v19/mod.rs
+++ b/client/src/client_sync/v19/mod.rs
@@ -137,6 +137,7 @@ crate::impl_client_v17__get_received_by_address!();
 crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
+crate::impl_client_v17__import_address!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();

--- a/client/src/client_sync/v20/mod.rs
+++ b/client/src/client_sync/v20/mod.rs
@@ -134,6 +134,7 @@ crate::impl_client_v17__get_received_by_address!();
 crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
+crate::impl_client_v17__import_address!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();

--- a/client/src/client_sync/v21/mod.rs
+++ b/client/src/client_sync/v21/mod.rs
@@ -136,6 +136,7 @@ crate::impl_client_v17__get_received_by_address!();
 crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
+crate::impl_client_v17__import_address!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -136,6 +136,7 @@ crate::impl_client_v17__get_received_by_address!();
 crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
+crate::impl_client_v17__import_address!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -138,6 +138,7 @@ crate::impl_client_v17__get_received_by_address!();
 crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
+crate::impl_client_v17__import_address!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -135,6 +135,7 @@ crate::impl_client_v17__get_received_by_address!();
 crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
+crate::impl_client_v17__import_address!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -135,6 +135,7 @@ crate::impl_client_v17__get_received_by_address!();
 crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
+crate::impl_client_v17__import_address!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -141,6 +141,7 @@ crate::impl_client_v17__get_received_by_address!();
 crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
+crate::impl_client_v17__import_address!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -137,6 +137,7 @@ crate::impl_client_v17__get_received_by_address!();
 crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
+crate::impl_client_v17__import_address!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -139,6 +139,7 @@ crate::impl_client_v17__get_received_by_address!();
 crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
+crate::impl_client_v17__import_address!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -139,6 +139,7 @@ crate::impl_client_v17__get_received_by_address!();
 crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
+crate::impl_client_v17__import_address!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();

--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -279,6 +279,30 @@ fn wallet__get_transaction__modelled() {
     model.unwrap();
 }
 
+#[test]
+fn wallet__import_address() {
+    let node = match () {
+        #[cfg(feature = "v22_and_below")]
+        () => Node::with_wallet(Wallet::Default, &[]),
+        #[cfg(not(feature = "v22_and_below"))]
+        () => {
+            let node = Node::with_wallet(Wallet::None, &["-deprecatedrpc=create_bdb"]);
+            node.client.create_legacy_wallet("wallet_name").expect("createlegacywallet");
+            node
+        }
+    };
+
+    let privkey =
+        PrivateKey::from_wif("cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy").unwrap();
+
+    // Derive the address from the private key
+    let secp = bitcoin::secp256k1::Secp256k1::new();
+    let pubkey = privkey.public_key(&secp);
+    let addr = bitcoin::Address::p2pkh(&pubkey, privkey.network);
+
+    node.client.import_address(&addr).expect("importaddress");
+}
+
 #[cfg(not(feature = "v17"))]
 #[test]
 fn wallet__list_received_by_label__modelled() {


### PR DESCRIPTION
The JSON-RPC method `importaddress` does return null. We want to test this to catch any changes in behavior in future Core versions.

This PR adds a client function that errors if the return value is anything other than `null`, along with an integration test that calls this function.

Ref: [#116](https://github.com/rust-bitcoin/corepc/pull/116)