### PR TITLE
Implement importpubkey method and test

### DIFF
--- a/client/src/client_sync/v17/mod.rs
+++ b/client/src/client_sync/v17/mod.rs
@@ -130,6 +130,7 @@ crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
+crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v17__list_lock_unspent!();

--- a/client/src/client_sync/v17/wallet.rs
+++ b/client/src/client_sync/v17/wallet.rs
@@ -337,6 +337,22 @@ macro_rules! impl_client_v17__import_pruned_funds {
     };
 }
 
+/// Implements Bitcoin Core JSON-RPC API method `importpubkey`.
+#[macro_export]
+macro_rules! impl_client_v17__import_pubkey {
+    () => {
+        impl Client {
+            pub fn import_pubkey(&self, pubkey: &bitcoin::PublicKey) -> Result<()> {
+                match self.call("importpubkey", &[into_json(pubkey)?]) {
+                    Ok(serde_json::Value::Null) => Ok(()),
+                    Ok(res) => Err(Error::Returned(res.to_string())),
+                    Err(err) => Err(err.into()),
+                }
+            }
+        }
+    };
+}
+
 /// Implements Bitcoin Core JSON-RPC API method `listaddressgroupings`.
 #[macro_export]
 macro_rules! impl_client_v17__list_address_groupings {

--- a/client/src/client_sync/v18/mod.rs
+++ b/client/src/client_sync/v18/mod.rs
@@ -145,6 +145,7 @@ crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
+crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v17__list_lock_unspent!();

--- a/client/src/client_sync/v19/mod.rs
+++ b/client/src/client_sync/v19/mod.rs
@@ -141,6 +141,7 @@ crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
+crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();
 crate::impl_client_v17__list_labels!();

--- a/client/src/client_sync/v20/mod.rs
+++ b/client/src/client_sync/v20/mod.rs
@@ -138,6 +138,7 @@ crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
+crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v18__list_received_by_label!();

--- a/client/src/client_sync/v21/mod.rs
+++ b/client/src/client_sync/v21/mod.rs
@@ -140,6 +140,7 @@ crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
+crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v18__list_received_by_label!();

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -140,6 +140,7 @@ crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
+crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();
 crate::impl_client_v17__list_labels!();

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -142,6 +142,7 @@ crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
+crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();
 crate::impl_client_v17__list_labels!();

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -139,6 +139,7 @@ crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
+crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();
 crate::impl_client_v17__list_labels!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -139,6 +139,7 @@ crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
+crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();
 crate::impl_client_v17__list_labels!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -145,6 +145,7 @@ crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
+crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v18__list_received_by_label!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -141,6 +141,7 @@ crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
+crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();
 crate::impl_client_v17__list_labels!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -143,6 +143,7 @@ crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
+crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();
 crate::impl_client_v17__list_labels!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -143,6 +143,7 @@ crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
+crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();
 crate::impl_client_v17__list_labels!();

--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -6,7 +6,7 @@
 
 #[cfg(feature = "TODO")]
 use bitcoin::address::{Address, NetworkChecked};
-use bitcoin::{Amount, PrivateKey};
+use bitcoin::{Amount, PrivateKey, PublicKey};
 use integration_test::{Node, NodeExt as _, Wallet};
 use node::{mtype,AddressType};
 use node::vtype::*;             // All the version specific types.
@@ -360,6 +360,26 @@ fn wallet__import_privkey() {
         PrivateKey::from_wif("cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy").unwrap();
 
     let _: () = node.client.import_privkey(&privkey).expect("importprivkey");
+}
+
+#[test]
+fn wallet__import_pubkey() {
+    let node = match () {
+        #[cfg(feature = "v22_and_below")]
+        () => Node::with_wallet(Wallet::Default, &[]),
+        #[cfg(not(feature = "v22_and_below"))]
+        () => {
+            let node = Node::with_wallet(Wallet::None, &["-deprecatedrpc=create_bdb"]);
+            node.client.create_legacy_wallet("wallet_name").expect("createlegacywallet");
+            node
+        }
+    };
+
+    let pubkey = "02ff12471208c14bd580709cb2358d98975247d8765f92bc25eab3b2763ed605f8"
+        .parse::<PublicKey>()
+        .unwrap();
+
+    let _: () = node.client.import_pubkey(&pubkey).expect("importpubkey");
 }
 
 #[test]


### PR DESCRIPTION
The JSON-RPC method `importpubkey` does not return anything. We want to test this to catch any changes in behavior in future Core versions.

This PR adds a client function that errors if the return value is anything other than `null`, along with an integration test that calls this function.

Ref: [#116](https://github.com/rust-bitcoin/corepc/pull/116)