### PR TITLE
Fix clippy lints in `verify`

### DIFF
--- a/verify/src/main.rs
+++ b/verify/src/main.rs
@@ -135,15 +135,11 @@ fn verify_status(version: Version, test_output: Option<&String>) -> Result<()> {
                 let out =
                     Method::from_name(version, &method.name).expect("guaranteed by methods_and_status()");
 
-                if !versioned::requires_type(version, &method.name)? {
-                    if versioned::type_exists(version, &method.name)? {
+                if !versioned::requires_type(version, &method.name)? && versioned::type_exists(version, &method.name)? {
                         eprintln!("return type found but method is omitted or TODO: {}", output_method(out));
-                    }
                 }
-                if !model::requires_type(version, &method.name)? {
-                    if model::type_exists(version, &method.name)? {
+                if !model::requires_type(version, &method.name)? && model::type_exists(version, &method.name)? {
                         eprintln!("model type found but method is omitted or TODO: {}", output_method(out));
-                    }
                 }
 
             }
@@ -156,19 +152,15 @@ fn verify_status(version: Version, test_output: Option<&String>) -> Result<()> {
 fn check_types_exist_if_required(version: Version, method_name: &str) -> Result<()> {
     let out = Method::from_name(version, method_name).expect("guaranteed by methods_and_status()");
 
-    if versioned::requires_type(version, method_name)? {
-        if !versioned::type_exists(version, method_name)? {
+    if versioned::requires_type(version, method_name)? && !versioned::type_exists(version, method_name)? {
             eprintln!("missing return type: {}", output_method(out));
         }
-    }
-    if model::requires_type(version, method_name)? {
-        if !model::type_exists(version, method_name)? {
+    if model::requires_type(version, method_name)? && !model::type_exists(version, method_name)? {
             eprintln!("missing model type: {}", output_method(out));
         }
-    } else {
-        if model::type_exists(version, method_name)? {
+     else if model::type_exists(version, method_name)? {
             eprintln!("found model type when none expected: {}", output_method(out));
-        }
+        
     }
     Ok(())
 }

--- a/verify/src/versioned.rs
+++ b/verify/src/versioned.rs
@@ -75,10 +75,7 @@ pub fn requires_type(version: Version, method_name: &str) -> Result<bool> {
             ))),
     };
 
-    let requires = match method.ret {
-        Some(Return::Type(_)) => true,
-        _ => false,
-    };
+    let requires = matches!(method.ret, Some(Return::Type(_)));
     Ok(requires)
 }
 


### PR DESCRIPTION
This PR fixes all Clippy lints in the `verify` crate by applying idiomatic Rust improvements and minor cleanups. 