### PR TITLE
Lint non-workspace crates in CI

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -24,6 +24,6 @@ Run from `rust.yml` unless stated otherwise. Total 11 jobs.
 10. `Format`
 11. `Verify`
 
-+15 jobs - 1 for each supported version of Core.
++16 jobs - 1 for each supported version of Core.
 
 

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -119,7 +119,10 @@ jobs:
       - name: "Set dependencies"
         run: cp Cargo-${{ matrix.dep }}.lock Cargo.lock
       - name: "Run test script"
-        run: ./maintainer-tools/ci/run_task.sh lint
+        run: |
+          ./maintainer-tools/ci/run_task.sh lint
+          ./contrib/lint-integtation-tests.sh
+          ./contrib/lint-verify.sh
 
   Docs:
     name: Docs - stable toolchain

--- a/contrib/lint-verify.sh
+++ b/contrib/lint-verify.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# The `verify` crate is not part of the workspace because it is a dev tool.
+
+set -euox pipefail
+
+REPO_DIR=$(git rev-parse --show-toplevel)
+
+cargo +"$(cat ./nightly-version)" clippy \
+      --manifest-path "$REPO_DIR/verify/Cargo.toml" \
+      --config ./rustfmt.toml \
+      --all-targets --all-features \
+      -- --deny warnings
+

--- a/justfile
+++ b/justfile
@@ -3,6 +3,9 @@ set export
 REPO_DIR := `git rev-parse --show-toplevel`
 
 alias ulf := update-lock-files
+alias l := lint
+alias li := lint-integration-tests
+alias lv := lint-verify
 
 default:
   @just --list
@@ -16,8 +19,14 @@ check:
   cargo check --workspace --all-targets --all-features
 
 # Lint everything.
-lint:
+lint: lint-verify lint-integration-tests
   cargo +$(cat ./nightly-version) clippy --workspace --all-targets --all-features -- --deny warnings
+
+lint-verify:
+  $REPO_DIR/contrib/lint-verify.sh
+
+lint-integration-tests:
+  $REPO_DIR/contrib/lint-integtation-tests.sh
 
 # Run cargo fmt
 fmt:

--- a/verify/src/main.rs
+++ b/verify/src/main.rs
@@ -135,17 +135,13 @@ fn verify_status(version: Version, test_output: Option<&String>) -> Result<()> {
                 let out =
                     Method::from_name(version, &method.name).expect("guaranteed by methods_and_status()");
 
-                if !versioned::requires_type(version, &method.name)? {
-                    if versioned::type_exists(version, &method.name)? {
-                        eprintln!("return type found but method is omitted or TODO: {}", output_method(out));
-                    }
-                }
-                if !model::requires_type(version, &method.name)? {
-                    if model::type_exists(version, &method.name)? {
-                        eprintln!("model type found but method is omitted or TODO: {}", output_method(out));
-                    }
+                if versioned::type_exists(version, &method.name)? && !versioned::requires_type(version, &method.name)? {
+                    eprintln!("return type found but method is omitted or TODO: {}", output_method(out));
                 }
 
+                if model::type_exists(version, &method.name)?  && !model::requires_type(version, &method.name)? {
+                    eprintln!("model type found but method is omitted or TODO: {}", output_method(out));
+                }
             }
         }
     }
@@ -156,19 +152,14 @@ fn verify_status(version: Version, test_output: Option<&String>) -> Result<()> {
 fn check_types_exist_if_required(version: Version, method_name: &str) -> Result<()> {
     let out = Method::from_name(version, method_name).expect("guaranteed by methods_and_status()");
 
-    if versioned::requires_type(version, method_name)? {
-        if !versioned::type_exists(version, method_name)? {
-            eprintln!("missing return type: {}", output_method(out));
-        }
+    if versioned::requires_type(version, method_name)? && !versioned::type_exists(version, method_name)? {
+        eprintln!("missing return type: {}", output_method(out));
     }
-    if model::requires_type(version, method_name)? {
-        if !model::type_exists(version, method_name)? {
-            eprintln!("missing model type: {}", output_method(out));
-        }
-    } else {
-        if model::type_exists(version, method_name)? {
-            eprintln!("found model type when none expected: {}", output_method(out));
-        }
+    if model::requires_type(version, method_name)? && !model::type_exists(version, method_name)? {
+        eprintln!("missing model type: {}", output_method(out));
+    }
+    if model::type_exists(version, method_name)? && !model::requires_type(version, method_name)? {
+        eprintln!("found model type when none expected: {}", output_method(out));
     }
     Ok(())
 }

--- a/verify/src/versioned.rs
+++ b/verify/src/versioned.rs
@@ -75,11 +75,7 @@ pub fn requires_type(version: Version, method_name: &str) -> Result<bool> {
             ))),
     };
 
-    let requires = match method.ret {
-        Some(Return::Type(_)) => true,
-        _ => false,
-    };
-    Ok(requires)
+    Ok(matches!(method.ret, Some(Return::Type(_))))
 }
 
 /// Checks that a type exists in version specific module.


### PR DESCRIPTION
Do a bunch of preparation and then add commands to the already present lint job in CI to lint `verify` and `integration_tests`.

Close: #236