### PR TITLE
Implement importmulti method and test

### DIFF
--- a/client/src/client_sync/v17/mod.rs
+++ b/client/src/client_sync/v17/mod.rs
@@ -128,6 +128,7 @@ crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
+crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();
@@ -244,4 +245,43 @@ pub enum AddNodeCommand {
 pub enum SetBanCommand {
     Add,
     Remove,
+}
+
+/// Args for the `importmulti` method
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+pub struct ImportMultiRequest {
+    /// Descriptor to import. If using descriptor, donot also provide address/scriptPubKey, scripts, or pubkeys.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub desc: Option<String>,
+    /// Type of scriptPubKey (string for script, json for address). Should not be provided if using descriptor.
+    #[serde(rename = "scriptPubKey", skip_serializing_if = "Option::is_none")]
+    pub script_pub_key: Option<ImportMultiScriptPubKey>,
+    /// Creation time of the key expressed in UNIX epoch time, or the string "now" to substitute the current synced blockchain time.
+    pub timestamp: ImportMultiTimestamp,
+}
+
+/// `scriptPubKey` can be a string for script or json for address.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum ImportMultiScriptPubKey {
+    /// The script.
+    Script(String),
+    /// The address.
+    Address { address: String },
+}
+
+/// `timestamp` can be a number (UNIX epoch time) or the string `"now"`
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum ImportMultiTimestamp {
+    /// The string "now".
+    Now(String),
+    /// The UNIX epoch time.
+    Time(u64),
+}
+
+impl Default for ImportMultiTimestamp {
+    fn default() -> Self {
+        ImportMultiTimestamp::Now("now".to_string())
+    }
 }

--- a/client/src/client_sync/v17/wallet.rs
+++ b/client/src/client_sync/v17/wallet.rs
@@ -298,6 +298,18 @@ macro_rules! impl_client_v17__import_address {
     };
 }
 
