### PR TITLE
Fix clippy lints in `integration_test`

### DIFF
--- a/integration_test/tests/mining.rs
+++ b/integration_test/tests/mining.rs
@@ -134,7 +134,7 @@ fn submit_empty_block(node: &Node, bt: &mtype::GetBlockTemplate) {
             version: block::Version::default(),
             prev_blockhash: bt.previous_block_hash,
             merkle_root: TxMerkleNode::all_zeros(),
-            time: Ord::max(bt.min_time, std::time::UNIX_EPOCH.elapsed().expect("elapsed").as_secs() as u32) as u32,
+            time: Ord::max(bt.min_time, std::time::UNIX_EPOCH.elapsed().expect("elapsed").as_secs() as u32),
             bits: bt.bits,
             nonce: 0,
         },

--- a/integration_test/tests/mining.rs
+++ b/integration_test/tests/mining.rs
@@ -150,7 +150,7 @@ fn submit_empty_block(node: &Node, bt: &mtype::GetBlockTemplate) {
         }
     }
 
-    let _ = node.client.submit_block(&block).expect("submitblock");
+    let _: () = node.client.submit_block(&block).expect("submitblock");
 }
 
 // FIXME: Submitting this block returns 'inconclusive'.
@@ -208,7 +208,7 @@ fn mining__submit_block_with_dummy_coinbase(node: &Node, bt: &mtype::GetBlockTem
         }
     }
 
-    let _ = node.client.submit_block(&block).expect("submitblock");
+    let _: () = node.client.submit_block(&block).expect("submitblock");
 }
 
 #[cfg(not(feature = "v17"))]

--- a/integration_test/tests/network.rs
+++ b/integration_test/tests/network.rs
@@ -146,8 +146,8 @@ fn network__set_ban() {
 fn network__set_network_active() {
     let node = Node::with_wallet(Wallet::None, &[]);
     let json: SetNetworkActive = node.client.set_network_active(false).expect("setnetworkactive false");
-    assert!(json.0 == false);
+    assert!(!json.0);
 
     let json: SetNetworkActive = node.client.set_network_active(true).expect("setnetworkactive true");
-    assert!(json.0 == true);
+    assert!(json.0);
 }

--- a/integration_test/tests/raw_transactions.rs
+++ b/integration_test/tests/raw_transactions.rs
@@ -546,6 +546,7 @@ fn create_sign_with_key_send(node: &Node) {
 // - fund_raw_transaction
 // - sign_raw_transaction_with_wallet (sign_raw_transaction was deprecated in v0.17).
 // - send_raw_transaction
+#[allow(clippy::inconsistent_digit_grouping)] // Sats to btc is a common use case.
 fn create_fund_sign_send(node: &Node) {
     let (_addr, _tx, txid, _tx_out, vout) = create_utxo(node);
 

--- a/integration_test/tests/raw_transactions.rs
+++ b/integration_test/tests/raw_transactions.rs
@@ -221,7 +221,7 @@ fn arbitrary_p2pkh_script() -> ScriptBuf {
     script::Builder::new()
         .push_opcode(OP_DUP)
         .push_opcode(OP_HASH160)
-        .push_slice(&pubkey_hash)
+        .push_slice(pubkey_hash)
         .push_opcode(OP_EQUALVERIFY)
         .push_opcode(OP_CHECKSIG)
         .into_script()
@@ -238,9 +238,9 @@ fn arbitrary_multisig_script() -> ScriptBuf {
     script::Builder::new()
         .push_opcode(OP_PUSHNUM_1)
         .push_opcode(OP_PUSHBYTES_33)
-        .push_slice(&pk1)
+        .push_slice(pk1)
         .push_opcode(OP_PUSHBYTES_33)
-        .push_slice(&pk2)
+        .push_slice(pk2)
         .push_opcode(OP_PUSHNUM_2)
         .push_opcode(OP_CHECKMULTISIG)
         .into_script()
@@ -581,7 +581,7 @@ fn create_fund_sign_send(node: &Node) {
 
 // Creates a transaction using client to do RPC call `create_raw_transaction`.
 fn create_a_raw_transaction(node: &Node) -> Transaction {
-    let (_addr, _tx, txid, tx_out, vout) = create_utxo(&node);
+    let (_addr, _tx, txid, tx_out, vout) = create_utxo(node);
 
     // Assumes tx_out has a million sats in it.
     let spend_amount = Amount::from_sat(100_000);

--- a/integration_test/tests/raw_transactions.rs
+++ b/integration_test/tests/raw_transactions.rs
@@ -388,7 +388,7 @@ fn raw_transactions__submit_package__modelled() {
         .expect("failed to submit package")
         .into_model()
         .expect("failed to submit package");
-    for (_, tx_result) in &res.tx_results {
+    for tx_result in res.tx_results.values() {
         assert!(tx_result.error.is_some());
     }
     assert!(res.replaced_transactions.is_empty());
@@ -416,7 +416,7 @@ fn raw_transactions__submit_package__modelled() {
         .expect("failed to submit package")
         .into_model()
         .expect("failed to submit package");
-    for (_, tx_result) in &res.tx_results {
+    for tx_result in res.tx_results.values() {
         assert!(tx_result.error.is_some());
     }
     assert!(res.replaced_transactions.is_empty());

--- a/integration_test/tests/util.rs
+++ b/integration_test/tests/util.rs
@@ -38,7 +38,7 @@ fn util__derive_addresses__modelled() {
     // Use a valid, deterministic public key from the pubkey_sort test vectors and the checksum for it.
     let descriptor = "pkh(02ff12471208c14bd580709cb2358d98975247d8765f92bc25eab3b2763ed605f8)#sf4k0g3u";
 
-    let json: DeriveAddresses = node.client.derive_addresses(&descriptor).expect("deriveaddresses");
+    let json: DeriveAddresses = node.client.derive_addresses(descriptor).expect("deriveaddresses");
     let res: Result<mtype::DeriveAddresses, _> = json.into_model();
     let _ = res.expect("DeriveAddresses into model");
 }
@@ -75,7 +75,7 @@ fn util__sign_message_with_priv_key__modelled() {
     // Derive the address from the private key
     let secp = bitcoin::secp256k1::Secp256k1::new();
     let pubkey = privkey.public_key(&secp);
-    let addr = bitcoin::Address::p2pkh(&pubkey, privkey.network);
+    let addr = bitcoin::Address::p2pkh(pubkey, privkey.network);
 
     // Sign the message with the private key
     let json: SignMessageWithPrivKey = node

--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -170,7 +170,7 @@ fn wallet__get_addresses_by_label__modelled() {
 
     // sanity checks.
     assert!(!map.0.is_empty());
-    assert!(map.0.get(&addr).is_some());
+    assert!(map.0.contains_key(&addr));
 }
 
 #[test]

--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -305,7 +305,7 @@ fn wallet__import_address() {
     // Derive the address from the private key
     let secp = bitcoin::secp256k1::Secp256k1::new();
     let pubkey = privkey.public_key(&secp);
-    let addr = bitcoin::Address::p2pkh(&pubkey, privkey.network);
+    let addr = bitcoin::Address::p2pkh(pubkey, privkey.network);
 
     let _: () = node.client.import_address(&addr).expect("importaddress");
 }


### PR DESCRIPTION
A new script to lint the integration tests is being added in #258.

Run the script and fix all the lint errors.