### PR TITLE
Add '()' annotation and error handling to submit_header

### DIFF
--- a/integration_test/tests/mining.rs
+++ b/integration_test/tests/mining.rs
@@ -221,8 +221,12 @@ fn mining__submit_header() {
     let best_block = node.client.get_best_block_hash().expect("getbestblockhash").into_model().unwrap().0;
     let mut header = node.client.get_block_header(&best_block).expect("getblockheader").into_model().unwrap().0;
 
-    // Change the nonce to ensure the header is different from the current tip.
-    header.nonce = header.nonce.wrapping_add(1);
+    for _ in 1..=u32::MAX {
+        header.nonce = header.nonce.wrapping_add(1);
+        if header.validate_pow(header.target()).is_ok() {
+            break;
+        }
+    }
 
-    let _ = node.client.submit_header(&header);
+    let _: () = node.client.submit_header(&header).expect("submitheader");
 }


### PR DESCRIPTION
This is a patch for [PR #259](https://github.com/rust-bitcoin/corepc/pull/259) that adds a `let _: () = ...` annotation and an `.expect("submitheader")` call to the integration test for `submit_header`.

The `.expect()` call is necessary to extract the `()` value from the result returned by `submit_header`, making the test both explicit and consistent with the other null-returning client function tests.

Also, Introduced a for loop to increment the header’s nonce until the PoW is valid. This ensures the header meets Bitcoin’s difficulty target before calling `submit_header`.