+/// Implements Bitcoin Core JSON-RPC API method `importmulti`
+#[macro_export]
+macro_rules! impl_client_v17__import_multi {
+    () => {
+        impl Client {
+            pub fn import_multi( &self, requests: &[ImportMultiRequest]) -> Result<ImportMulti> {
+                self.call("importmulti", &[into_json(requests)?])
+            }
+        }
+    };
+}
+
 /// Implements Bitcoin Core JSON-RPC API method `importprivkey`.
 #[macro_export]
 macro_rules! impl_client_v17__import_privkey {

--- a/client/src/client_sync/v18/mod.rs
+++ b/client/src/client_sync/v18/mod.rs
@@ -24,7 +24,7 @@ use crate::types::v18::*;
 pub use crate::client_sync::{
     v17::{
         AddNodeCommand, AddressType, Input, Output, SetBanCommand, TemplateRequest,
-        TemplateRules, WalletCreateFundedPsbtInput
+        TemplateRules, WalletCreateFundedPsbtInput, ImportMultiRequest, ImportMultiScriptPubKey, ImportMultiTimestamp,
     },
 };
 
@@ -143,6 +143,7 @@ crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
+crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();

--- a/client/src/client_sync/v19/mod.rs
+++ b/client/src/client_sync/v19/mod.rs
@@ -20,7 +20,7 @@ use crate::types::v19::*;
 pub use crate::client_sync::{
     v17::{
         AddNodeCommand, AddressType, Input, Output, SetBanCommand, TemplateRequest,
-        TemplateRules, WalletCreateFundedPsbtInput
+        TemplateRules, WalletCreateFundedPsbtInput, ImportMultiRequest, ImportMultiScriptPubKey, ImportMultiTimestamp,
     },
 };
 
@@ -139,6 +139,7 @@ crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
+crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();

--- a/client/src/client_sync/v20/mod.rs
+++ b/client/src/client_sync/v20/mod.rs
@@ -17,7 +17,7 @@ use crate::types::v20::*;
 pub use crate::client_sync::{
     v17::{
         AddressType, AddNodeCommand, Input, Output, SetBanCommand, TemplateRequest, TemplateRules,
-        WalletCreateFundedPsbtInput
+        WalletCreateFundedPsbtInput, ImportMultiRequest, ImportMultiScriptPubKey, ImportMultiTimestamp,
     },
 };
 
@@ -136,6 +136,7 @@ crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
+crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();

--- a/client/src/client_sync/v21/mod.rs
+++ b/client/src/client_sync/v21/mod.rs
@@ -19,7 +19,7 @@ use crate::types::v21::*;
 pub use crate::client_sync::{
     v17::{
         AddNodeCommand, AddressType, Input, Output, SetBanCommand, TemplateRequest,
-        TemplateRules, WalletCreateFundedPsbtInput
+        TemplateRules, WalletCreateFundedPsbtInput, ImportMultiRequest, ImportMultiScriptPubKey, ImportMultiTimestamp,
     },
 };
 
@@ -138,6 +138,7 @@ crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
+crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -19,7 +19,7 @@ use crate::types::v22::*;
 pub use crate::client_sync::{
     v17::{
         AddNodeCommand, AddressType, Input, Output, SetBanCommand, TemplateRequest,
-        TemplateRules, WalletCreateFundedPsbtInput
+        TemplateRules, WalletCreateFundedPsbtInput, ImportMultiRequest, ImportMultiScriptPubKey, ImportMultiTimestamp,
     },
 };
 
@@ -138,6 +138,7 @@ crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
+crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -21,7 +21,7 @@ use crate::types::v23::*;
 pub use crate::client_sync::{
     v17::{
         AddNodeCommand, Input, Output, SetBanCommand, TemplateRequest, TemplateRules,
-        WalletCreateFundedPsbtInput
+        WalletCreateFundedPsbtInput, ImportMultiRequest, ImportMultiScriptPubKey, ImportMultiTimestamp,
     },
 };
 
@@ -140,6 +140,7 @@ crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
+crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -17,7 +17,7 @@ use crate::types::v24::*;
 pub use crate::client_sync::{
     v17::{
         AddNodeCommand, Input, Output, SetBanCommand, TemplateRequest, TemplateRules,
-        WalletCreateFundedPsbtInput
+        WalletCreateFundedPsbtInput, ImportMultiRequest, ImportMultiScriptPubKey, ImportMultiTimestamp,
     },
     v23::AddressType,
 };
@@ -137,6 +137,7 @@ crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
+crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -17,7 +17,7 @@ use crate::types::v25::*;
 pub use crate::client_sync::{
     v17::{
         AddNodeCommand, Input, Output, SetBanCommand, TemplateRequest, TemplateRules,
-        WalletCreateFundedPsbtInput
+        WalletCreateFundedPsbtInput, ImportMultiRequest, ImportMultiScriptPubKey, ImportMultiTimestamp,
     },
     v23::AddressType,
 };
@@ -137,6 +137,7 @@ crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
+crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -21,7 +21,7 @@ use crate::types::v26::*;
 pub use crate::client_sync::{
     v17::{
         AddNodeCommand, Input, Output, SetBanCommand, TemplateRequest, TemplateRules,
-        WalletCreateFundedPsbtInput
+        WalletCreateFundedPsbtInput, ImportMultiRequest, ImportMultiScriptPubKey, ImportMultiTimestamp,
     },
     v23::AddressType,
 };
@@ -143,6 +143,7 @@ crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
+crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -17,7 +17,7 @@ use crate::types::v27::*;
 pub use crate::client_sync::{
     v17::{
         AddNodeCommand, Input, Output, SetBanCommand, TemplateRequest, TemplateRules,
-        WalletCreateFundedPsbtInput
+        WalletCreateFundedPsbtInput, ImportMultiRequest, ImportMultiScriptPubKey, ImportMultiTimestamp,
     },
     v23::AddressType,
 };
@@ -139,6 +139,7 @@ crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
+crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -19,7 +19,7 @@ use crate::types::v28::*;
 pub use crate::client_sync::{
     v17::{
         AddNodeCommand, Input, Output, SetBanCommand, TemplateRequest, TemplateRules,
-        WalletCreateFundedPsbtInput
+        WalletCreateFundedPsbtInput, ImportMultiRequest, ImportMultiScriptPubKey, ImportMultiTimestamp,
     },
     v23::AddressType,
 };
@@ -141,6 +141,7 @@ crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
+crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -19,7 +19,7 @@ use crate::types::v29::*;
 
 #[rustfmt::skip]                // Keep public re-exports separate.
 pub use crate::client_sync::{
-    v17::{AddNodeCommand, Input, Output, SetBanCommand, WalletCreateFundedPsbtInput},
+    v17::{AddNodeCommand, Input, Output, SetBanCommand, WalletCreateFundedPsbtInput, ImportMultiRequest, ImportMultiScriptPubKey, ImportMultiTimestamp,},
     v23::AddressType,
 };
 
@@ -141,6 +141,7 @@ crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
+crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();

--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -8,7 +8,7 @@
 use bitcoin::address::{Address, NetworkChecked};
 use bitcoin::{Amount, PrivateKey};
 use integration_test::{Node, NodeExt as _, Wallet};
-use node::{mtype,AddressType};
+use node::{mtype, AddressType, ImportMultiRequest, ImportMultiScriptPubKey, ImportMultiTimestamp};
 use node::vtype::*;             // All the version specific types.
 use std::fs;
 
@@ -327,6 +327,46 @@ fn wallet__list_received_by_label__modelled() {
     let model: Result<mtype::ListReceivedByLabel, ListReceivedByLabelError> = json.into_model();
     let model = model.unwrap();
     assert!(model.0.iter().any(|item| item.label == label));
+}
+
+#[test]
+fn wallet__import_multi() {
+    let node = match () {
+        #[cfg(feature = "v22_and_below")]
+        () => Node::with_wallet(Wallet::Default, &[]),
+        #[cfg(not(feature = "v22_and_below"))]
+        () => {
+            let node = Node::with_wallet(Wallet::None, &["-deprecatedrpc=create_bdb"]);
+            node.client.create_legacy_wallet("wallet_name").expect("createlegacywallet");
+            node
+        }
+    };
+
+    let dummy_script_hex = "76a914aabbccddeeff00112233445566778899aabbccdd88ac";
+    let addr = node.client.new_address().expect("newaddress");
+    let dummy_desc = "pkh(02c6047f9441ed7d6d3045406e95c07cd85a2a0e5c1e507a7a7e3d2f0d6c3d8ef8)#tp9h0863";
+
+    let req1 = ImportMultiRequest {
+        script_pub_key: Some(ImportMultiScriptPubKey::Script(dummy_script_hex.to_string())),
+        timestamp: ImportMultiTimestamp::Now("now".to_string()),
+        ..Default::default()
+    };
+
+    let req2 = ImportMultiRequest {
+        script_pub_key: Some(ImportMultiScriptPubKey::Address {
+            address: addr.to_string(),
+        }),
+        timestamp: ImportMultiTimestamp::Now("now".to_string()),
+        ..Default::default()
+    };
+
+    let req3 = ImportMultiRequest {
+        desc: Some(dummy_desc.to_string()),
+        timestamp: ImportMultiTimestamp::Time(1_700_000_000),
+        ..Default::default()
+    };
+
+    let _: ImportMulti = node.client.import_multi(&[req1, req2, req3]).expect("importmulti");
 }
 
 #[test]

--- a/types/src/v17/mod.rs
+++ b/types/src/v17/mod.rs
@@ -173,7 +173,7 @@
 //! | getunconfirmedbalance              | version + model | UNTESTED                               |
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
-//! | importmulti                        | returns nothing |                                        |
+//! | importmulti                        | version         |                                        |
 //! | importprivkey                      | returns nothing |                                        |
 //! | importprunedfunds                  | returns nothing |                                        |
 //! | importpubkey                       | returns nothing |                                        |
@@ -284,7 +284,7 @@ pub use self::{
         ListTransactionsItem, ListTransactionsItemError, ListUnspent, ListUnspentItem,
         ListUnspentItemError, ListWallets, LoadWallet, RescanBlockchain, SendMany, SendToAddress,
         SignMessage, TransactionCategory, WalletCreateFundedPsbt, WalletCreateFundedPsbtError,
-        WalletProcessPsbt,
+        WalletProcessPsbt, ImportMulti, ImportMultiEntry, JsonRpcError,
     },
     zmq::GetZmqNotifications,
 };

