### PR TITLE
Annotate null-returning integration test functions with ()

### DIFF
--- a/integration_test/tests/blockchain.rs
+++ b/integration_test/tests/blockchain.rs
@@ -267,7 +267,7 @@ fn blockchain__precious_block() {
     let hash = node.client.best_block_hash().expect("best_block_hash failed");
     node.mine_a_block();
 
-    let _ = node.client.precious_block(hash).expect("preciousblock");
+    let _: () = node.client.precious_block(hash).expect("preciousblock");
 }
 
 #[test]
@@ -293,7 +293,7 @@ fn blockchain__savemempool() {
 
     #[cfg(feature = "v22_and_below")]
     {
-        node.client.save_mempool().expect("savemempool");
+        let _: () = node.client.save_mempool().expect("savemempool");
     }
 
     #[cfg(not(feature = "v22_and_below"))]

--- a/integration_test/tests/network.rs
+++ b/integration_test/tests/network.rs
@@ -19,9 +19,9 @@ fn network__add_node() {
 
     let dummy_peer = "192.0.2.1:8333";
 
-    node.client.add_node(dummy_peer, AddNodeCommand::OneTry).expect("addnode onetry");
-    node.client.add_node(dummy_peer, AddNodeCommand::Add).expect("addnode add");
-    node.client.add_node(dummy_peer, AddNodeCommand::Remove).expect("addnode remove");
+    let _: () = node.client.add_node(dummy_peer, AddNodeCommand::OneTry).expect("addnode onetry");
+    let _: () = node.client.add_node(dummy_peer, AddNodeCommand::Add).expect("addnode add");
+    let _: () = node.client.add_node(dummy_peer, AddNodeCommand::Remove).expect("addnode remove");
 }
 
 #[test]
@@ -29,8 +29,8 @@ fn network__clear_banned() {
     let node = Node::with_wallet(Wallet::None, &[]);
     let dummy_subnet = "192.0.2.2";
 
-    node.client.set_ban(dummy_subnet, SetBanCommand::Add).expect("setban add");
-    node.client.clear_banned().expect("clearbanned");
+    let _: () = node.client.set_ban(dummy_subnet, SetBanCommand::Add).expect("setban add");
+    let _: () = node.client.clear_banned().expect("clearbanned");
 }
 
 #[test]
@@ -40,7 +40,7 @@ fn network__disconnect_node() {
     let peers = node2.client.get_peer_info().expect("getpeerinfo");
     let peer = peers.0.first().expect("should have at least one peer");
 
-    node2.client.disconnect_node(&peer.address).expect("disconnectnode");
+    let _: () = node2.client.disconnect_node(&peer.address).expect("disconnectnode");
 }
 
 #[test]
@@ -130,7 +130,7 @@ fn network__list_banned() {
 #[test]
 fn network__ping() {
     let node = Node::with_wallet(Wallet::None, &[]);
-    node.client.ping().expect("ping");
+    let _: () = node.client.ping().expect("ping");
 }
 
 #[test]
@@ -138,8 +138,8 @@ fn network__set_ban() {
     let node = Node::with_wallet(Wallet::None, &[]);
     let dummy_subnet = "192.0.2.3";
 
-    node.client.set_ban(dummy_subnet, SetBanCommand::Add).expect("setban add");
-    node.client.set_ban(dummy_subnet, SetBanCommand::Remove).expect("setban remove");
+    let _: () = node.client.set_ban(dummy_subnet, SetBanCommand::Add).expect("setban add");
+    let _: () = node.client.set_ban(dummy_subnet, SetBanCommand::Remove).expect("setban remove");
 }
 
 #[test]

--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -34,7 +34,7 @@ fn wallet__abandon_transaction() {
 
     node.client.invalidate_block(block_hash).expect("invalidateblock");
 
-    node.client.abandon_transaction(txid).expect("abandontransaction");
+    let _: () = node.client.abandon_transaction(txid).expect("abandontransaction");
 }
 
 #[test]
@@ -69,7 +69,7 @@ fn wallet__backup_wallet() {
     let node = Node::with_wallet(Wallet::Default, &[]);
     let file_path = integration_test::random_tmp_file();
 
-    node.client.backup_wallet(&file_path).expect("backupwallet");
+    let _: () = node.client.backup_wallet(&file_path).expect("backupwallet");
     assert!(file_path.exists(), "Backup file should exist at destination");
     assert!(file_path.is_file(), "Backup destination should be a file");
 
@@ -307,7 +307,7 @@ fn wallet__import_address() {
     let pubkey = privkey.public_key(&secp);
     let addr = bitcoin::Address::p2pkh(&pubkey, privkey.network);
 
-    node.client.import_address(&addr).expect("importaddress");
+    let _: () = node.client.import_address(&addr).expect("importaddress");
 }
 
 #[cfg(not(feature = "v17"))]
@@ -345,7 +345,7 @@ fn wallet__import_privkey() {
     let privkey =
         PrivateKey::from_wif("cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy").unwrap();
 
-    node.client.import_privkey(&privkey).expect("importprivkey");
+    let _: () = node.client.import_privkey(&privkey).expect("importprivkey");
 }
 
 #[test]
@@ -428,7 +428,7 @@ fn create_load_unload_wallet() {
 
     // Upto version 20 Core returns null for `unloadwallet`.
     #[cfg(feature = "v20_and_below")]
-    let _ = node.client.unload_wallet(&wallet).expect("unloadwallet");
+    let _: () = node.client.unload_wallet(&wallet).expect("unloadwallet");
 
     // From version 21 Core returns warnings for `unloadwallet`.
     #[cfg(not(feature = "v20_and_below"))]


### PR DESCRIPTION
Adds `let _: () = ...` to all integration test cases where client functions return `()`, making it obvious that these functions return no value.

Closes #256.
