### PR TITLE
integration test: Document incompatibility of `--all-features`

### DIFF
--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -7,6 +7,11 @@ enabled. However `node` allows setting the environment variable
 
 `BITCOIND_EXE=/opt/bitcoin-28.0/bin/bitcoind cargo test --features=28_0`
 
+## All features
+
+Note that this crate cannot be built with `--all-features` because of
+how the internal `v28_and_below` style feature gates work.
+
 ## Shell alias' for the impatient
 
 I have all the Core versions on my machine e.g., `/opt/bitcoin-28.0`


### PR DESCRIPTION
And I always forget that the integration test crate cannot be built with all features enabled.

Add a section to the README in an attempt to save poor future Tobin the time to work this out again.