--- a/types/src/v17/wallet/mod.rs
+++ b/types/src/v17/wallet/mod.rs
@@ -547,6 +547,48 @@ pub struct GetWalletInfo {
     pub private_keys_enabled: bool,
 }
 
+/// Result of JSON-RPC method `importmulti`.
+///
+/// > importmulti requests ( options )
+/// >
+/// > Arguments:
+/// > 1. requests                                                         (json array, required) Data to be imported
+/// >   [
+/// >   {                                                            (json object)
+/// >   "desc": "str",                                             (string, optional) Descriptor to import. If using descriptor, do not also provide address/scriptPubKey, scripts, or pubkeys
+/// >   "scriptPubKey": "script" | { "address":"address" },    (string / json, required) Type of scriptPubKey (string for script, json for address). Should not be provided if using a descriptor
+/// >   "timestamp": timestamp | "now",                            (integer / string, required) Creation time of the key expressed in UNIX epoch time,or the string "now" to substitute the current synced blockchain time. The timestamp of the oldest key will determine how far back blockchain rescans need to begin for missing wallet transactions. "now" can be specified to bypass scanning, for keys which are known to never have been used, and 0 can be specified to scan the entire blockchain. Blocks up to 2 hours before the earliest key creation time of all keys being imported by the importmulti call will be scanned.
+/// >   },
+/// >   ...
+/// >   ]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct ImportMulti(pub Vec<ImportMultiEntry>);
+
+/// Represents a single entry in the importmulti result array.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct ImportMultiEntry {
+    /// The success.
+    pub success: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// The warnings.
+    pub warnings: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// The error.
+    pub error: Option<JsonRpcError>,
+}
+
+/// Represents the error object in a JSON-RPC error response.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct JsonRpcError {
+    /// The error code.
+    pub code: i32,
+    /// The error message.
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    /// The error data.
+    pub data: Option<serde_json::Value>, // Can hold arbitrary extra information
+}
+
 /// Result of the JSON-RPC method `listaddressgroupings`.
 ///
 /// > listaddressgroupings

