### PR TITLE
Implement importwallet method and test

### DIFF
--- a/client/src/client_sync/v17/mod.rs
+++ b/client/src/client_sync/v17/mod.rs
@@ -132,6 +132,7 @@ crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
 crate::impl_client_v17__import_pubkey!();
+crate::impl_client_v17__import_wallet!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v17__list_lock_unspent!();

--- a/client/src/client_sync/v17/wallet.rs
+++ b/client/src/client_sync/v17/wallet.rs
@@ -365,6 +365,22 @@ macro_rules! impl_client_v17__import_pubkey {
     };
 }
 
+/// Implements Bitcoin Core JSON-RPC API method `importwallet`.
+#[macro_export]
+macro_rules! impl_client_v17__import_wallet {
+    () => {
+        impl Client {
+            pub fn import_wallet(&self, filename: &Path) -> Result<()> {
+                match self.call("importwallet", &[into_json(filename)?]) {
+                    Ok(serde_json::Value::Null) => Ok(()),
+                    Ok(res) => Err(Error::Returned(res.to_string())),
+                    Err(err) => Err(err.into()),
+                }
+            }
+        }
+    };
+}
+
 /// Implements Bitcoin Core JSON-RPC API method `listaddressgroupings`.
 #[macro_export]
 macro_rules! impl_client_v17__list_address_groupings {

--- a/client/src/client_sync/v18/mod.rs
+++ b/client/src/client_sync/v18/mod.rs
@@ -147,6 +147,7 @@ crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
 crate::impl_client_v17__import_pubkey!();
+crate::impl_client_v17__import_wallet!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v17__list_lock_unspent!();

--- a/client/src/client_sync/v19/mod.rs
+++ b/client/src/client_sync/v19/mod.rs
@@ -143,6 +143,7 @@ crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
 crate::impl_client_v17__import_pubkey!();
+crate::impl_client_v17__import_wallet!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();
 crate::impl_client_v17__list_labels!();

--- a/client/src/client_sync/v20/mod.rs
+++ b/client/src/client_sync/v20/mod.rs
@@ -140,6 +140,7 @@ crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
 crate::impl_client_v17__import_pubkey!();
+crate::impl_client_v17__import_wallet!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v18__list_received_by_label!();

--- a/client/src/client_sync/v21/mod.rs
+++ b/client/src/client_sync/v21/mod.rs
@@ -142,6 +142,7 @@ crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
 crate::impl_client_v17__import_pubkey!();
+crate::impl_client_v17__import_wallet!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v18__list_received_by_label!();

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -142,6 +142,7 @@ crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
 crate::impl_client_v17__import_pubkey!();
+crate::impl_client_v17__import_wallet!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();
 crate::impl_client_v17__list_labels!();

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -144,6 +144,7 @@ crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
 crate::impl_client_v17__import_pubkey!();
+crate::impl_client_v17__import_wallet!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();
 crate::impl_client_v17__list_labels!();

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -141,6 +141,7 @@ crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
 crate::impl_client_v17__import_pubkey!();
+crate::impl_client_v17__import_wallet!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();
 crate::impl_client_v17__list_labels!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -141,6 +141,7 @@ crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
 crate::impl_client_v17__import_pubkey!();
+crate::impl_client_v17__import_wallet!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();
 crate::impl_client_v17__list_labels!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -147,6 +147,7 @@ crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
 crate::impl_client_v17__import_pubkey!();
+crate::impl_client_v17__import_wallet!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v18__list_received_by_label!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -143,6 +143,7 @@ crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
 crate::impl_client_v17__import_pubkey!();
+crate::impl_client_v17__import_wallet!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();
 crate::impl_client_v17__list_labels!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -145,6 +145,7 @@ crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
 crate::impl_client_v17__import_pubkey!();
+crate::impl_client_v17__import_wallet!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();
 crate::impl_client_v17__list_labels!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -145,6 +145,7 @@ crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
 crate::impl_client_v17__import_pubkey!();
+crate::impl_client_v17__import_wallet!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();
 crate::impl_client_v17__list_labels!();

--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -324,6 +324,28 @@ fn wallet__import_pruned_funds() {
     let _: () = node.client.import_pruned_funds(&raw_tx.0, &tx_out_proof).expect("importprunedfunds");
 }
 
+#[test]
+fn wallet__import_wallet() {
+    let node = match () {
+        #[cfg(feature = "v22_and_below")]
+        () => Node::with_wallet(Wallet::Default, &[]),
+        #[cfg(not(feature = "v22_and_below"))]
+        () => {
+            let node = Node::with_wallet(Wallet::None, &["-deprecatedrpc=create_bdb"]);
+            node.client.create_legacy_wallet("wallet_name").expect("createlegacywallet");
+            node
+        }
+    };
+
+    node.client.new_address().expect("newaddress");
+    let dump_file_path = integration_test::random_tmp_file();
+
+    node.client.dump_wallet(&dump_file_path).expect("dumpwallet");
+    assert!(dump_file_path.exists());
+
+    let _: () = node.client.import_wallet(&dump_file_path).expect("importwallet");
+}
+
 #[cfg(not(feature = "v17"))]
 #[test]
 fn wallet__list_received_by_label__modelled() {


### PR DESCRIPTION
The JSON-RPC method `importwallet` does not return anything. We want to test this to catch any changes in behavior in future Core versions.

This PR adds a client function that errors if the return value is anything other than `null`, along with an integration test that calls this function.

Ref: [#116](https://github.com/rust-bitcoin/corepc/pull/116)