### PR TITLE
Ensure missing return fields from types structs are tested for

### DIFF
--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -180,6 +180,7 @@ pub fn compact_size_decode(slice: &mut &[u8]) -> u64 {
 /// backwards compatible so we only provide it not a v0.17 specific type. The `mtype::ScriptPubkey`
 /// mirrors this design (but with concrete `rust-bitcoin` types).
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ScriptPubkey {
     /// Script assembly.
     pub asm: String,
@@ -218,6 +219,7 @@ impl ScriptPubkey {
 
 /// Data returned by Core for a script signature.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ScriptSig {
     /// Assembly representation of the script.
     pub asm: String,

--- a/types/src/model/blockchain.rs
+++ b/types/src/model/blockchain.rs
@@ -18,14 +18,17 @@ use crate::ScriptPubkey;
 
 /// Models the result of JSON-RPC method `getbestblockhash`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBestBlockHash(pub BlockHash);
 
 /// Models the result of JSON-RPC method `getblock` with verbosity set to 0.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBlockVerboseZero(pub Block);
 
 /// Models the result of JSON-RPC method `getblock` with verbosity set to 1.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBlockVerboseOne {
     /// The block hash (same as provided) in RPC call.
     pub hash: BlockHash,
@@ -69,6 +72,7 @@ pub struct GetBlockVerboseOne {
 
 /// Models the result of JSON-RPC method `getblockchaininfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBlockchainInfo {
     /// Current network name as defined in BIP70 (main, test, signet, regtest).
     pub chain: Network,
@@ -114,6 +118,7 @@ pub struct GetBlockchainInfo {
 
 /// Status of softfork.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Softfork {
     /// The [`SoftforkType`]: one of "buried", "bip9".
     #[serde(rename = "type")]
@@ -142,6 +147,7 @@ pub enum SoftforkType {
 
 /// Status of BIP-9 softforks.
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Bip9SoftforkInfo {
     /// One of "defined", "started", "locked_in", "active", "failed".
     pub status: Bip9SoftforkStatus,
@@ -176,6 +182,7 @@ pub enum Bip9SoftforkStatus {
 
 /// Statistics for a BIP-9 softfork.
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Bip9SoftforkStatistics {
     /// The length in blocks of the BIP9 signalling period.
     pub period: u32,
@@ -191,10 +198,12 @@ pub struct Bip9SoftforkStatistics {
 
 /// Models the result of JSON-RPC method `getblockcount`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBlockCount(pub u64);
 
 /// Models the result of JSON-RPC method `getblockfilter`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBlockFilter {
     /// The filter data.
     pub filter: Vec<u8>,
@@ -204,14 +213,17 @@ pub struct GetBlockFilter {
 
 /// Models the result of JSON-RPC method `getblockhash`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBlockHash(pub BlockHash);
 
 /// Models the result of JSON-RPC method `getblockheader`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBlockHeader(pub block::Header);
 
 /// Models the result of JSON-RPC method `getblockheader`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBlockHeaderVerbose {
     /// the block hash (same as provided).
     pub hash: BlockHash,
@@ -247,6 +259,7 @@ pub struct GetBlockHeaderVerbose {
 
 /// Models the result of JSON-RPC method `getblockstats`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBlockStats {
     /// Average fee in the block.
     pub average_fee: Amount,
@@ -316,10 +329,12 @@ pub struct GetBlockStats {
 
 /// Models the result of JSON-RPC method `getchaintips`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetChainTips(pub Vec<ChainTips>);
 
 /// An individual list item from the result of JSON-RPC method `getchaintips`.
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ChainTips {
     /// Height of the chain tip.
     pub height: u32,
@@ -349,6 +364,7 @@ pub enum ChainTipsStatus {
 
 /// Models the result of JSON-RPC method `getchaintxstats`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetChainTxStats {
     /// The timestamp for the final block in the window in UNIX format.
     pub time: u32,
@@ -370,30 +386,37 @@ pub struct GetChainTxStats {
 
 /// Models the result of JSON-RPC method `getdifficulty`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetDifficulty(pub f64);
 
 /// Models the result of JSON-RPC method `getmempoolancestors` with verbose set to false.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetMempoolAncestors(pub Vec<Txid>);
 
 /// Models the result of JSON-RPC method `getmempoolancestors` with verbose set to true.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetMempoolAncestorsVerbose(pub BTreeMap<Txid, MempoolEntry>);
 
 /// Models the result of JSON-RPC method `getmempoolancestors` with verbose set to false.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetMempoolDescendants(pub Vec<Txid>);
 
 /// Models the result of JSON-RPC method `getmempooldescendants` with verbose set to true.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetMempoolDescendantsVerbose(pub BTreeMap<Txid, MempoolEntry>);
 
 /// Models the result of JSON-RPC method `getmempoolentry`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetMempoolEntry(pub MempoolEntry);
 
 /// A relative (ancestor or descendant) transaction of a transaction in the mempool.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct MempoolEntry {
     /// Virtual transaction size as defined in BIP 141. v0.19 and later only.
     ///
@@ -436,6 +459,7 @@ pub struct MempoolEntry {
 
 /// (No docs in Core v0.17.)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct MempoolEntryFees {
     /// Transaction fee in BTC.
     pub base: Amount,
@@ -449,6 +473,7 @@ pub struct MempoolEntryFees {
 
 /// Models the result of JSON-RPC method `getmempoolinfo` with verbose set to true.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetMempoolInfo {
     /// True if the mempool is fully loaded. v0.19 and later only.
     pub loaded: Option<bool>,
@@ -482,14 +507,17 @@ pub struct GetMempoolInfo {
 
 /// Models the result of JSON-RPC method `getrawmempool` with verbose set to false.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetRawMempool(pub Vec<Txid>);
 
 /// Models the result of JSON-RPC method `getrawmempool` with verbose set to true.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetRawMempoolVerbose(pub BTreeMap<Txid, MempoolEntry>);
 
 /// Models the result of JSON-RPC method `gettxout`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetTxOut {
     /// The hash of the block at the tip of the chain.
     pub best_block: BlockHash,
@@ -507,6 +535,7 @@ pub struct GetTxOut {
 
 /// Models the result of JSON-RPC method `gettxoutsetinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetTxOutSetInfo {
     /// The current block height (index).
     pub height: u32,
@@ -533,10 +562,12 @@ pub struct GetTxOutSetInfo {
 
 /// Models the result of JSON-RPC method `verifytxoutproof`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct VerifyTxOutProof(pub Vec<Txid>);
 
 /// Models the result of the JSON-RPC method `getdescriptoractivity`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetDescriptorActivity {
     /// A list of activity events related to the descriptors.
     pub activity: Vec<ActivityEntry>,
@@ -553,6 +584,7 @@ pub enum ActivityEntry {
 
 /// Models a 'spend' activity event with strongly typed fields.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SpendActivity {
     /// The total amount of the spent output.
     pub amount: Amount,
@@ -574,6 +606,7 @@ pub struct SpendActivity {
 
 /// Models a 'receive' activity event with strongly typed fields.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ReceiveActivity {
     /// The total amount in BTC of the new output, converted to `bitcoin::Amount`.
     pub amount: Amount,

--- a/types/src/model/generating.rs
+++ b/types/src/model/generating.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 
 /// Models the result of JSON-RPC method `generate`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Generate(pub Vec<BlockHash>);
 
 impl Generate {
@@ -22,6 +23,7 @@ impl Generate {
 
 /// Models the result of JSON-RPC method `generatetoaddress`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GenerateToAddress(pub Vec<BlockHash>);
 
 impl GenerateToAddress {

--- a/types/src/model/mining.rs
+++ b/types/src/model/mining.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 
 /// Models the result of JSON-RPC method `getblocktemplate`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBlockTemplate {
     /// The preferred block version.
     pub version: block::Version,
@@ -73,6 +74,7 @@ pub struct GetBlockTemplate {
 ///
 /// Returned as part of `getblocktemplate`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct BlockTemplateTransaction {
     /// The transaction.
     pub data: Transaction,
@@ -99,6 +101,7 @@ pub struct BlockTemplateTransaction {
 
 /// Models the result of JSON-RPC method `getmininginfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetMiningInfo {
     /// The current block.
     pub blocks: u64,
@@ -131,6 +134,7 @@ pub struct GetMiningInfo {
 
 /// Represents the `next` block information within the GetMiningInfo result.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct NextBlockInfo {
     /// The next height.
     pub height: u64,
@@ -144,9 +148,11 @@ pub struct NextBlockInfo {
 
 /// Models the result of JSON-RPC method `getprioritisedtransactions`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetPrioritisedTransactions(pub BTreeMap<Txid, PrioritisedTransaction>);
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct PrioritisedTransaction {
     /// Transaction fee delta in satoshis.
     pub fee_delta: i64,

--- a/types/src/model/network.rs
+++ b/types/src/model/network.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 
 /// Models the result of JSON-RPC method `getnetworkinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetNetworkInfo {
     /// The server version.
     pub version: usize,
@@ -48,6 +49,7 @@ pub struct GetNetworkInfo {
 
 /// Part of the result of the JSON-RPC method `getnetworkinfo` (information per network).
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetNetworkInfoNetwork {
     /// Network (ipv4, ipv6, onion, i2p, cjdns).
     pub name: String,
@@ -63,6 +65,7 @@ pub struct GetNetworkInfoNetwork {
 
 /// Part of the result of the JSON-RPC method `getnetworkinfo` (local address info).
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetNetworkInfoAddress {
     /// Network address.
     pub address: String,
@@ -78,10 +81,12 @@ pub struct GetNetworkInfoAddress {
 /// >
 /// > Return known addresses which can potentially be used to find new nodes in the network.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetNodeAddresses(pub Vec<NodeAddress>);
 
 /// An item from the list returned by the JSON-RPC method `getnodeaddresses`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct NodeAddress {
     /// Timestamp in seconds since epoch (Jan 1 1970 GMT) when the node was last seen.
     pub time: u64,

--- a/types/src/model/raw_transactions.rs
+++ b/types/src/model/raw_transactions.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 
 /// Models the result of JSON-RPC method `analyzepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct AnalyzePsbt {
     /// Array of input objects.
     pub inputs: Vec<AnalyzePsbtInput>,
@@ -31,6 +32,7 @@ pub struct AnalyzePsbt {
 
 /// Represents an input in a PSBT operation.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct AnalyzePsbtInput {
     /// Whether a UTXO is provided.
     pub has_utxo: bool,
@@ -44,6 +46,7 @@ pub struct AnalyzePsbtInput {
 
 /// Represents missing elements required to complete an input.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct AnalyzePsbtInputMissing {
     /// Public key IDs of public keys whose BIP 32 derivation paths are missing.
     pub pubkeys: Vec<hash160::Hash>,
@@ -57,26 +60,32 @@ pub struct AnalyzePsbtInputMissing {
 
 /// Models the result of JSON-RPC method `combinepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct CombinePsbt(pub Psbt);
 
 /// Models the result of JSON-RPC method `combinerawtransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct CombineRawTransaction(pub Transaction);
 
 /// Models the result of JSON-RPC method `converttopsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ConvertToPsbt(pub Psbt);
 
 /// Models the result of JSON-RPC method `createpsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct CreatePsbt(pub Psbt);
 
 /// Models the result of JSON-RPC method `createrawtransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct CreateRawTransaction(pub Transaction);
 
 /// Models the result of JSON-RPC method `decodepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct DecodePsbt {
     /// The decoded PSBT.
     pub psbt: Psbt,
@@ -86,10 +95,12 @@ pub struct DecodePsbt {
 
 /// Models the result of JSON-RPC method `decoderawtransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct DecodeRawTransaction(pub Transaction);
 
 /// Models the result of JSON-RPC method `decodescript`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct DecodeScript {
     /// The `scriptPubkey`.
     pub script_pubkey: Option<ScriptBuf>,
@@ -111,6 +122,7 @@ pub struct DecodeScript {
 
 /// Models the result of JSON-RPC method `descriptorprocesspsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct DescriptorProcessPsbt {
     /// The decoded PSBT.
     pub psbt: Psbt,
@@ -122,6 +134,7 @@ pub struct DescriptorProcessPsbt {
 
 /// Models the result of JSON-RPC method `finalizepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct FinalizePsbt {
     /// The partially signed transaction if not extracted.
     pub psbt: Psbt,
@@ -133,6 +146,7 @@ pub struct FinalizePsbt {
 
 /// Models the result of JSON-RPC method `fundrawtransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct FundRawTransaction {
     /// The resulting raw transaction.
     pub tx: Transaction,
@@ -144,11 +158,13 @@ pub struct FundRawTransaction {
 
 /// Models the result of JSON-RPC method `getrawtransaction` with verbose set to `false`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetRawTransaction(pub Transaction);
 
 /// Models the result of JSON-RPC method `getrawtransaction` with verbose set to `true`.
 /// Result of JSON-RPC method `getrawtransaction`
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetRawTransactionVerbose {
     /// Whether specified block is in the active chain or not (only present with explicit "blockhash" argument).
     pub in_active_chain: Option<bool>,
@@ -166,14 +182,17 @@ pub struct GetRawTransactionVerbose {
 
 /// Models the result of JSON-RPC method `joinpsbts`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct JoinPsbts(pub Psbt);
 
 /// Models the result of JSON-RPC method `sendrawtransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SendRawTransaction(pub Txid);
 
 /// Models the result of JSON-RPC method `signrawtransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SignRawTransaction {
     /// The raw transaction with signature(s).
     pub tx: Transaction,
@@ -185,6 +204,7 @@ pub struct SignRawTransaction {
 
 /// Represents a script verification error.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SignFail {
     /// The referenced, previous transaction.
     pub txid: Txid,
@@ -200,6 +220,7 @@ pub struct SignFail {
 
 /// Models the result of JSON-RPC method `submitpackage`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SubmitPackage {
     /// The transaction package result message. "success" indicates all transactions were accepted into or are already in the mempool.
     pub package_msg: String,
@@ -211,6 +232,7 @@ pub struct SubmitPackage {
 
 /// Models the per-transaction result included in the JSON-RPC method `submitpackage`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SubmitPackageTxResult {
     /// The transaction id.
     pub txid: Txid,
@@ -228,6 +250,7 @@ pub struct SubmitPackageTxResult {
 
 /// Models the fees included in the per-transaction result of the JSON-RPC method `submitpackage`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SubmitPackageTxResultFees {
     /// Transaction fee.
     pub base_fee: Amount,
@@ -243,6 +266,7 @@ pub struct SubmitPackageTxResultFees {
 
 /// Models the result of JSON-RPC method `testmempoolaccept`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct TestMempoolAccept {
     /// Test results for each raw transaction in the input array.
     pub results: Vec<MempoolAcceptance>,
@@ -250,6 +274,7 @@ pub struct TestMempoolAccept {
 
 /// Represents a single mempool acceptance test result.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct MempoolAcceptance {
     /// The transaction ID.
     pub txid: Txid,
@@ -261,4 +286,5 @@ pub struct MempoolAcceptance {
 
 /// Models the result of JSON-RPC method `utxoupdatepsbt;`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct UtxoUpdatePsbt(pub Psbt);

--- a/types/src/model/util.rs
+++ b/types/src/model/util.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 
 /// Models the result of JSON-RPC method `createmultisig`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct CreateMultisig {
     /// The value of the new multisig address.
     pub address: Address<NetworkUnchecked>,
@@ -24,6 +25,7 @@ pub struct CreateMultisig {
 
 /// Models the result of JSON-RPC method `estimatesmartfee`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct EstimateSmartFee {
     /// Estimate fee rate in BTC/kB.
     pub fee_rate: Option<FeeRate>,
@@ -40,6 +42,7 @@ pub struct EstimateSmartFee {
 /// > Derives one or more addresses corresponding to an output descriptor.
 /// > Returns an array of derived addresses.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct DeriveAddresses {
     /// The derived addresses.
     pub addresses: Vec<Address<NetworkUnchecked>>,

--- a/types/src/model/wallet.rs
+++ b/types/src/model/wallet.rs
@@ -52,6 +52,7 @@ pub enum Bip125Replaceable {
 
 /// Models the result of JSON-RPC method `addmultisigaddress`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct AddMultisigAddress {
     /// The new multisig address.
     pub address: Address<NetworkUnchecked>,
@@ -61,6 +62,7 @@ pub struct AddMultisigAddress {
 
 /// Models the result of JSON-RPC method `bumpfee`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct BumpFee {
     /// The id of the new transaction.
     pub txid: Txid,
@@ -74,6 +76,7 @@ pub struct BumpFee {
 
 /// Models the result of JSON-RPC method `createwallet`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct CreateWallet {
     /// The wallet name if created successfully.
     ///
@@ -85,14 +88,17 @@ pub struct CreateWallet {
 
 /// Models the result of JSON-RPC method `dumpprivkey`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct DumpPrivKey(pub PrivateKey);
 
 /// Models the result of JSON-RPC method `getaddressesbylabel`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetAddressesByLabel(pub BTreeMap<Address<NetworkUnchecked>, AddressInformation>);
 
 /// Information about address.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct AddressInformation {
     /// Purpose of address.
     pub purpose: AddressPurpose,
@@ -173,6 +179,7 @@ pub enum ScriptType {
 
 /// An address label.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct AddressLabel {
     /// The address label.
     pub name: String,
@@ -223,12 +230,14 @@ pub struct GetAddressInfoEmbedded {
 
 /// Models the result of JSON-RPC method `getbalance`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBalance(pub Amount);
 
 /// Models the result of JSON-RPC method `getbalances`.
 ///
 /// Core version 0.19 onwards.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBalances {
     /// Balances from outputs that the wallet can sign.
     pub mine: GetBalancesMine,
@@ -241,6 +250,7 @@ pub struct GetBalances {
 
 /// Balances from outputs that the wallet can sign.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBalancesMine {
     /// Trusted balance (outputs created by the wallet or confirmed outputs).
     pub trusted: Amount,
@@ -256,6 +266,7 @@ pub struct GetBalancesMine {
 
 /// Hash and height of the block this information was generated on.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBalancesWatchOnly {
     /// Trusted balance (outputs created by the wallet or confirmed outputs).
     pub trusted: Amount,
@@ -267,22 +278,27 @@ pub struct GetBalancesWatchOnly {
 
 /// Models the result of JSON-RPC method `getnewaddress`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetNewAddress(pub Address<NetworkUnchecked>);
 
 /// Models the result of JSON-RPC method `getrawchangeaddress`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetRawChangeAddress(pub Address<NetworkUnchecked>);
 
 /// Models the result of JSON-RPC method `getreceivedbyaddress`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetReceivedByAddress(pub Amount);
 
 /// Models the result of JSON-RPC method `getreceivedbylabel`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetReceivedByLabel(pub Amount);
 
 /// Models the result of JSON-RPC method `gettransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetTransaction {
     /// The transaction amount.
     #[serde(default, with = "bitcoin::amount::serde::as_btc")]
@@ -343,6 +359,7 @@ pub struct GetTransaction {
 
 /// Part of the `GetTransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetTransactionDetail {
     /// Only returns true if imported addresses were involved in transaction. v20 and later only.
     pub involves_watchonly: Option<bool>,
@@ -375,6 +392,7 @@ pub struct GetTransactionDetail {
 
 /// Part of the `GetTransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct LastProcessedBlock {
     /// Hash of the block this information was generated on.
     pub hash: BlockHash,
@@ -384,10 +402,12 @@ pub struct LastProcessedBlock {
 
 /// Models the result of JSON-RPC method `getunconfirmedbalance`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetUnconfirmedBalance(pub Amount);
 
 /// Models the result of JSON-RPC method `getwalletinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetWalletInfo {
     /// The wallet name.
     pub wallet_name: String,
@@ -421,11 +441,13 @@ pub struct GetWalletInfo {
 
 /// Models the result of JSON-RPC method `listaddressgroupings`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListAddressGroupings(pub Vec<Vec<ListAddressGroupingsItem>>);
 
 /// List item type returned as part of `listaddressgroupings`.
 // FIXME: The Core docs seem wrong, not sure what shape this should be?
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListAddressGroupingsItem {
     /// The bitcoin address.
     pub address: Address<NetworkUnchecked>,
@@ -437,14 +459,17 @@ pub struct ListAddressGroupingsItem {
 
 /// Models the result of JSON-RPC method `listlabels`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListLabels(pub Vec<String>);
 
 /// Models the result of JSON-RPC method `listlockunspent`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListLockUnspent(pub Vec<ListLockUnspentItem>);
 
 /// List item returned as part of of `listlockunspent`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListLockUnspentItem {
     /// The transaction id locked.
     pub txid: Txid,
@@ -454,10 +479,12 @@ pub struct ListLockUnspentItem {
 
 /// Models the result of JSON-RPC method `listreceivedbyaddress`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListReceivedByAddress(pub Vec<ListReceivedByAddressItem>);
 
 /// List item returned as part of of `listreceivedbyaddress`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListReceivedByAddressItem {
     /// Only returned if imported addresses were involved in transaction.
     pub involves_watch_only: bool,
@@ -475,10 +502,12 @@ pub struct ListReceivedByAddressItem {
 
 /// Models the result of JSON-RPC method `listreceivedbylabel`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListReceivedByLabel(pub Vec<ListReceivedByLabelItem>);
 
 /// Item returned as part of `listreceivedbylabel`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListReceivedByLabelItem {
     /// Only returned if imported addresses were involved in transaction.
     pub involves_watch_only: Option<bool>,
@@ -492,6 +521,7 @@ pub struct ListReceivedByLabelItem {
 
 /// Models the result of JSON-RPC method `listsinceblock`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListSinceBlock {
     /// All the transactions.
     pub transactions: Vec<ListSinceBlockTransaction>,
@@ -511,6 +541,7 @@ pub struct ListSinceBlock {
 /// Transaction list item, part of `ListSinceBlock`.
 // https://github.com/rust-bitcoin/rust-bitcoin/issues/3516
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListSinceBlockTransaction {
     /// The bitcoin address of the transaction.
     pub address: Option<Address<NetworkUnchecked>>,
@@ -571,10 +602,12 @@ pub struct ListSinceBlockTransaction {
 
 /// Models the result of JSON-RPC method `listtransactions`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListTransactions(pub Vec<ListTransactionsItem>);
 
 /// Transaction list item, part of `ListTransactions`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListTransactionsItem {
     /// The bitcoin address of the transaction.
     pub address: Address<NetworkUnchecked>,
@@ -625,10 +658,12 @@ pub struct ListTransactionsItem {
 
 /// Models the result of JSON-RPC method `listunspent`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListUnspent(pub Vec<ListUnspentItem>);
 
 /// Unspent transaction output, returned as part of `listunspent`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListUnspentItem {
     /// The transaction id.
     pub txid: Txid,
@@ -664,10 +699,12 @@ pub struct ListUnspentItem {
 
 /// Models the result of JSON-RPC method `listwallets`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListWallets(pub Vec<String>);
 
 /// Models the result of JSON-RPC method `loadwallet`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct LoadWallet {
     /// The wallet name if loaded successfully.
     pub name: String,
@@ -677,6 +714,7 @@ pub struct LoadWallet {
 
 /// Models the result of JSON-RPC method `rescanblockchain`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct RescanBlockchain {
     /// The block height where the rescan has started.
     pub start_height: u32,
@@ -686,10 +724,12 @@ pub struct RescanBlockchain {
 
 /// Models the result of JSON-RPC method `sendmany`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SendMany(pub Txid);
 
 /// Models the result of JSON-RPC method `sendtoaddress`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SendToAddress {
     pub txid: Txid,
 }
@@ -702,6 +742,7 @@ pub struct SignMessage(pub sign_message::MessageSignature);
 ///
 /// Core version v0.21 onwards.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct UnloadWallet {
     /// Warning messages, if any, related to unloading the wallet.
     // Changes from single string to vector in Core v25
@@ -709,6 +750,7 @@ pub struct UnloadWallet {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct WalletCreateFundedPsbt {
     /// The resulting PSBT.
     pub psbt: Psbt,
@@ -721,6 +763,7 @@ pub struct WalletCreateFundedPsbt {
 
 /// Models the result of JSON-RPC method `walletprocesspsbt`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct WalletProcessPsbt {
     /// The partially signed transaction.
     pub psbt: Psbt,

--- a/types/src/model/wallet.rs
+++ b/types/src/model/wallet.rs
@@ -509,9 +509,8 @@ pub struct ListSinceBlock {
 }
 
 /// Transaction list item, part of `ListSinceBlock`.
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-
 // https://github.com/rust-bitcoin/rust-bitcoin/issues/3516
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct ListSinceBlockTransaction {
     /// The bitcoin address of the transaction.
     pub address: Option<Address<NetworkUnchecked>>,

--- a/types/src/psbt/mod.rs
+++ b/types/src/psbt/mod.rs
@@ -22,6 +22,7 @@ use crate::{ScriptPubkey, ScriptSig};
 /// Returned as part of `decoderawtransaction` and `decodepsbt`.
 // This JSON data can be encapsulated by a `bitcoin::Transaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct RawTransaction {
     /// The transaction id.
     pub txid: String,
@@ -73,6 +74,7 @@ impl RawTransaction {
 /// Represents a transaction input.
 // This JSON data can be encapsulated by a `bitcoin::TxIn`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct RawTransactionInput {
     /// The transaction id.
     pub txid: String,
@@ -113,6 +115,7 @@ impl RawTransactionInput {
 /// Represents a transaction output.
 // This JSON data can be encapsulated by a `bitcoin::TxOut` + index.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct RawTransactionOutput {
     /// The value in BTC.
     pub value: f64,
@@ -139,6 +142,7 @@ impl RawTransactionOutput {
 /// Transaction output for witness UTXOs.
 // This JSON data can be encapsulated by a `bitcoin::TxOut`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct WitnessUtxo {
     /// The value in BTC.
     pub amount: f64,
@@ -161,6 +165,7 @@ impl WitnessUtxo {
 
 /// A script returned as part of a PSBT input or output.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct PsbtScript {
     /// The asm.
     pub asm: String,
@@ -186,6 +191,7 @@ impl PsbtScript {
 // bip32_derivation: BTreeMap<secp256k1::PublicKey, KeySource>,
 // KeySource = (Fingerprint, DerivationPath);
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Bip32Deriv {
     /// The public key this path corresponds to.
     pub pubkey: String,
@@ -198,6 +204,7 @@ pub struct Bip32Deriv {
 /// The key source data for a BIP-32 derivation.
 // In v0.17 the BIP-32 derivation for inputs is a map of pubkey to this type.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct InputKeySource {
     /// The fingerprint of the master key.
     pub master_fingerprint: String,
@@ -207,6 +214,7 @@ pub struct InputKeySource {
 
 /// Final script data.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct FinalScript {
     /// The asm.
     pub asm: String,

--- a/types/src/v17/blockchain/mod.rs
+++ b/types/src/v17/blockchain/mod.rs
@@ -23,6 +23,7 @@ use crate::{model, ScriptPubkey};
 /// >
 /// > Returns the hash of the best (tip) block in the most-work fully-validated chain.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBestBlockHash(pub String);
 
 /// Result of JSON-RPC method `getblock` with verbosity set to 0.
@@ -37,6 +38,7 @@ pub struct GetBestBlockHash(pub String);
 /// > 1. "blockhash"          (string, required) The block hash
 /// > 2. verbosity              (numeric, optional, default=1) 0 for hex encoded data, 1 for a json object, and 2 for json object with transaction data
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBlockVerboseZero(
     /// A string that is serialized, hex-encoded data for block 'hash'.
     pub String,
@@ -44,6 +46,7 @@ pub struct GetBlockVerboseZero(
 
 /// Result of JSON-RPC method `getblock` with verbosity set to 1.
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBlockVerboseOne {
     /// The block hash (same as provided) in RPC call.
     pub hash: String,
@@ -99,6 +102,7 @@ pub struct GetBlockVerboseOne {
 /// >
 /// > Returns an object containing various state info regarding blockchain processing.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBlockchainInfo {
     /// Current network name as defined in BIP70 (main, test, signet, regtest).
     pub chain: String,
@@ -144,6 +148,7 @@ pub struct GetBlockchainInfo {
 
 /// Status of softfork.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Softfork {
     /// Name of softfork.
     pub id: String,
@@ -155,6 +160,7 @@ pub struct Softfork {
 
 /// Progress toward rejecting pre-softfork blocks.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SoftforkReject {
     /// `true` if threshold reached.
     pub status: bool,
@@ -162,6 +168,7 @@ pub struct SoftforkReject {
 
 /// Status of BIP-9 softforksin progress.
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Bip9Softfork {
     /// One of "defined", "started", "locked_in", "active", "failed".
     pub status: Bip9SoftforkStatus,
@@ -198,6 +205,7 @@ pub enum Bip9SoftforkStatus {
 /// >
 /// > Returns the number of blocks in the longest blockchain.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBlockCount(pub u64);
 
 /// Result of JSON-RPC method `getblockhash`.
@@ -207,6 +215,7 @@ pub struct GetBlockCount(pub u64);
 /// > Arguments:
 /// > 1. height         (numeric, required) The height index
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBlockHash(pub String);
 
 /// Result of JSON-RPC method `getblockheader` with verbosity set to `false`.
@@ -217,6 +226,7 @@ pub struct GetBlockHash(pub String);
 /// > Arguments:
 /// > 1. "hash"          (string, required) The block hash
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBlockHeader(pub String);
 
 /// Result of JSON-RPC method `getblockheader` with verbosity set to `true`.
@@ -227,6 +237,7 @@ pub struct GetBlockHeader(pub String);
 /// > Arguments:
 /// > 1. "hash"          (string, required) The block hash
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBlockHeaderVerbose {
     /// The block hash (same as provided).
     pub hash: String,
@@ -281,6 +292,7 @@ pub struct GetBlockHeaderVerbose {
 /// > Arguments:
 /// > 1. "hash_or_height"     (string or numeric, required) The block hash or height of the target block
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBlockStats {
     /// Average fee in the block.
     #[serde(rename = "avgfee")]
@@ -369,10 +381,12 @@ pub struct GetBlockStats {
 ///
 /// > Return information about all known tips in the block tree, including the main chain as well as orphaned branches.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetChainTips(pub Vec<ChainTips>);
 
 /// An individual list item from the result of JSON-RPC method `getchaintips`.
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ChainTips {
     /// Height of the chain tip.
     pub height: i64,
@@ -407,6 +421,7 @@ pub enum ChainTipsStatus {
 /// >
 /// > Compute statistics about the total number and rate of transactions in the chain.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetChainTxStats {
     /// The timestamp for the final block in the window in UNIX format.
     pub time: i64,
@@ -435,6 +450,7 @@ pub struct GetChainTxStats {
 /// > Result:
 /// > n.nnn       (numeric) the proof-of-work difficulty as a multiple of the minimum difficulty.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetDifficulty(pub f64);
 
 /// Result of JSON-RPC method `getmempoolancestors` with verbose set to `false`.
@@ -446,12 +462,14 @@ pub struct GetDifficulty(pub f64);
 /// > Arguments:
 /// > 1. "txid"                 (string, required) The transaction id (must be in mempool)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetMempoolAncestors(pub Vec<String>);
 
 /// Result of JSON-RPC method `getmempoolancestors` with verbose set to true.
 ///
 /// Map of txid to [`MempoolEntry`] i.e., an ancestor.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetMempoolAncestorsVerbose(pub BTreeMap<String, MempoolEntry>);
 
 /// Result of JSON-RPC method `getmempooldescendants` with verbose set to `false`.
@@ -463,12 +481,14 @@ pub struct GetMempoolAncestorsVerbose(pub BTreeMap<String, MempoolEntry>);
 /// > Arguments:
 /// > 1. "txid"                 (string, required) The transaction id (must be in mempool)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetMempoolDescendants(pub Vec<String>);
 
 /// Result of JSON-RPC method `getmempooldescendants` with verbose set to true.
 ///
 /// Map of txid to [`MempoolEntry`] i.e., a descendant.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetMempoolDescendantsVerbose(pub BTreeMap<String, MempoolEntry>);
 
 /// Result of JSON-RPC method `getmempoolentry`.
@@ -480,10 +500,12 @@ pub struct GetMempoolDescendantsVerbose(pub BTreeMap<String, MempoolEntry>);
 /// > Arguments:
 /// > 1. "txid"                 (string, required) The transaction id (must be in mempool)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetMempoolEntry(pub MempoolEntry);
 
 /// A relative (ancestor or descendant) transaction of a transaction in the mempool.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct MempoolEntry {
     /// Virtual transaction size as defined in BIP 141.
     ///
@@ -529,6 +551,7 @@ pub struct MempoolEntry {
 
 /// (No docs in Core v0.17.)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct MempoolEntryFees {
     /// Transaction fee in BTC.
     pub base: f64,
@@ -546,6 +569,7 @@ pub struct MempoolEntryFees {
 /// >
 /// > Returns details on the active state of the TX memory pool.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetMempoolInfo {
     /// Current transaction count.
     pub size: i64,
@@ -575,12 +599,14 @@ pub struct GetMempoolInfo {
 /// >
 /// > Hint: use getmempoolentry to fetch a specific transaction from the mempool.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetRawMempool(pub Vec<String>);
 
 /// Result of JSON-RPC method `getmempooldescendants` with verbose set to `true`.
 ///
 /// Map of txid to [`MempoolEntry`].
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetRawMempoolVerbose(pub BTreeMap<String, MempoolEntry>);
 
 /// Result of JSON-RPC method `gettxout`.
@@ -593,6 +619,7 @@ pub struct GetRawMempoolVerbose(pub BTreeMap<String, MempoolEntry>);
 /// > 1. txid               (string, required) The transaction id
 /// > 2. n                  (numeric, required) vout number
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetTxOut {
     /// The hash of the block at the tip of the chain.
     #[serde(rename = "bestblock")]
@@ -615,6 +642,7 @@ pub struct GetTxOut {
 /// > Returns statistics about the unspent transaction output set.
 /// > Note this call may take some time.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetTxOutSetInfo {
     /// The current block height (index).
     pub height: i64,
@@ -645,6 +673,7 @@ pub struct GetTxOutSetInfo {
 /// > 1. "height"       (numeric, required) The block height to prune up to. May be set to a discrete height, or a unix timestamp
 /// >                   to prune blocks whose block time is at least 2 hours older than the provided timestamp.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct PruneBlockchain(
     /// The height of the last block pruned.
     pub i64,
@@ -652,6 +681,7 @@ pub struct PruneBlockchain(
 
 /// Result of JSON-RPC method `verifychain`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct VerifyChain(pub bool);
 
 /// Result of JSON-RPC method `verifytxoutproof`.
@@ -666,4 +696,5 @@ pub struct VerifyChain(pub bool);
 ///
 /// Inner field is the txid(s) which the proof commits to, or empty array if the proof can not be validated.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct VerifyTxOutProof(pub Vec<String>);

--- a/types/src/v17/control.rs
+++ b/types/src/v17/control.rs
@@ -23,10 +23,12 @@ use serde::{Deserialize, Serialize};
 // This just mimics the map returned by my instance of Core `v0.17`, I don't know how
 // to handle other map values or if they exist?
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetMemoryInfoStats(pub BTreeMap<String, Locked>);
 
 /// Information about locked memory manager.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Locked {
     /// Number of bytes used.
     pub used: u64,
@@ -51,6 +53,7 @@ pub struct Locked {
 ///
 /// > Gets and sets the logging configuration.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Logging {
     pub addrman: bool,
     pub bench: bool,

--- a/types/src/v17/generating.rs
+++ b/types/src/v17/generating.rs
@@ -18,6 +18,7 @@ use crate::model;
 /// > Arguments:
 /// > 1. nblocks      (numeric, required) How many blocks are generated immediately.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Generate(
     /// Hashes of blocks generated.
     pub Vec<String>,
@@ -41,6 +42,7 @@ impl Generate {
 /// > 1. nblocks     (numeric, required) How many blocks are generated immediately.
 /// > 2. address     (string, required) The address to send the newly generated bitcoin to.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GenerateToAddress(
     /// Hashes of blocks generated.
     pub Vec<String>,

--- a/types/src/v17/mining/mod.rs
+++ b/types/src/v17/mining/mod.rs
@@ -42,6 +42,7 @@ pub use self::error::{BlockTemplateTransactionError, GetBlockTemplateError};
 /// >        "data": "hex",          (string, optional) proposed block data to check, encoded in hexadecimal; valid only for mode="proposal"
 /// >      }
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBlockTemplate {
     /// The preferred block version.
     pub version: i32,
@@ -114,6 +115,7 @@ pub struct GetBlockTemplate {
 ///
 /// Returned as part of `getblocktemplate`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct BlockTemplateTransaction {
     /// Transaction data encoded in hexadecimal (byte-for-byte).
     pub data: String,
@@ -143,6 +145,7 @@ pub struct BlockTemplateTransaction {
 /// >
 /// > Returns a json object containing mining-related information.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetMiningInfo {
     /// The current block.
     pub blocks: u64,

--- a/types/src/v17/network/mod.rs
+++ b/types/src/v17/network/mod.rs
@@ -24,10 +24,12 @@ pub use self::error::*;
 /// > Arguments:
 /// > 1. "node"   (string, optional) If provided, return information about this specific node, otherwise all nodes are returned.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetAddedNodeInfo(pub Vec<AddedNode>);
 
 /// An item from the list returned by the JSON-RPC method `getaddednodeinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct AddedNode {
     /// The node IP address or name (as provided to addnode).
     #[serde(rename = "addednode")]
@@ -40,6 +42,7 @@ pub struct AddedNode {
 
 /// An address returned as part of the JSON-RPC method `getaddednodeinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct AddedNodeAddress {
     /// The bitcoin server IP and port we're connected to.
     pub address: String,
@@ -53,6 +56,7 @@ pub struct AddedNodeAddress {
 /// >
 /// > Returns n (numeric) The connection count
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetConnectionCount(pub u64);
 
 /// Result of JSON-RPC method `getnettotals`.
@@ -62,6 +66,7 @@ pub struct GetConnectionCount(pub u64);
 /// > Returns information about network traffic, including bytes in, bytes out,
 /// > and current time.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetNetTotals {
     /// Total bytes received.
     #[serde(rename = "totalbytesrecv")]
@@ -79,6 +84,7 @@ pub struct GetNetTotals {
 
 /// The `upload_target` field from the result of JSON-RPC method `getnettotals`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct UploadTarget {
     /// Length of the measuring timeframe in seconds.
     pub timeframe: u64,
@@ -100,6 +106,7 @@ pub struct UploadTarget {
 ///
 /// > Returns an object containing various state info regarding P2P networking.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetNetworkInfo {
     /// The server version.
     pub version: usize,
@@ -139,6 +146,7 @@ pub struct GetNetworkInfo {
 
 /// Part of the result of the JSON-RPC method `getnetworkinfo` (information per network).
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetNetworkInfoNetwork {
     /// Network (ipv4, ipv6, onion, i2p, cjdns).
     pub name: String,
@@ -154,6 +162,7 @@ pub struct GetNetworkInfoNetwork {
 
 /// Part of the result of the JSON-RPC method `getnetworkinfo` (local address info).
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetNetworkInfoAddress {
     /// Network address.
     pub address: String,
@@ -169,10 +178,12 @@ pub struct GetNetworkInfoAddress {
 /// >
 /// > Returns data about each connected network node as a json array of objects.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetPeerInfo(pub Vec<PeerInfo>);
 
 /// An item from the list returned by the JSON-RPC method `getpeerinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct PeerInfo {
     /// Peer index.
     pub id: u32,
@@ -259,10 +270,12 @@ pub struct PeerInfo {
 ///
 /// > List all banned IPs/Subnets.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListBanned(pub Vec<Banned>);
 
 /// An item from the list returned by the JSON-RPC method `listbanned`
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Banned {
     // NOTE: Shape taken from Core source code,as method is undocumented in the Bitcoin RPC CLI for version 17 to 20.
     /// The IP/Subnet of the banned node.
@@ -281,4 +294,5 @@ pub struct Banned {
 /// >
 /// > Disable/enable all p2p network activity.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SetNetworkActive(pub bool);

--- a/types/src/v17/raw_transactions/mod.rs
+++ b/types/src/v17/raw_transactions/mod.rs
@@ -38,6 +38,7 @@ pub use crate::psbt::{
 /// >       ,...
 /// >     ]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct CombinePsbt(
     /// The base64-encoded partially signed transaction.
     pub String,
@@ -57,6 +58,7 @@ pub struct CombinePsbt(
 /// >       ,...
 /// >     ]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct CombineRawTransaction(
     /// The hex-encoded raw transaction with signature(s).
     pub String,
@@ -72,6 +74,7 @@ pub struct CombineRawTransaction(
 /// > Arguments:
 /// > 1. "hexstring"              (string, required) The hex string of a raw transaction
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ConvertToPsbt(
     /// The resulting raw transaction (base64-encoded string).
     pub String,
@@ -91,6 +94,7 @@ pub struct ConvertToPsbt(
 /// >          "txid":"id",      (string, required) The transaction id
 /// >          "vout":n,         (numeric, required) The output number
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct CreatePsbt(
     /// The resulting raw transaction (base64-encoded string).
     pub String,
@@ -113,6 +117,7 @@ pub struct CreatePsbt(
 /// >          "txid":"id",      (string, required) The transaction id
 /// >          "vout":n,         (numeric, required) The output number
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct CreateRawTransaction(
     /// hex string of the transaction.
     pub String,
@@ -127,6 +132,7 @@ pub struct CreateRawTransaction(
 /// > Arguments:
 /// > 1. "psbt"            (string, required) The PSBT base64 string
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct DecodePsbt {
     /// The decoded network-serialized unsigned transaction.
     pub tx: RawTransaction,
@@ -142,6 +148,7 @@ pub struct DecodePsbt {
 
 /// An input in a partially signed Bitcoin transaction.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct PsbtInput {
     /// Decoded network transaction for non-witness UTXOs.
     pub non_witness_utxo: Option<RawTransaction>,
@@ -170,6 +177,7 @@ pub struct PsbtInput {
 
 /// An output in a partially signed Bitcoin transaction.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct PsbtOutput {
     /// The redeem script.
     pub redeem_script: Option<PsbtScript>,
@@ -190,6 +198,7 @@ pub struct PsbtOutput {
 /// > Arguments:
 /// > 1. "hexstring"      (string, required) The transaction hex string
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct DecodeRawTransaction(pub RawTransaction);
 
 /// Result of JSON-RPC method `decodescript`.
@@ -202,6 +211,7 @@ pub struct DecodeRawTransaction(pub RawTransaction);
 /// > 1. "hexstring"     (string) the hex encoded script
 // The docs on Core v0.17 appear to be way off what is actually returned.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct DecodeScript {
     /// Script public key.
     pub asm: String,
@@ -227,6 +237,7 @@ pub struct DecodeScript {
 /// Seemingly undocumented data returned in the `segwit` field of `DecodeScript`.
 // This seems to be the same as `DecodeScript` except the `p2sh` field is called `p2sh-segwit`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct DecodeScriptSegwit {
     /// Script public key.
     pub asm: String,
@@ -256,6 +267,7 @@ pub struct DecodeScriptSegwit {
 /// > Arguments:
 /// > 1. "psbt"                 (string) A base64 string of a PSBT
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct FinalizePsbt {
     /// The base64-encoded partially signed transaction if not extracted.
     pub psbt: String,
@@ -283,6 +295,7 @@ pub struct FinalizePsbt {
 /// > Arguments:
 /// > 1. "hexstring"           (string, required) The hex string of the raw transaction
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct FundRawTransaction {
     /// The resulting raw transaction (hex-encoded string).
     pub hex: String,
@@ -314,6 +327,7 @@ pub struct FundRawTransaction {
 /// > 2. verbose     (bool, optional, default=false) If false, return a string, otherwise return a json object
 /// > 3. "blockhash" (string, optional) The block in which to look for the transaction
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetRawTransaction(
     /// The serialized, hex-encoded data for 'txid'.
     pub String,
@@ -321,6 +335,7 @@ pub struct GetRawTransaction(
 
 /// Result of JSON-RPC method `getrawtransaction` with verbose set to `true`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetRawTransactionVerbose {
     /// Whether specified block is in the active chain or not (only present with explicit "blockhash" argument).
     pub in_active_chain: Option<bool>,
@@ -373,6 +388,7 @@ pub struct GetRawTransactionVerbose {
 /// > 1. hexstring        (string, required) The hex string of the raw transaction
 /// > 2. allowhighfees    (boolean, optional, default=false) Allow high fees
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SendRawTransaction(
     /// The transaction hash in hex.
     pub String,
@@ -392,6 +408,7 @@ pub struct SendRawTransaction(
 /// > Arguments:
 /// > 1. "hexstring"     (string, required) The transaction hex string
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SignRawTransaction {
     /// The hex-encoded raw transaction with signature(s).
     pub hex: String,
@@ -403,6 +420,7 @@ pub struct SignRawTransaction {
 
 /// Represents a script verification error.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SignFail {
     /// The hash of the referenced, previous transaction.
     pub txid: String,
@@ -432,6 +450,7 @@ pub struct SignFail {
 /// >                                         Length must be one for now.
 /// > 2. allowhighfees    (boolean, optional, default=false) Allow high fees
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct TestMempoolAccept {
     /// Array of test results for each raw transaction in the input array.
     ///
@@ -441,6 +460,7 @@ pub struct TestMempoolAccept {
 
 /// Represents a single mempool acceptance test result.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct MempoolAcceptance {
     /// The transaction hash in hex.
     pub txid: String,

--- a/types/src/v17/util/mod.rs
+++ b/types/src/v17/util/mod.rs
@@ -27,6 +27,7 @@ pub use self::error::{CreateMultisigError, ValidateAddressError};
 /// >        ,...
 /// >      ]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct CreateMultisig {
     /// The value of the new multisig address.
     pub address: String,
@@ -56,6 +57,7 @@ pub struct CreateMultisig {
 /// >        "ECONOMICAL"
 /// >        "CONSERVATIVE"
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct EstimateSmartFee {
     /// Estimate fee rate in BTC/kB.
     #[serde(rename = "feerate")]
@@ -76,6 +78,7 @@ pub struct EstimateSmartFee {
 /// > 1. "privkey"         (string, required) The private key to sign the message with.
 /// > 2. "message"         (string, required) The message to create a signature of.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SignMessageWithPrivKey(pub String);
 
 /// Result of JSON-RPC method `validateaddress`.
@@ -91,6 +94,7 @@ pub struct SignMessageWithPrivKey(pub String);
 /// > Arguments:
 /// > 1. "address"                    (string, required) The bitcoin address to validate
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ValidateAddress {
     /// If the address is valid or not. If not, this is the only property returned.
     #[serde(rename = "isvalid")]
@@ -123,4 +127,5 @@ pub struct ValidateAddress {
 /// > 2. "signature"       (string, required) The signature provided by the signer in base 64 encoding (see signmessage).
 /// > 3. "message"         (string, required) The message that was signed.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct VerifyMessage(pub bool);

--- a/types/src/v17/wallet/mod.rs
+++ b/types/src/v17/wallet/mod.rs
@@ -68,6 +68,7 @@ pub enum Bip125Replaceable {
 /// >
 /// > Stops current wallet rescan triggered by an RPC call, e.g. by an importprivkey call.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct AbortRescan(pub bool);
 
 /// Result of the JSON-RPC method `addmultisigaddress`.
@@ -84,6 +85,7 @@ pub struct AbortRescan(pub bool);
 /// > 1. nrequired                      (numeric, required) The number of required signatures out of the n keys or addresses.
 /// > 2. "keys"                         (string, required) A json array of bitcoin addresses or hex-encoded public keys
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct AddMultisigAddress {
     /// The value of the new multisig address.
     pub address: String,
@@ -111,6 +113,7 @@ pub struct AddMultisigAddress {
 /// > Arguments:
 /// > 1. txid                  (string, required) The txid to be bumped
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct BumpFee {
     /// The id of the new transaction.
     pub txid: String,
@@ -132,6 +135,7 @@ pub struct BumpFee {
 /// > Arguments:
 /// > 1. "wallet_name"          (string, required) The name for the new wallet. If this is a path, the wallet will be created at the path location.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct CreateWallet {
     /// The wallet name if created successfully.
     ///
@@ -156,6 +160,7 @@ impl CreateWallet {
 /// > Arguments:
 /// > 1. "address"   (string, required) The bitcoin address for the private key
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct DumpPrivKey(pub String); // The private key.
 
 impl DumpPrivKey {
@@ -175,6 +180,7 @@ impl DumpPrivKey {
 /// > Arguments:
 /// > 1. "filename"    (string, required) The filename with path (either absolute or relative to bitcoind)
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct DumpWallet {
     /// The filename with full absolute path.
     #[serde(rename = "filename")]
@@ -194,6 +200,7 @@ pub struct DumpWallet {
 /// > Arguments:
 /// > 1. passphrase    (string, required) The pass phrase to encrypt the wallet with. It must be at least 1 character, but should be long.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct EncryptWallet(pub String);
 
 /// Result of the JSON-RPC method `getaddressesbylabel`.
@@ -205,10 +212,12 @@ pub struct EncryptWallet(pub String);
 /// > Arguments:
 /// > 1. "label"  (string, required) The label.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetAddressesByLabel(pub BTreeMap<String, AddressInformation>);
 
 /// Returned as part of `getaddressesbylabel`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct AddressInformation {
     /// Purpose of address.
     pub purpose: AddressPurpose,
@@ -224,6 +233,7 @@ pub struct AddressInformation {
 /// > Arguments:
 /// > 1. "address"                    (string, required) The bitcoin address to get the information of.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetAddressInfo {
     /// The bitcoin address validated.
     pub address: String,
@@ -323,6 +333,7 @@ pub enum ScriptType {
 /// ("timestamp", "hdkeypath", "hdseedid") and relation to the wallet ("ismine", "iswatchonly",
 /// "account").
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetAddressInfoEmbedded {
     /// The bitcoin address validated.
     pub address: String,
@@ -363,6 +374,7 @@ pub struct GetAddressInfoEmbedded {
 
 /// The `label` field of `GetAddressInfo` (and `GetAddressInfoEmbedded`).
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetAddressInfoLabel {
     /// The label.
     pub name: String,
@@ -378,6 +390,7 @@ pub struct GetAddressInfoLabel {
 /// > The available balance is what the wallet considers currently spendable, and is
 /// > thus affected by options which limit spendability such as -spendzeroconfchange.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBalance(pub f64);
 
 impl GetBalance {
@@ -396,6 +409,7 @@ impl GetBalance {
 /// > If 'label' is specified, it is added to the address book
 /// > so payments received with the address will be associated with 'label'.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetNewAddress(pub String);
 
 /// Result of the JSON-RPC method `getrawchangeaddress`.
@@ -405,6 +419,7 @@ pub struct GetNewAddress(pub String);
 /// > Returns a new Bitcoin address, for receiving change.
 /// > This is for use with raw transactions, NOT normal use.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetRawChangeAddress(pub String);
 
 /// Result of the JSON-RPC method `getreceivedbyaddress`.
@@ -416,6 +431,7 @@ pub struct GetRawChangeAddress(pub String);
 /// > Arguments:
 /// > 1. "address"         (string, required) The bitcoin address for transactions.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetReceivedByAddress(pub f64); // Amount in BTC.
 
 /// Result of the JSON-RPC method `gettransaction`.
@@ -427,6 +443,7 @@ pub struct GetReceivedByAddress(pub f64); // Amount in BTC.
 /// > Arguments:
 /// > 1. txid                 (string, required) The transaction id
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetTransaction {
     /// The transaction amount in BTC.
     pub amount: f64,
@@ -470,6 +487,7 @@ pub struct GetTransaction {
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetTransactionDetail {
     /// DEPRECATED. The account name involved in the transaction, can be "" for the default account.
     pub account: Option<String>, // Docs are wrong, this is not documented as optional.
@@ -498,6 +516,7 @@ pub struct GetTransactionDetail {
 /// > getunconfirmedbalance
 /// > Returns the server's total unconfirmed balance
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetUnconfirmedBalance(pub f64); // Core docs are missing so this is just a guess.
 
 /// Result of the JSON-RPC method `getwalletinfo`.
@@ -505,6 +524,7 @@ pub struct GetUnconfirmedBalance(pub f64); // Core docs are missing so this is j
 /// > getwalletinfo
 /// > Returns an object containing various wallet state info.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetWalletInfo {
     /// The wallet name.
     #[serde(rename = "walletname")]
@@ -555,11 +575,13 @@ pub struct GetWalletInfo {
 /// > made public by common use as inputs or as the resulting change
 /// > in past transactions
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListAddressGroupings(pub Vec<Vec<ListAddressGroupingsItem>>);
 
 /// List item type returned as part of `listaddressgroupings`.
 // FIXME: The Core docs seem wrong, not sure what shape this should be?
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListAddressGroupingsItem {
     /// The bitcoin address.
     pub address: String,
@@ -575,6 +597,7 @@ pub struct ListAddressGroupingsItem {
 /// >
 /// > Returns the list of all labels, or labels that are assigned to addresses with a specific purpose.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListLabels(pub Vec<String>);
 
 /// Result of the JSON-RPC method `listlockunspent`.
@@ -584,10 +607,12 @@ pub struct ListLabels(pub Vec<String>);
 /// > Returns list of temporarily unspendable outputs.
 /// > See the lockunspent call to lock and unlock transactions for spending.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListLockUnspent(pub Vec<ListLockUnspentItem>);
 
 /// List item returned as part of of `listlockunspent`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListLockUnspentItem {
     /// The transaction id locked.
     pub txid: String,
@@ -601,10 +626,12 @@ pub struct ListLockUnspentItem {
 /// >
 /// > List balances by receiving address.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListReceivedByAddress(pub Vec<ListReceivedByAddressItem>);
 
 /// List item returned as part of of `listreceivedByaddress`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListReceivedByAddressItem {
     /// Only returned if imported addresses were involved in transaction.
     #[serde(rename = "involvesWatchonly")]
@@ -631,6 +658,7 @@ pub struct ListReceivedByAddressItem {
 /// > If "blockhash" is no longer a part of the main chain, transactions from the fork point onward are included.
 /// > Additionally, if include_removed is set, transactions affecting the wallet which were removed are returned in the "removed" array.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListSinceBlock {
     /// All the transactions.
     pub transactions: Vec<ListSinceBlockTransaction>,
@@ -651,6 +679,7 @@ pub struct ListSinceBlock {
 /// Transaction item returned as part of `listsinceblock`.
 // FIXME: These docs from Core seem to buggy, there is only partial mention of 'move' category?
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListSinceBlockTransaction {
     /// DEPRECATED. The account name associated with the transaction. Will be "" for the default account.
     pub account: String,
@@ -727,10 +756,12 @@ pub struct ListSinceBlockTransaction {
 /// > Note that the "account" argument and "otheraccount" return value have been removed in V0.17. To use this RPC with an "account" argument, restart
 /// > bitcoind with -deprecatedrpc=accounts
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListTransactions(pub Vec<ListTransactionsItem>);
 
 /// Transaction item returned as part of `listtransactions`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListTransactionsItem {
     /// The bitcoin address of the transaction.
     pub address: String,
@@ -790,10 +821,12 @@ pub struct ListTransactionsItem {
 /// > with between minconf and maxconf (inclusive) confirmations.
 /// > Optionally filter to only include txouts paid to specified addresses.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListUnspent(pub Vec<ListUnspentItem>);
 
 /// Unspent transaction output, returned as part of `listunspent`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListUnspentItem {
     /// The transaction id.
     pub txid: String,
@@ -831,6 +864,7 @@ pub struct ListUnspentItem {
 /// > Returns a list of currently loaded wallets.
 /// > For full information on the wallet, use "getwalletinfo"
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListWallets(pub Vec<String>);
 
 /// Result of the JSON-RPC method `loadwallet`.
@@ -844,6 +878,7 @@ pub struct ListWallets(pub Vec<String>);
 /// > Arguments:
 /// > 1. "filename"    (string, required) The wallet directory or .dat file.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct LoadWallet {
     /// The wallet name if loaded successfully.
     pub name: String,
@@ -862,6 +897,7 @@ impl LoadWallet {
 /// >
 /// > Rescan the local blockchain for wallet related transactions.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct RescanBlockchain {
     /// The block height where the rescan has started.
     pub start_height: i64,
@@ -886,6 +922,7 @@ pub struct RescanBlockchain {
 /// >       ,...
 /// >     }
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SendMany(
     /// The transaction id for the send.
     ///
@@ -903,6 +940,7 @@ pub struct SendMany(
 /// > 1. "address"            (string, required) The bitcoin address to send to.
 /// > 2. "amount"             (numeric or string, required) The amount in BTC to send. eg 0.1
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SendToAddress(pub String);
 
 impl SendToAddress {
@@ -920,6 +958,7 @@ impl SendToAddress {
 /// > 1. "address"         (string, required) The bitcoin address to use for the private key.
 /// > 2. "message"         (string, required) The message to create a signature of.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SignMessage(
     /// The signature of the message encoded in base 64.
     pub String,
@@ -954,6 +993,7 @@ pub struct SignMessage(
 /// >                              accepted as second parameter.
 /// >    ]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct WalletCreateFundedPsbt {
     /// The resulting raw transaction (base64-encoded string).
     pub psbt: String,
@@ -975,6 +1015,7 @@ pub struct WalletCreateFundedPsbt {
 /// > Arguments:
 /// > 1. "psbt"                      (string, required) The transaction base64 string
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct WalletProcessPsbt {
     /// The base64-encoded partially signed transaction.
     pub psbt: String,

--- a/types/src/v17/zmq.rs
+++ b/types/src/v17/zmq.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 ///>
 ///> Returns information about the active ZeroMQ notifications.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetZmqNotifications {
     /// Type of notification.
     #[serde(rename = "type")]

--- a/types/src/v18/blockchain/mod.rs
+++ b/types/src/v18/blockchain/mod.rs
@@ -19,10 +19,12 @@ use super::{MempoolEntryError, MempoolEntryFees};
 /// > Arguments:
 /// > 1. "txid"                 (string, required) The transaction id (must be in mempool)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetMempoolEntry(pub MempoolEntry);
 
 /// A relative (ancestor or descendant) transaction of a transaction in the mempool.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct MempoolEntry {
     /// Virtual transaction size as defined in BIP 141.
     ///

--- a/types/src/v18/control.rs
+++ b/types/src/v18/control.rs
@@ -12,12 +12,14 @@ use serde::{Deserialize, Serialize};
 /// >
 /// > Returns details of the RPC server.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetRpcInfo {
     active_commands: Vec<ActiveCommand>,
 }
 
 /// Information about an active command - return as part of `getrpcinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ActiveCommand {
     /// The name of the RPC command.
     pub method: String,

--- a/types/src/v18/network/mod.rs
+++ b/types/src/v18/network/mod.rs
@@ -16,10 +16,12 @@ use serde::{Deserialize, Serialize};
 /// >
 /// > Return known addresses which can potentially be used to find new nodes in the network.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetNodeAddresses(pub Vec<NodeAddress>);
 
 /// An item from the list returned by the JSON-RPC method `getnodeaddresses`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct NodeAddress {
     /// Timestamp in seconds since epoch (Jan 1 1970 GMT) when the node was last seen.
     pub time: u64,
@@ -37,10 +39,12 @@ pub struct NodeAddress {
 /// >
 /// > Returns data about each connected network node as a json array of objects.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetPeerInfo(pub Vec<PeerInfo>);
 
 /// An item from the list returned by the JSON-RPC method `getpeerinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct PeerInfo {
     /// Peer index.
     pub id: u32,

--- a/types/src/v18/raw_transactions/mod.rs
+++ b/types/src/v18/raw_transactions/mod.rs
@@ -20,6 +20,7 @@ pub use self::error::{AnalyzePsbtError, AnalyzePsbtInputMissingError};
 /// Arguments:
 /// 1. psbt    (string, required) A base64 string of a PSBT
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct AnalyzePsbt {
     /// Array of input objects.
     pub inputs: Vec<AnalyzePsbtInput>,
@@ -38,6 +39,7 @@ pub struct AnalyzePsbt {
 
 /// Represents an input in a PSBT operation.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct AnalyzePsbtInput {
     /// Whether a UTXO is provided.
     pub has_utxo: bool,
@@ -51,6 +53,7 @@ pub struct AnalyzePsbtInput {
 
 /// Represents missing elements required to complete an input.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct AnalyzePsbtInputMissing {
     /// Public key ID, hash160 of the public key, of a public key whose BIP 32 derivation path is missing.
     pub pubkeys: Option<Vec<String>>,
@@ -78,6 +81,7 @@ pub struct AnalyzePsbtInputMissing {
 /// >        ...
 /// >      ]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct JoinPsbts(
     /// The base64-encoded partially signed transaction.
     pub String,
@@ -92,6 +96,7 @@ pub struct JoinPsbts(
 /// > Arguments:
 /// > 1. psbt    (string, required) A base64 string of a PSBT
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct UtxoUpdatePsbt(
     /// The base64-encoded partially signed transaction with inputs updated.
     pub String,

--- a/types/src/v18/util/mod.rs
+++ b/types/src/v18/util/mod.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 /// > Derives one or more addresses corresponding to an output descriptor.
 /// > Returns an array of derived addresses.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct DeriveAddresses(pub Vec<String>);
 
 /// Result of JSON-RPC method `getdescriptorinfo`.
@@ -24,6 +25,7 @@ pub struct DeriveAddresses(pub Vec<String>);
 /// > Analyses a descriptor.
 /// > Returns information about the descriptor.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetDescriptorInfo {
     /// The descriptor in canonical form, without private keys.
     pub descriptor: String,

--- a/types/src/v18/wallet/mod.rs
+++ b/types/src/v18/wallet/mod.rs
@@ -17,6 +17,7 @@ pub use self::error::ListReceivedByLabelError;
 /// >
 /// > Returns the total amount received by addresses with `<label>` in transactions with at least `[minconf]` confirmations.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetReceivedByLabel(pub f64);
 
 /// Result of the JSON-RPC method `listreceivedbylabel`.
@@ -25,10 +26,12 @@ pub struct GetReceivedByLabel(pub f64);
 /// >
 /// > List received transactions by label.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListReceivedByLabel(pub Vec<ListReceivedByLabelItem>);
 
 /// Item returned as part of `listreceivedbylabel`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListReceivedByLabelItem {
     /// Only returned if imported addresses were involved in transaction.
     #[serde(rename = "involvesWatchonly")]
@@ -49,10 +52,12 @@ pub struct ListReceivedByLabelItem {
 /// > with between minconf and maxconf (inclusive) confirmations.
 /// > Optionally filter to only include txouts paid to specified addresses.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListUnspent(pub Vec<ListUnspentItem>);
 
 /// Unspent transaction output, returned as part of `listunspent`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListUnspentItem {
     /// The transaction id.
     pub txid: String,
@@ -91,6 +96,7 @@ pub struct ListUnspentItem {
 /// >
 /// > Returns a list of wallets in the wallet directory.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListWalletDir {
     /// The list of wallets in the wallet directory.
     pub wallets: Vec<ListWalletDirWallet>,
@@ -98,6 +104,7 @@ pub struct ListWalletDir {
 
 /// Wallet entry returned as part of `listwalletdir`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListWalletDirWallet {
     /// The wallet name.
     pub name: String,

--- a/types/src/v19/blockchain/mod.rs
+++ b/types/src/v19/blockchain/mod.rs
@@ -21,6 +21,7 @@ use super::{GetChainTxStatsError, GetMempoolInfoError};
 /// >
 /// > Returns an object containing various state info regarding blockchain processing.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBlockchainInfo {
     /// Current network name as defined in BIP70 (main, test, signet, regtest).
     pub chain: String,
@@ -65,6 +66,7 @@ pub struct GetBlockchainInfo {
 
 /// Status of softfork.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Softfork {
     /// The [`SoftforkType`]: one of "buried", "bip9".
     #[serde(rename = "type")]
@@ -93,6 +95,7 @@ pub enum SoftforkType {
 
 /// Status of BIP-9 softforks.
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Bip9SoftforkInfo {
     /// One of "defined", "started", "locked_in", "active", "failed".
     pub status: Bip9SoftforkStatus,
@@ -126,6 +129,7 @@ pub enum Bip9SoftforkStatus {
 
 /// Statistics for a BIP-9 softfork.
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Bip9SoftforkStatistics {
     /// The length in blocks of the BIP9 signalling period.
     pub period: i64,
@@ -149,6 +153,7 @@ pub struct Bip9SoftforkStatistics {
 /// > 1. blockhash     (string, required) The hash of the block
 /// > 2. filtertype    (string, optional, default=basic) The type name of the filter
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBlockFilter {
     /// The hex-encoded filter data.
     pub filter: String,
@@ -162,6 +167,7 @@ pub struct GetBlockFilter {
 /// >
 /// > Compute statistics about the total number and rate of transactions in the chain.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetChainTxStats {
     /// The timestamp for the final block in the window in UNIX format.
     pub time: i64,
@@ -192,12 +198,14 @@ pub struct GetChainTxStats {
 /// > Arguments:
 /// > 1. "txid"                 (string, required) The transaction id (must be in mempool)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetMempoolAncestors(pub Vec<String>);
 
 /// Result of JSON-RPC method `getmempoolancestors` with verbose set to true.
 ///
 /// Map of txid to `MempoolEntry` i.e., an ancestor.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetMempoolAncestorsVerbose(pub BTreeMap<String, MempoolEntry>);
 
 /// Result of JSON-RPC method `getmempooldescendants` with verbose set to `false`.
@@ -209,12 +217,14 @@ pub struct GetMempoolAncestorsVerbose(pub BTreeMap<String, MempoolEntry>);
 /// > Arguments:
 /// > 1. "txid"                 (string, required) The transaction id (must be in mempool)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetMempoolDescendants(pub Vec<String>);
 
 /// Result of JSON-RPC method `getmempooldescendants` with verbose set to true.
 ///
 /// Map of txid to [`MempoolEntry`] i.e., a descendant.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetMempoolDescendantsVerbose(pub BTreeMap<String, MempoolEntry>);
 
 /// Result of JSON-RPC method `getmempoolentry`.
@@ -226,10 +236,12 @@ pub struct GetMempoolDescendantsVerbose(pub BTreeMap<String, MempoolEntry>);
 /// > Arguments:
 /// > 1. "txid"                 (string, required) The transaction id (must be in mempool)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetMempoolEntry(pub MempoolEntry);
 
 /// A relative (ancestor or descendant) transaction of a transaction in the mempool.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct MempoolEntry {
     /// Virtual transaction size as defined in BIP 141.
     ///
@@ -287,6 +299,7 @@ pub struct MempoolEntry {
 /// Contains the base fee, modified fee (with fee deltas), and ancestor/descendant fee totals,
 /// all in BTC.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct MempoolEntryFees {
     /// Transaction fee in BTC.
     pub base: f64,
@@ -304,6 +317,7 @@ pub struct MempoolEntryFees {
 /// >
 /// > Returns details on the active state of the TX memory pool.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetMempoolInfo {
     /// True if the mempool is fully loaded. v0.19 and later only.
     pub loaded: bool,

--- a/types/src/v19/control.rs
+++ b/types/src/v19/control.rs
@@ -14,6 +14,7 @@ use super::ActiveCommand;
 /// >
 /// > Returns details of the RPC server.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetRpcInfo {
     /// All active commands
     pub active_commands: Vec<ActiveCommand>,

--- a/types/src/v19/network/mod.rs
+++ b/types/src/v19/network/mod.rs
@@ -18,6 +18,7 @@ use super::{GetNetworkInfoAddress, GetNetworkInfoError, GetNetworkInfoNetwork};
 ///
 /// > Returns an object containing various state info regarding P2P networking.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetNetworkInfo {
     /// The server version.
     pub version: usize,
@@ -64,10 +65,12 @@ pub struct GetNetworkInfo {
 /// >
 /// > Returns data about each connected network node as a json array of objects.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetPeerInfo(pub Vec<PeerInfo>);
 
 /// An item from the list returned by the JSON-RPC method `getpeerinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct PeerInfo {
     /// Peer index.
     pub id: u32,

--- a/types/src/v19/util.rs
+++ b/types/src/v19/util.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 /// > Analyses a descriptor.
 /// > Returns information about the descriptor.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetDescriptorInfo {
     /// The descriptor in canonical form, without private keys.
     pub descriptor: String,

--- a/types/src/v19/wallet/mod.rs
+++ b/types/src/v19/wallet/mod.rs
@@ -19,6 +19,7 @@ use super::{Bip125Replaceable, GetTransactionDetail, GetTransactionError};
 /// >
 /// > Returns an object with all balances in BTC.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBalances {
     /// Balances from outputs that the wallet can sign.
     pub mine: GetBalancesMine,
@@ -28,6 +29,7 @@ pub struct GetBalances {
 
 /// Balances from outputs that the wallet can sign.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBalancesMine {
     /// Trusted balance (outputs created by the wallet or confirmed outputs).
     pub trusted: f64,
@@ -43,6 +45,7 @@ pub struct GetBalancesMine {
 
 /// Hash and height of the block this information was generated on.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBalancesWatchOnly {
     /// Trusted balance (outputs created by the wallet or confirmed outputs).
     pub trusted: f64,
@@ -61,6 +64,7 @@ pub struct GetBalancesWatchOnly {
 /// > Arguments:
 /// > 1. txid                 (string, required) The transaction id
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetTransaction {
     /// The transaction amount in BTC.
     pub amount: f64,

--- a/types/src/v20/control.rs
+++ b/types/src/v20/control.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// > Gets and sets the logging configuration.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Logging {
     pub addrman: bool,
     pub bench: bool,

--- a/types/src/v20/network.rs
+++ b/types/src/v20/network.rs
@@ -12,10 +12,12 @@ use serde::{Deserialize, Serialize};
 ///
 /// > List all banned IPs/Subnets.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListBanned(pub Vec<Banned>);
 
 /// An item from the list returned by the JSON-RPC method `listbanned`
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Banned {
     /// The IP/Subnet of the banned node.
     pub address: String,

--- a/types/src/v20/util/mod.rs
+++ b/types/src/v20/util/mod.rs
@@ -25,6 +25,7 @@ pub use super::CreateMultisigError;
 /// >        ,...
 /// >      ]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct CreateMultisig {
     /// The value of the new multisig address.
     pub address: String,

--- a/types/src/v20/wallet/mod.rs
+++ b/types/src/v20/wallet/mod.rs
@@ -22,6 +22,7 @@ pub use super::{
 /// > Arguments:
 /// > 1. txid                 (string, required) The transaction id
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetTransaction {
     /// The transaction amount in BTC.
     pub amount: f64,
@@ -72,6 +73,7 @@ pub struct GetTransaction {
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetTransactionDetail {
     /// Only returns true if imported addresses were involved in transaction. v20 and later only.
     #[serde(rename = "involvesWatchonly")]

--- a/types/src/v21/blockchain/mod.rs
+++ b/types/src/v21/blockchain/mod.rs
@@ -21,6 +21,7 @@ pub use super::{
 /// >
 /// > Returns an object containing various state info regarding blockchain processing.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBlockchainInfo {
     /// Current network name as defined in BIP70 (main, test, signet, regtest).
     pub chain: String,
@@ -65,6 +66,7 @@ pub struct GetBlockchainInfo {
 
 /// Status of softfork.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Softfork {
     /// The [`SoftforkType`]: one of "buried", "bip9".
     #[serde(rename = "type")]
@@ -93,6 +95,7 @@ pub enum SoftforkType {
 
 /// Status of BIP-9 softforks.
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Bip9SoftforkInfo {
     /// One of "defined", "started", "locked_in", "active", "failed".
     pub status: Bip9SoftforkStatus,
@@ -119,10 +122,12 @@ pub struct Bip9SoftforkInfo {
 /// > Arguments:
 /// > 1. "txid"                 (string, required) The transaction id (must be in mempool)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetMempoolEntry(pub MempoolEntry);
 
 /// A relative (ancestor or descendant) transaction of a transaction in the mempool.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct MempoolEntry {
     /// Virtual transaction size as defined in BIP 141.
     ///
@@ -180,6 +185,7 @@ pub struct MempoolEntry {
 /// >
 /// > Returns details on the active state of the TX memory pool.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetMempoolInfo {
     /// True if the mempool is fully loaded. v0.19 and later only.
     pub loaded: bool,

--- a/types/src/v21/network/mod.rs
+++ b/types/src/v21/network/mod.rs
@@ -18,6 +18,7 @@ use super::{GetNetworkInfoAddress, GetNetworkInfoError, GetNetworkInfoNetwork};
 ///
 /// > Returns an object containing various state info regarding P2P networking.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetNetworkInfo {
     /// The server version.
     pub version: usize,
@@ -68,10 +69,12 @@ pub struct GetNetworkInfo {
 /// >
 /// > Returns data about each connected network node as a json array of objects.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetPeerInfo(pub Vec<PeerInfo>);
 
 /// An item from the list returned by the JSON-RPC method `getpeerinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct PeerInfo {
     /// Peer index.
     pub id: u32,

--- a/types/src/v21/wallet.rs
+++ b/types/src/v21/wallet.rs
@@ -15,6 +15,7 @@ use crate::model;
 /// > Unloads the wallet referenced by the request endpoint, otherwise unloads the wallet specified in the argument.
 /// > Specifying the wallet name on a wallet endpoint is invalid.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct UnloadWallet {
     /// Warning messages, if any, related to unloading the wallet.
     pub warning: String,

--- a/types/src/v22/blockchain/mod.rs
+++ b/types/src/v22/blockchain/mod.rs
@@ -16,6 +16,7 @@ pub use super::GetMempoolInfoError;
 /// >
 /// > Returns details on the active state of the TX memory pool.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetMempoolInfo {
     /// True if the mempool is fully loaded. v0.19 and later only.
     pub loaded: bool,

--- a/types/src/v22/control.rs
+++ b/types/src/v22/control.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// > Gets and sets the logging configuration.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Logging {
     pub addrman: bool,
     pub bench: bool,

--- a/types/src/v22/network.rs
+++ b/types/src/v22/network.rs
@@ -14,10 +14,12 @@ use serde::{Deserialize, Serialize};
 ///
 /// > List all banned IPs/Subnets.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListBanned(pub Vec<Banned>);
 
 /// An item from the list returned by the JSON-RPC method `listbanned`
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Banned {
     /// The IP/Subnet of the banned node.
     pub address: String,
@@ -37,10 +39,12 @@ pub struct Banned {
 /// >
 /// > Returns data about each connected network node as a json array of objects.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetPeerInfo(pub Vec<PeerInfo>);
 
 /// An item from the list returned by the JSON-RPC method `getpeerinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct PeerInfo {
     /// Peer index.
     pub id: u32,

--- a/types/src/v22/raw_transactions/mod.rs
+++ b/types/src/v22/raw_transactions/mod.rs
@@ -21,6 +21,7 @@ pub use self::error::DecodeScriptError;
 /// > 1. "hexstring"     (string) the hex encoded script
 // The docs on Core v0.17 appear to be way off what is actually returned.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct DecodeScript {
     /// Script public key.
     pub asm: String,
@@ -45,6 +46,7 @@ pub struct DecodeScript {
 
 /// `segwit` item returned as part of `decodescript`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct DecodeScriptSegwit {
     /// Script public key.
     pub asm: String,

--- a/types/src/v23/blockchain/mod.rs
+++ b/types/src/v23/blockchain/mod.rs
@@ -18,6 +18,7 @@ pub use super::{GetBlockchainInfoError, MempoolEntryError, MempoolEntryFees, Sof
 /// >
 /// > Returns an object containing various state info regarding blockchain processing.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBlockchainInfo {
     /// Current network name as defined in BIP70 (main, test, signet, regtest).
     pub chain: String,
@@ -71,10 +72,12 @@ pub struct GetBlockchainInfo {
 /// > Arguments:
 /// > 1. "txid"                 (string, required) The transaction id (must be in mempool)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetMempoolEntry(pub MempoolEntry);
 
 /// A relative (ancestor or descendant) transaction of a transaction in the mempool.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct MempoolEntry {
     /// Virtual transaction size as defined in BIP 141.
     ///
@@ -139,6 +142,7 @@ pub struct MempoolEntry {
 ///
 /// > Dumps the mempool to disk. It will fail until the previous dump is fully loaded.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SaveMempool {
     /// The directory and file where the mempool was saved.
     pub filename: String,

--- a/types/src/v23/control.rs
+++ b/types/src/v23/control.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// > Gets and sets the logging configuration.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Logging {
     pub addrman: bool,
     pub bench: bool,

--- a/types/src/v23/network.rs
+++ b/types/src/v23/network.rs
@@ -14,10 +14,12 @@ use serde::{Deserialize, Serialize};
 /// >
 /// > Returns data about each connected network node as a json array of objects.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetPeerInfo(pub Vec<PeerInfo>);
 
 /// An item from the list returned by the JSON-RPC method `getpeerinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct PeerInfo {
     /// Peer index.
     pub id: u32,

--- a/types/src/v23/raw_transactions/mod.rs
+++ b/types/src/v23/raw_transactions/mod.rs
@@ -27,6 +27,7 @@ pub use crate::psbt::{Bip32Deriv, PsbtScript, RawTransaction, WitnessUtxo};
 /// > Arguments:
 /// > 1. "psbt"            (string, required) The PSBT base64 string
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct DecodePsbt {
     /// The decoded network-serialized unsigned transaction.
     pub tx: RawTransaction,
@@ -48,6 +49,7 @@ pub struct DecodePsbt {
 
 /// An item from the global xpubs list of `DecodePsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GlobalXpub {
     /// The extended public key this path corresponds to.
     pub xpub: String,
@@ -59,6 +61,7 @@ pub struct GlobalXpub {
 
 /// An item from the global proprietary list of `DecodePsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Proprietary {
     /// The hex string for the proprietary identifier.
     identifier: String,
@@ -72,6 +75,7 @@ pub struct Proprietary {
 
 /// An input in a partially signed Bitcoin transaction.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct PsbtInput {
     /// Decoded network transaction for non-witness UTXOs.
     pub non_witness_utxo: Option<RawTransaction>,
@@ -109,6 +113,7 @@ pub struct PsbtInput {
 
 /// An output in a partially signed Bitcoin transaction.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct PsbtOutput {
     /// The redeem script.
     pub redeem_script: Option<PsbtScript>,
@@ -132,6 +137,7 @@ pub struct PsbtOutput {
 /// > 1. "hexstring"     (string) the hex encoded script
 // The docs on Core v0.17 appear to be way off what is actually returned.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct DecodeScript {
     /// Script public key.
     pub asm: String,
@@ -159,6 +165,7 @@ pub struct DecodeScript {
 
 /// `segwit` item returned as part of `decodescript`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct DecodeScriptSegwit {
     /// Script public key.
     pub asm: String,

--- a/types/src/v23/util/mod.rs
+++ b/types/src/v23/util/mod.rs
@@ -25,6 +25,7 @@ pub use super::CreateMultisigError;
 /// >        ,...
 /// >      ]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct CreateMultisig {
     /// The value of the new multisig address.
     pub address: String,

--- a/types/src/v23/wallet/mod.rs
+++ b/types/src/v23/wallet/mod.rs
@@ -22,6 +22,7 @@ pub use super::{Bip125Replaceable, GetTransactionDetail, GetTransactionDetailErr
 /// > Arguments:
 /// > 1. txid                 (string, required) The transaction id
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetTransaction {
     /// The transaction amount in BTC.
     pub amount: f64,

--- a/types/src/v24/blockchain/mod.rs
+++ b/types/src/v24/blockchain/mod.rs
@@ -19,10 +19,12 @@ pub use super::{GetMempoolInfoError, MempoolEntryError, MempoolEntryFees};
 /// > Arguments:
 /// > 1. "txid"                 (string, required) The transaction id (must be in mempool)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetMempoolEntry(pub MempoolEntry);
 
 /// A relative (ancestor or descendant) transaction of a transaction in the mempool.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct MempoolEntry {
     /// Virtual transaction size as defined in BIP 141.
     ///
@@ -71,6 +73,7 @@ pub struct MempoolEntry {
 /// >
 /// > Returns details on the active state of the TX memory pool.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetMempoolInfo {
     /// True if the mempool is fully loaded. v0.19 and later only.
     pub loaded: bool,

--- a/types/src/v24/network.rs
+++ b/types/src/v24/network.rs
@@ -14,10 +14,12 @@ use serde::{Deserialize, Serialize};
 /// >
 /// > Returns data about each connected network node as a json array of objects.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetPeerInfo(pub Vec<PeerInfo>);
 
 /// An item from the list returned by the JSON-RPC method `getpeerinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct PeerInfo {
     /// Peer index.
     pub id: u32,

--- a/types/src/v24/raw_transactions/mod.rs
+++ b/types/src/v24/raw_transactions/mod.rs
@@ -27,6 +27,7 @@ pub use crate::psbt::{Bip32Deriv, PsbtScript, RawTransaction, WitnessUtxo};
 /// > Arguments:
 /// > 1. "psbt"            (string, required) The PSBT base64 string
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct DecodePsbt {
     /// The decoded network-serialized unsigned transaction.
     pub tx: RawTransaction,
@@ -48,6 +49,7 @@ pub struct DecodePsbt {
 
 /// An item from the global xpubs list of `DecodePsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GlobalXpub {
     /// The extended public key this path corresponds to.
     pub xpub: String,
@@ -59,6 +61,7 @@ pub struct GlobalXpub {
 
 /// An item from the global proprietary list of `DecodePsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Proprietary {
     /// The hex string for the proprietary identifier.
     identifier: String,
@@ -72,6 +75,7 @@ pub struct Proprietary {
 
 /// An input in a partially signed Bitcoin transaction.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct PsbtInput {
     /// Decoded network transaction for non-witness UTXOs.
     pub non_witness_utxo: Option<RawTransaction>,
@@ -121,6 +125,7 @@ pub struct PsbtInput {
 
 /// An output in a partially signed Bitcoin transaction.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct PsbtOutput {
     /// The redeem script.
     pub redeem_script: Option<PsbtScript>,
@@ -142,6 +147,7 @@ pub struct PsbtOutput {
 
 /// An item from the `taproot_script_path_sigs` list of `PsbtInput`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct TaprootScriptPathSig {
     /// The x-only pubkey for this signature.
     pub pubkey: String,
@@ -153,6 +159,7 @@ pub struct TaprootScriptPathSig {
 
 /// An item from the `taproot_scripts` list of `PsbtInput`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct TaprootScript {
     /// A leaf script.
     pub script: String,
@@ -164,6 +171,7 @@ pub struct TaprootScript {
 
 /// An item from the `taproot_bip32_derivs` list of `PsbtInput`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct TaprootBip32Deriv {
     /// The x-only public key this path corresponds to.
     pub pubkey: String,
@@ -177,6 +185,7 @@ pub struct TaprootBip32Deriv {
 
 /// A Taproot leaf script at depth with version.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct TaprootLeaf {
     /// The depth of this element in the tree.
     pub depth: u32,

--- a/types/src/v24/wallet/mod.rs
+++ b/types/src/v24/wallet/mod.rs
@@ -24,6 +24,7 @@ pub use super::{
 /// > Arguments:
 /// > 1. txid                 (string, required) The transaction id
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetTransaction {
     /// The transaction amount in BTC.
     pub amount: f64,
@@ -86,6 +87,7 @@ pub struct GetTransaction {
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetTransactionDetail {
     /// Only returns true if imported addresses were involved in transaction. v20 and later only.
     #[serde(rename = "involvesWatchonly")]
@@ -124,10 +126,12 @@ pub struct GetTransactionDetail {
 /// > with between minconf and maxconf (inclusive) confirmations.
 /// > Optionally filter to only include txouts paid to specified addresses.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListUnspent(pub Vec<ListUnspentItem>);
 
 /// Unspent transaction output, returned as part of `listunspent`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ListUnspentItem {
     /// The transaction id.
     pub txid: String,

--- a/types/src/v25/blockchain/mod.rs
+++ b/types/src/v25/blockchain/mod.rs
@@ -24,6 +24,7 @@ pub use super::GetBlockStatsError;
 /// > Arguments:
 /// > 1. "hash_or_height"     (string or numeric, required) The block hash or height of the target block
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBlockStats {
     /// Average fee in the block.
     #[serde(rename = "avgfee")]

--- a/types/src/v25/control.rs
+++ b/types/src/v25/control.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// > Gets and sets the logging configuration.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Logging {
     pub addrman: bool,
     pub bench: bool,

--- a/types/src/v25/wallet.rs
+++ b/types/src/v25/wallet.rs
@@ -24,6 +24,7 @@ use crate::model;
 /// > 7. load_on_startup         (boolean, optional) Save wallet name to persistent settings and load on startup. True to add wallet to startup list, false to remove, null to leave unchanged.
 /// > 8. external_signer         (boolean, optional, default=false) Use an external signer such as a hardware wallet. Requires -signer to be configured. Wallet creation will fail if keys cannot be fetched. Requires disable_private_keys and descriptors set to true.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct CreateWallet {
     /// The wallet name if created successfully.
     ///
@@ -62,6 +63,7 @@ impl CreateWallet {
 /// > 1. filename           (string, required) The wallet directory or .dat file.
 /// > 2. load_on_startup    (boolean, optional) Save wallet name to persistent settings and load on startup. True to add wallet to startup list, false to remove, null to leave unchanged.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct LoadWallet {
     /// The wallet name if loaded successfully.
     pub name: String,
@@ -97,6 +99,7 @@ impl LoadWallet {
 /// > 1. wallet_name        (string, optional, default=the wallet name from the RPC endpoint) The name of the wallet to unload. If provided both here and in the RPC endpoint, the two must be identical.
 /// > 2. load_on_startup    (boolean, optional) Save wallet name to persistent settings and load on startup. True to add wallet to startup list, false to remove, null to leave unchanged.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct UnloadWallet {
     /// Warning messages, if any, related to unloading the wallet. Multiple messages will be delimited by newlines.
     ///

--- a/types/src/v26/blockchain.rs
+++ b/types/src/v26/blockchain.rs
@@ -19,6 +19,7 @@ use crate::{model, NumericError};
 /// > Returns statistics about the unspent transaction output set.
 /// > Note this call may take some time.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetTxOutSetInfo {
     /// The current block height (index).
     pub height: i64,

--- a/types/src/v26/control.rs
+++ b/types/src/v26/control.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// > Gets and sets the logging configuration.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Logging {
     pub addrman: bool,
     pub bench: bool,

--- a/types/src/v26/mining.rs
+++ b/types/src/v26/mining.rs
@@ -17,12 +17,14 @@ use crate::model;
 /// >
 /// > Returns a map of all user-created (see prioritisetransaction) fee deltas by txid, and whether the tx is present in mempool.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetPrioritisedTransactions(
     /// prioritisation keyed by txid.
     pub BTreeMap<String, PrioritisedTransaction>,
 );
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct PrioritisedTransaction {
     /// Transaction fee delta in satoshis.
     pub fee_delta: i64,

--- a/types/src/v26/network.rs
+++ b/types/src/v26/network.rs
@@ -14,10 +14,12 @@ use serde::{Deserialize, Serialize};
 /// >
 /// > Returns data about each connected network node as a json array of objects.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetPeerInfo(pub Vec<PeerInfo>);
 
 /// An item from the list returned by the JSON-RPC method `getpeerinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct PeerInfo {
     /// Peer index.
     pub id: u32,

--- a/types/src/v26/raw_transactions/mod.rs
+++ b/types/src/v26/raw_transactions/mod.rs
@@ -34,6 +34,7 @@ use crate::model;
 /// >        ...
 /// >      ]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct DescriptorProcessPsbt {
     /// The base64-encoded partially signed transaction.
     pub psbt: String,
@@ -61,6 +62,7 @@ pub struct DescriptorProcessPsbt {
 /// >        ...
 /// >      ]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SubmitPackage {
     /// The transaction package result message.
     ///
@@ -76,6 +78,7 @@ pub struct SubmitPackage {
 
 /// Models the per-transaction result included in the JSON-RPC method `submitpackage`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SubmitPackageTxResult {
     /// The transaction id.
     pub txid: String,
@@ -94,6 +97,7 @@ pub struct SubmitPackageTxResult {
 
 /// Models the fees included in the per-transaction result of the JSON-RPC method `submitpackage`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SubmitPackageTxResultFees {
     /// Transaction fee.
     #[serde(rename = "base")]

--- a/types/src/v26/wallet/mod.rs
+++ b/types/src/v26/wallet/mod.rs
@@ -32,6 +32,7 @@ pub use super::{
 /// > 7. load_on_startup         (boolean, optional) Save wallet name to persistent settings and load on startup. True to add wallet to startup list, false to remove, null to leave unchanged.
 /// > 8. external_signer         (boolean, optional, default=false) Use an external signer such as a hardware wallet. Requires -signer to be configured. Wallet creation will fail if keys cannot be fetched. Requires disable_private_keys and descriptors set to true.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct CreateWallet {
     /// The wallet name if created successfully.
     ///
@@ -47,6 +48,7 @@ pub struct CreateWallet {
 /// >
 /// > Returns an object with all balances in BTC.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBalances {
     /// Balances from outputs that the wallet can sign.
     pub mine: GetBalancesMine,
@@ -66,6 +68,7 @@ pub struct GetBalances {
 /// > Arguments:
 /// > 1. txid                 (string, required) The transaction id
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetTransaction {
     /// The transaction amount in BTC.
     pub amount: f64,
@@ -132,6 +135,7 @@ pub struct GetTransaction {
 
 /// Item returned as part of of `gettransaction`. v26 and later only.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct LastProcessedBlock {
     /// Hash of the block this information was generated on.
     pub hash: String,
@@ -151,6 +155,7 @@ pub struct LastProcessedBlock {
 /// > 1. filename           (string, required) The wallet directory or .dat file.
 /// > 2. load_on_startup    (boolean, optional) Save wallet name to persistent settings and load on startup. True to add wallet to startup list, false to remove, null to leave unchanged.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct LoadWallet {
     /// The wallet name if loaded successfully.
     pub name: String,
@@ -169,6 +174,7 @@ pub struct LoadWallet {
 /// > 1. wallet_name        (string, optional, default=the wallet name from the RPC endpoint) The name of the wallet to unload. If provided both here and in the RPC endpoint, the two must be identical.
 /// > 2. load_on_startup    (boolean, optional) Save wallet name to persistent settings and load on startup. True to add wallet to startup list, false to remove, null to leave unchanged.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct UnloadWallet {
     /// Warning messages, if any, related to loading the wallet.
     pub warnings: Option<Vec<String>>,

--- a/types/src/v28/blockchain.rs
+++ b/types/src/v28/blockchain.rs
@@ -18,6 +18,7 @@ use crate::model;
 ///
 /// > Returns an object containing various state info regarding blockchain processing.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBlockchainInfo {
     /// Current network name as defined in BIP70 (main, test, signet, regtest).
     pub chain: String,

--- a/types/src/v28/control.rs
+++ b/types/src/v28/control.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// > Gets and sets the logging configuration.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Logging {
     pub addrman: bool,
     pub bench: bool,

--- a/types/src/v28/mining.rs
+++ b/types/src/v28/mining.rs
@@ -15,6 +15,7 @@ use crate::model;
 /// >
 /// > Returns a json object containing mining-related information.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetMiningInfo {
     /// The current block.
     pub blocks: u64,

--- a/types/src/v28/network.rs
+++ b/types/src/v28/network.rs
@@ -14,6 +14,7 @@ use crate::model;
 ///
 /// > Returns an object containing various state info regarding P2P networking.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetNetworkInfo {
     /// The server version.
     pub version: usize,

--- a/types/src/v28/raw_transactions/mod.rs
+++ b/types/src/v28/raw_transactions/mod.rs
@@ -33,6 +33,7 @@ use crate::model;
 /// >        ...
 /// >      ]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SubmitPackage {
     /// The transaction package result message.
     ///
@@ -48,6 +49,7 @@ pub struct SubmitPackage {
 
 /// Models the per-transaction result included in the JSON-RPC method `submitpackage`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SubmitPackageTxResult {
     /// The transaction id.
     pub txid: String,
@@ -66,6 +68,7 @@ pub struct SubmitPackageTxResult {
 
 /// Models the fees included in the per-transaction result of the JSON-RPC method `submitpackage`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SubmitPackageTxResultFees {
     /// Transaction fee.
     #[serde(rename = "base")]

--- a/types/src/v28/wallet/mod.rs
+++ b/types/src/v28/wallet/mod.rs
@@ -20,6 +20,7 @@ pub use super::{Bip125Replaceable, GetTransactionDetail, GetTransactionError, La
 /// > Arguments:
 /// > 1. txid                 (string, required) The transaction id
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetTransaction {
     /// The transaction amount in BTC.
     pub amount: f64,

--- a/types/src/v29/blockchain/mod.rs
+++ b/types/src/v29/blockchain/mod.rs
@@ -18,6 +18,7 @@ use crate::{model, ScriptPubkey};
 
 /// Result of JSON-RPC method `getblock` with verbosity set to 1.
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBlockVerboseOne {
     /// The block hash (same as provided) in RPC call.
     pub hash: String,
@@ -75,6 +76,7 @@ pub struct GetBlockVerboseOne {
 /// >
 /// > Returns an object containing various state info regarding blockchain processing.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBlockchainInfo {
     /// Current network name as defined in BIP70 (main, test, signet, regtest).
     pub chain: String,
@@ -127,6 +129,7 @@ pub struct GetBlockchainInfo {
 /// > Arguments:
 /// > 1. "hash"          (string, required) The block hash
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBlockHeader(pub String);
 
 /// Result of JSON-RPC method `getblockheader` with verbosity set to `true`.
@@ -137,6 +140,7 @@ pub struct GetBlockHeader(pub String);
 /// > Arguments:
 /// > 1. "hash"          (string, required) The block hash
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetBlockHeaderVerbose {
     /// The block hash.
     pub hash: String,
@@ -188,6 +192,7 @@ pub struct GetBlockHeaderVerbose {
 /// > 2. scanobjects  (json array, optional) Array of scan objects. Required for "start" action
 /// > 3. include_mempool  (boolean, optional, default=true) Whether to include unconfirmed activitydata
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetDescriptorActivity {
     pub activity: Vec<ActivityEntry>,
 }
@@ -204,6 +209,7 @@ pub enum ActivityEntry {
 
 /// Represents a 'spend' activity event.
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct SpendActivity {
     // Note: 'type' field is used for deserialization tag, not included here explicitly.
     /// The total amount in BTC of the spent output.
@@ -229,6 +235,7 @@ pub struct SpendActivity {
 
 /// Represents a 'receive' activity event.
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ReceiveActivity {
     // Note: 'type' field is used for deserialization tag, not included here explicitly.
     /// The total amount in BTC of the new output

--- a/types/src/v29/blockchain/mod.rs
+++ b/types/src/v29/blockchain/mod.rs
@@ -187,13 +187,13 @@ pub struct GetBlockHeaderVerbose {
 /// > 1. blockhashes  (json array, optional) The list of blockhashes to examine for activity. Order doesn't matter. Must be along main chain or an error is thrown.
 /// > 2. scanobjects  (json array, optional) Array of scan objects. Required for "start" action
 /// > 3. include_mempool  (boolean, optional, default=true) Whether to include unconfirmed activitydata
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 pub struct GetDescriptorActivity {
     pub activity: Vec<ActivityEntry>,
 }
 
 /// Enum representing either a spend or receive activity entry.
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum ActivityEntry {
     /// The spend activity.
@@ -203,7 +203,7 @@ pub enum ActivityEntry {
 }
 
 /// Represents a 'spend' activity event.
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 pub struct SpendActivity {
     // Note: 'type' field is used for deserialization tag, not included here explicitly.
     /// The total amount in BTC of the spent output.
@@ -228,7 +228,7 @@ pub struct SpendActivity {
 }
 
 /// Represents a 'receive' activity event.
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 pub struct ReceiveActivity {
     // Note: 'type' field is used for deserialization tag, not included here explicitly.
     /// The total amount in BTC of the new output

--- a/types/src/v29/mining/mod.rs
+++ b/types/src/v29/mining/mod.rs
@@ -15,6 +15,7 @@ pub use self::error::{BlockTemplateTransactionError, GetMiningInfoError, NextBlo
 ///
 /// Returned as part of `getblocktemplate`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct BlockTemplateTransaction {
     /// Transaction data encoded in hexadecimal (byte-for-byte).
     pub data: String,
@@ -44,6 +45,7 @@ pub struct BlockTemplateTransaction {
 /// >
 /// > Returns a json object containing mining-related information.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetMiningInfo {
     /// The current block.
     pub blocks: u64,
@@ -80,6 +82,7 @@ pub struct GetMiningInfo {
 
 /// Represents the `next` block information within the GetMiningInfo result.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct NextBlockInfo {
     /// The next height.
     pub height: u64,

--- a/types/src/v29/util.rs
+++ b/types/src/v29/util.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 /// > Analyses a descriptor.
 /// > Returns information about the descriptor.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GetDescriptorInfo {
     /// The descriptor in canonical form, without private keys. For a multipath descriptor, only the
     /// first will be returned.


### PR DESCRIPTION
If there are missing return fields in the types structs the integration tests still pass.

All of the missing fields have been added in #243, #251, #255, #267 and #272.

The solution suggested in issue #241 is adding `#[serde(deny_unknown_fields)]` to each struct which makes the test fail if there are fields returned that are not in the struct.

- First two patches: do a small code reorganisation to make sure the third patch that uses a search and replace catches all cases.
- Third patch: add `#[serde(deny_unknown_fields)]` to all structs in `types` that derive `Serialize` and therefore use serde. Using a search and replace.

Closes #241