--- a/types/src/v18/mod.rs
+++ b/types/src/v18/mod.rs
@@ -177,7 +177,7 @@
 //! | getunconfirmedbalance              | version + model | UNTESTED                               |
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
-//! | importmulti                        | returns nothing |                                        |
+//! | importmulti                        | version         |                                        |
 //! | importprivkey                      | returns nothing |                                        |
 //! | importprunedfunds                  | returns nothing |                                        |
 //! | importpubkey                       | returns nothing |                                        |
@@ -281,5 +281,5 @@ pub use crate::v17::{
     SignMessageWithPrivKey, SignRawTransaction, SignRawTransactionError, Softfork, SoftforkReject,
     TestMempoolAccept, TransactionCategory, UploadTarget, ValidateAddress, ValidateAddressError,
     VerifyChain, VerifyMessage, VerifyTxOutProof, WalletCreateFundedPsbt,
-    WalletCreateFundedPsbtError, WalletProcessPsbt, WitnessUtxo,
+    WalletCreateFundedPsbtError, WalletProcessPsbt, WitnessUtxo, ImportMulti, ImportMultiEntry, JsonRpcError,
 };

--- a/types/src/v19/mod.rs
+++ b/types/src/v19/mod.rs
@@ -178,7 +178,7 @@
 //! | getunconfirmedbalance              | version + model | UNTESTED                               |
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
-//! | importmulti                        | returns nothing |                                        |
+//! | importmulti                        | version         |                                        |
 //! | importprivkey                      | returns nothing |                                        |
 //! | importprunedfunds                  | returns nothing |                                        |
 //! | importpubkey                       | returns nothing |                                        |
@@ -273,6 +273,7 @@ pub use crate::v17::{
     SignRawTransactionError, SoftforkReject, TestMempoolAccept, TransactionCategory, UploadTarget,
     ValidateAddress, ValidateAddressError, VerifyChain, VerifyMessage, VerifyTxOutProof,
     WalletCreateFundedPsbt, WalletCreateFundedPsbtError, WalletProcessPsbt, WitnessUtxo,
+    ImportMulti, ImportMultiEntry, JsonRpcError,
 };
 #[doc(inline)]
 pub use crate::v18::{

--- a/types/src/v20/mod.rs
+++ b/types/src/v20/mod.rs
@@ -179,7 +179,7 @@
 //! | getunconfirmedbalance              | version + model | UNTESTED                               |
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
-//! | importmulti                        | returns nothing |                                        |
+//! | importmulti                        | version         |                                        |
 //! | importprivkey                      | returns nothing |                                        |
 //! | importprunedfunds                  | returns nothing |                                        |
 //! | importpubkey                       | returns nothing |                                        |
@@ -268,7 +268,7 @@ pub use crate::{
         SignRawTransactionError, SoftforkReject, TestMempoolAccept, TransactionCategory,
         UploadTarget, ValidateAddress, ValidateAddressError, VerifyChain, VerifyMessage,
         VerifyTxOutProof, WalletCreateFundedPsbt, WalletCreateFundedPsbtError, WalletProcessPsbt,
-        WitnessUtxo,
+        WitnessUtxo, ImportMulti, ImportMultiEntry, JsonRpcError,
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,

--- a/types/src/v21/mod.rs
+++ b/types/src/v21/mod.rs
@@ -182,7 +182,7 @@
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
 //! | importdescriptors                  | version         | TODO                                   |
-//! | importmulti                        | returns nothing |                                        |
+//! | importmulti                        | version         |                                        |
 //! | importprivkey                      | returns nothing |                                        |
 //! | importprunedfunds                  | returns nothing |                                        |
 //! | importpubkey                       | returns nothing |                                        |
@@ -271,7 +271,7 @@ pub use crate::{
         SignRawTransactionError, SoftforkReject, TestMempoolAccept, TransactionCategory,
         UploadTarget, ValidateAddress, ValidateAddressError, VerifyChain, VerifyMessage,
         VerifyTxOutProof, WalletCreateFundedPsbt, WalletCreateFundedPsbtError, WalletProcessPsbt,
-        WitnessUtxo,
+        WitnessUtxo, ImportMulti, ImportMultiEntry, JsonRpcError,
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -191,7 +191,7 @@
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
 //! | importdescriptors                  | version         | TODO                                   |
-//! | importmulti                        | returns nothing |                                        |
+//! | importmulti                        | version         |                                        |
 //! | importprivkey                      | returns nothing |                                        |
 //! | importprunedfunds                  | returns nothing |                                        |
 //! | importpubkey                       | returns nothing |                                        |
@@ -285,7 +285,7 @@ pub use crate::{
         SignRawTransactionError, SoftforkReject, TestMempoolAccept, TransactionCategory,
         UploadTarget, ValidateAddress, ValidateAddressError, VerifyChain, VerifyMessage,
         VerifyTxOutProof, WalletCreateFundedPsbt, WalletCreateFundedPsbtError, WalletProcessPsbt,
-        WitnessUtxo,
+        WitnessUtxo, ImportMulti, ImportMultiEntry, JsonRpcError,
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -182,7 +182,7 @@
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
 //! | importdescriptors                  | version         | TODO                                   |
-//! | importmulti                        | returns nothing |                                        |
+//! | importmulti                        | version         |                                        |
 //! | importprivkey                      | returns nothing |                                        |
 //! | importprunedfunds                  | returns nothing |                                        |
 //! | importpubkey                       | returns nothing |                                        |
@@ -280,7 +280,7 @@ pub use crate::{
         SignRawTransactionError, SoftforkReject, TestMempoolAccept, TransactionCategory,
         UploadTarget, ValidateAddress, ValidateAddressError, VerifyChain, VerifyMessage,
         VerifyTxOutProof, WalletCreateFundedPsbt, WalletCreateFundedPsbtError, WalletProcessPsbt,
-        WitnessUtxo,
+        WitnessUtxo, ImportMulti, ImportMultiEntry, JsonRpcError,
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -183,7 +183,7 @@
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
 //! | importdescriptors                  | version         | TODO                                   |
-//! | importmulti                        | returns nothing |                                        |
+//! | importmulti                        | version         |                                        |
 //! | importprivkey                      | returns nothing |                                        |
 //! | importprunedfunds                  | returns nothing |                                        |
 //! | importpubkey                       | returns nothing |                                        |
@@ -285,7 +285,7 @@ pub use crate::{
         SignRawTransactionError, SoftforkReject, TestMempoolAccept, TransactionCategory,
         UploadTarget, ValidateAddress, ValidateAddressError, VerifyChain, VerifyMessage,
         VerifyTxOutProof, WalletCreateFundedPsbt, WalletCreateFundedPsbtError, WalletProcessPsbt,
-        WitnessUtxo,
+        WitnessUtxo, ImportMulti, ImportMultiEntry, JsonRpcError,
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -184,7 +184,7 @@
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
 //! | importdescriptors                  | version         | TODO                                   |
-//! | importmulti                        | returns nothing |                                        |
+//! | importmulti                        | version         |                                        |
 //! | importprivkey                      | returns nothing |                                        |
 //! | importprunedfunds                  | returns nothing |                                        |
 //! | importpubkey                       | returns nothing |                                        |
@@ -276,7 +276,7 @@ pub use crate::{
         SignMessage, SignMessageWithPrivKey, SignRawTransaction, SignRawTransactionError,
         SoftforkReject, TestMempoolAccept, TransactionCategory, UploadTarget, ValidateAddress,
         ValidateAddressError, VerifyChain, VerifyMessage, VerifyTxOutProof, WalletCreateFundedPsbt,
-        WalletCreateFundedPsbtError, WalletProcessPsbt, WitnessUtxo,
+        WalletCreateFundedPsbtError, WalletProcessPsbt, WitnessUtxo, ImportMulti, ImportMultiEntry, JsonRpcError,
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -192,7 +192,7 @@
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
 //! | importdescriptors                  | version         | TODO                                   |
-//! | importmulti                        | returns nothing |                                        |
+//! | importmulti                        | version         |                                        |
 //! | importprivkey                      | returns nothing |                                        |
 //! | importprunedfunds                  | returns nothing |                                        |
 //! | importpubkey                       | returns nothing |                                        |
@@ -296,7 +296,7 @@ pub use crate::{
         SignRawTransaction, SignRawTransactionError, SoftforkReject, TestMempoolAccept,
         TransactionCategory, UploadTarget, ValidateAddress, ValidateAddressError, VerifyChain,
         VerifyMessage, VerifyTxOutProof, WalletCreateFundedPsbt, WalletCreateFundedPsbtError,
-        WalletProcessPsbt, WitnessUtxo,
+        WalletProcessPsbt, WitnessUtxo, ImportMulti, ImportMultiEntry, JsonRpcError,
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -192,7 +192,7 @@
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
 //! | importdescriptors                  | version         | TODO                                   |
-//! | importmulti                        | returns nothing |                                        |
+//! | importmulti                        | version         |                                        |
 //! | importprivkey                      | returns nothing |                                        |
 //! | importprunedfunds                  | returns nothing |                                        |
 //! | importpubkey                       | returns nothing |                                        |
@@ -280,7 +280,7 @@ pub use crate::{
         SignRawTransaction, SignRawTransactionError, SoftforkReject, TestMempoolAccept,
         TransactionCategory, UploadTarget, ValidateAddress, ValidateAddressError, VerifyChain,
         VerifyMessage, VerifyTxOutProof, WalletCreateFundedPsbt, WalletCreateFundedPsbtError,
-        WalletProcessPsbt, WitnessUtxo,
+        WalletProcessPsbt, WitnessUtxo, ImportMulti, ImportMultiEntry, JsonRpcError,
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -194,7 +194,7 @@
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
 //! | importdescriptors                  | version         | TODO                                   |
-//! | importmulti                        | returns nothing |                                        |
+//! | importmulti                        | version         |                                        |
 //! | importprivkey                      | returns nothing |                                        |
 //! | importprunedfunds                  | returns nothing |                                        |
 //! | importpubkey                       | returns nothing |                                        |
@@ -297,7 +297,7 @@ pub use crate::{
         SignRawTransaction, SignRawTransactionError, SoftforkReject, TestMempoolAccept,
         TransactionCategory, UploadTarget, ValidateAddress, ValidateAddressError, VerifyChain,
         VerifyMessage, VerifyTxOutProof, WalletCreateFundedPsbt, WalletCreateFundedPsbtError,
-        WalletProcessPsbt, WitnessUtxo,
+        WalletProcessPsbt, WitnessUtxo, ImportMulti, ImportMultiEntry, JsonRpcError,
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -195,7 +195,7 @@
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
 //! | importdescriptors                  | version         | TODO                                   |
-//! | importmulti                        | returns nothing |                                        |
+//! | importmulti                        | version         |                                        |
 //! | importprivkey                      | returns nothing |                                        |
 //! | importprunedfunds                  | returns nothing |                                        |
 //! | importpubkey                       | returns nothing |                                        |
@@ -301,7 +301,7 @@ pub use crate::{
         SignRawTransaction, SignRawTransactionError, TestMempoolAccept, TransactionCategory,
         UploadTarget, ValidateAddress, ValidateAddressError, VerifyChain, VerifyMessage,
         VerifyTxOutProof, WalletCreateFundedPsbt, WalletCreateFundedPsbtError, WalletProcessPsbt,
-        WitnessUtxo,
+        WitnessUtxo, ImportMulti, ImportMultiEntry, JsonRpcError,
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,

--- a/verify/src/method/v17.rs
+++ b/verify/src/method/v17.rs
@@ -113,7 +113,7 @@ pub const METHODS: &[Method] = &[
     ),
     Method::new_modelled("getwalletinfo", "GetWalletInfo", "get_wallet_info"),
     Method::new_nothing("importaddress", "import_addressss"),
-    Method::new_nothing("importmulti", "import_multi"),
+    Method::new_no_model("importmulti", "ImportMulti", "import_multi"),
     Method::new_nothing("importprivkey", "import_priv_key"),
     Method::new_nothing("importprunedfunds", "import_pruned_funds"),
     Method::new_nothing("importpubkey", "import_pubkey"),

--- a/verify/src/method/v18.rs
+++ b/verify/src/method/v18.rs
@@ -117,7 +117,7 @@ pub const METHODS: &[Method] = &[
     ),
     Method::new_modelled("getwalletinfo", "GetWalletInfo", "get_wallet_info"),
     Method::new_nothing("importaddress", "import_addressss"),
-    Method::new_nothing("importmulti", "import_multi"),
+    Method::new_no_model("importmulti", "ImportMulti", "import_multi"),
     Method::new_nothing("importprivkey", "import_priv_key"),
     Method::new_nothing("importprunedfunds", "import_pruned_funds"),
     Method::new_nothing("importpubkey", "import_pubkey"),

--- a/verify/src/method/v19.rs
+++ b/verify/src/method/v19.rs
@@ -118,7 +118,7 @@ pub const METHODS: &[Method] = &[
     ),
     Method::new_modelled("getwalletinfo", "GetWalletInfo", "get_wallet_info"),
     Method::new_nothing("importaddress", "import_addressss"),
-    Method::new_nothing("importmulti", "import_multi"),
+    Method::new_no_model("importmulti", "ImportMulti", "import_multi"),
     Method::new_nothing("importprivkey", "import_priv_key"),
     Method::new_nothing("importprunedfunds", "import_pruned_funds"),
     Method::new_nothing("importpubkey", "import_pubkey"),

--- a/verify/src/method/v20.rs
+++ b/verify/src/method/v20.rs
@@ -119,7 +119,7 @@ pub const METHODS: &[Method] = &[
     ),
     Method::new_modelled("getwalletinfo", "GetWalletInfo", "get_wallet_info"),
     Method::new_nothing("importaddress", "import_addressss"),
-    Method::new_nothing("importmulti", "import_multi"),
+    Method::new_no_model("importmulti", "ImportMulti", "import_multi"),
     Method::new_nothing("importprivkey", "import_priv_key"),
     Method::new_nothing("importprunedfunds", "import_pruned_funds"),
     Method::new_nothing("importpubkey", "import_pubkey"),

--- a/verify/src/method/v21.rs
+++ b/verify/src/method/v21.rs
@@ -122,7 +122,7 @@ pub const METHODS: &[Method] = &[
     Method::new_modelled("getwalletinfo", "GetWalletInfo", "get_wallet_info"),
     Method::new_nothing("importaddress", "import_address"),
     Method::new_no_model("importdescriptors", "ImportDescriptors", "import_descriptors"),
-    Method::new_nothing("importmulti", "import_multi"),
+    Method::new_no_model("importmulti", "ImportMulti", "import_multi"),
     Method::new_nothing("importprivkey", "import_priv_key"),
     Method::new_nothing("importprunedfunds", "import_pruned_funds"),
     Method::new_nothing("importpubkey", "import_pubkey"),

--- a/verify/src/method/v22.rs
+++ b/verify/src/method/v22.rs
@@ -124,7 +124,7 @@ pub const METHODS: &[Method] = &[
     Method::new_modelled("getwalletinfo", "GetWalletInfo", "get_wallet_info"),
     Method::new_nothing("importaddress", "import_address"),
     Method::new_no_model("importdescriptors", "ImportDescriptors", "import_descriptors"),
-    Method::new_nothing("importmulti", "import_multi"),
+    Method::new_no_model("importmulti", "ImportMulti", "import_multi"),
     Method::new_nothing("importprivkey", "import_priv_key"),
     Method::new_nothing("importprunedfunds", "import_pruned_funds"),
     Method::new_nothing("importpubkey", "import_pubkey"),

--- a/verify/src/method/v23.rs
+++ b/verify/src/method/v23.rs
@@ -120,7 +120,7 @@ pub const METHODS: &[Method] = &[
     Method::new_modelled("getwalletinfo", "GetWalletInfo", "get_wallet_info"),
     Method::new_nothing("importaddress", "import_address"),
     Method::new_no_model("importdescriptors", "ImportDescriptors", "import_descriptors"),
-    Method::new_nothing("importmulti", "import_multi"),
+    Method::new_no_model("importmulti", "ImportMulti", "import_multi"),
     Method::new_nothing("importprivkey", "import_priv_key"),
     Method::new_nothing("importprunedfunds", "import_pruned_funds"),
     Method::new_nothing("importpubkey", "import_pubkey"),

--- a/verify/src/method/v24.rs
+++ b/verify/src/method/v24.rs
@@ -121,7 +121,7 @@ pub const METHODS: &[Method] = &[
     Method::new_modelled("getwalletinfo", "GetWalletInfo", "get_wallet_info"),
     Method::new_nothing("importaddress", "import_address"),
     Method::new_no_model("importdescriptors", "ImportDescriptors", "import_descriptors"),
-    Method::new_nothing("importmulti", "import_multi"),
+    Method::new_no_model("importmulti", "ImportMulti", "import_multi"),
     Method::new_nothing("importprivkey", "import_priv_key"),
     Method::new_nothing("importprunedfunds", "import_pruned_funds"),
     Method::new_nothing("importpubkey", "import_pubkey"),

--- a/verify/src/method/v25.rs
+++ b/verify/src/method/v25.rs
@@ -122,7 +122,7 @@ pub const METHODS: &[Method] = &[
     Method::new_modelled("getwalletinfo", "GetWalletInfo", "get_wallet_info"),
     Method::new_nothing("importaddress", "import_address"),
     Method::new_no_model("importdescriptors", "ImportDescriptors", "import_descriptors"),
-    Method::new_nothing("importmulti", "import_multi"),
+    Method::new_no_model("importmulti", "ImportMulti", "import_multi"),
     Method::new_nothing("importprivkey", "import_priv_key"),
     Method::new_nothing("importprunedfunds", "import_pruned_funds"),
     Method::new_nothing("importpubkey", "import_pubkey"),

--- a/verify/src/method/v26.rs
+++ b/verify/src/method/v26.rs
@@ -129,7 +129,7 @@ pub const METHODS: &[Method] = &[
     Method::new_modelled("getwalletinfo", "GetWalletInfo", "get_wallet_info"),
     Method::new_nothing("importaddress", "import_address"),
     Method::new_no_model("importdescriptors", "ImportDescriptors", "import_descriptors"),
-    Method::new_nothing("importmulti", "import_multi"),
+    Method::new_no_model("importmulti", "ImportMulti", "import_multi"),
     Method::new_nothing("importprivkey", "import_priv_key"),
     Method::new_nothing("importprunedfunds", "import_pruned_funds"),
     Method::new_nothing("importpubkey", "import_pubkey"),

--- a/verify/src/method/v27.rs
+++ b/verify/src/method/v27.rs
@@ -132,7 +132,7 @@ pub const METHODS: &[Method] = &[
     Method::new_modelled("getwalletinfo", "GetWalletInfo", "get_wallet_info"),
     Method::new_nothing("importaddress", "import_address"),
     Method::new_no_model("importdescriptors", "ImportDescriptors", "import_descriptors"),
-    Method::new_nothing("importmulti", "import_multi"),
+    Method::new_no_model("importmulti", "ImportMulti", "import_multi"),
     Method::new_nothing("importprivkey", "import_priv_key"),
     Method::new_nothing("importprunedfunds", "import_pruned_funds"),
     Method::new_nothing("importpubkey", "import_pubkey"),

--- a/verify/src/method/v28.rs
+++ b/verify/src/method/v28.rs
@@ -134,7 +134,7 @@ pub const METHODS: &[Method] = &[
     Method::new_modelled("getwalletinfo", "GetWalletInfo", "get_wallet_info"),
     Method::new_nothing("importaddress", "import_address"),
     Method::new_no_model("importdescriptors", "ImportDescriptors", "import_descriptors"),
-    Method::new_nothing("importmulti", "import_multi"),
+    Method::new_no_model("importmulti", "ImportMulti", "import_multi"),
     Method::new_nothing("importprivkey", "import_priv_key"),
     Method::new_nothing("importprunedfunds", "import_pruned_funds"),
     Method::new_nothing("importpubkey", "import_pubkey"),

--- a/verify/src/method/v29.rs
+++ b/verify/src/method/v29.rs
@@ -135,7 +135,7 @@ pub const METHODS: &[Method] = &[
     Method::new_modelled("getwalletinfo", "GetWalletInfo", "get_wallet_info"),
     Method::new_nothing("importaddress", "import_address"),
     Method::new_no_model("importdescriptors", "ImportDescriptors", "import_descriptors"),
-    Method::new_nothing("importmulti", "import_multi"),
+    Method::new_no_model("importmulti", "ImportMulti", "import_multi"),
     Method::new_nothing("importprivkey", "import_priv_key"),
     Method::new_nothing("importprunedfunds", "import_pruned_funds"),
     Method::new_nothing("importpubkey", "import_pubkey"),


### PR DESCRIPTION
The JSON-RPC method `importmulti` does return a type. We want to test this to catch any changes in behavior in future Core versions.

This PR adds a client function that errors if the return value is anything other than the type it returns, along with an integration test that calls this function.

Ref: [#116](https://github.com/rust-bitcoin/corepc/pull/116)