### PR TITLE
Implement keypoolrefill method and test

### DIFF
--- a/client/src/client_sync/v17/mod.rs
+++ b/client/src/client_sync/v17/mod.rs
@@ -133,6 +133,7 @@ crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
 crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__import_wallet!();
+crate::impl_client_v17__key_pool_refill!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v17__list_lock_unspent!();

--- a/client/src/client_sync/v17/wallet.rs
+++ b/client/src/client_sync/v17/wallet.rs
@@ -381,6 +381,22 @@ macro_rules! impl_client_v17__import_wallet {
     };
 }
 
+/// Implements Bitcoin Core JSON-RPC API method `keypoolrefill`.
+#[macro_export]
+macro_rules! impl_client_v17__key_pool_refill {
+    () => {
+        impl Client {
+            pub fn key_pool_refill(&self) -> Result<()> {
+                match self.call("keypoolrefill", &[]) {
+                    Ok(serde_json::Value::Null) => Ok(()),
+                    Ok(res) => Err(Error::Returned(res.to_string())),
+                    Err(err) => Err(err.into()),
+                }
+            }
+        }
+    };
+}
+
 /// Implements Bitcoin Core JSON-RPC API method `listaddressgroupings`.
 #[macro_export]
 macro_rules! impl_client_v17__list_address_groupings {

--- a/client/src/client_sync/v18/mod.rs
+++ b/client/src/client_sync/v18/mod.rs
@@ -148,6 +148,7 @@ crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
 crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__import_wallet!();
+crate::impl_client_v17__key_pool_refill!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v17__list_lock_unspent!();

--- a/client/src/client_sync/v19/mod.rs
+++ b/client/src/client_sync/v19/mod.rs
@@ -144,6 +144,7 @@ crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
 crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__import_wallet!();
+crate::impl_client_v17__key_pool_refill!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();
 crate::impl_client_v17__list_labels!();

--- a/client/src/client_sync/v20/mod.rs
+++ b/client/src/client_sync/v20/mod.rs
@@ -141,6 +141,7 @@ crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
 crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__import_wallet!();
+crate::impl_client_v17__key_pool_refill!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v18__list_received_by_label!();

--- a/client/src/client_sync/v21/mod.rs
+++ b/client/src/client_sync/v21/mod.rs
@@ -143,6 +143,7 @@ crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
 crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__import_wallet!();
+crate::impl_client_v17__key_pool_refill!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v18__list_received_by_label!();

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -143,6 +143,7 @@ crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
 crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__import_wallet!();
+crate::impl_client_v17__key_pool_refill!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();
 crate::impl_client_v17__list_labels!();

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -145,6 +145,7 @@ crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
 crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__import_wallet!();
+crate::impl_client_v17__key_pool_refill!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();
 crate::impl_client_v17__list_labels!();

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -142,6 +142,7 @@ crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
 crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__import_wallet!();
+crate::impl_client_v17__key_pool_refill!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();
 crate::impl_client_v17__list_labels!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -142,6 +142,7 @@ crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
 crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__import_wallet!();
+crate::impl_client_v17__key_pool_refill!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();
 crate::impl_client_v17__list_labels!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -148,6 +148,7 @@ crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
 crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__import_wallet!();
+crate::impl_client_v17__key_pool_refill!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v18__list_received_by_label!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -144,6 +144,7 @@ crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
 crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__import_wallet!();
+crate::impl_client_v17__key_pool_refill!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();
 crate::impl_client_v17__list_labels!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -146,6 +146,7 @@ crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
 crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__import_wallet!();
+crate::impl_client_v17__key_pool_refill!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();
 crate::impl_client_v17__list_labels!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -146,6 +146,7 @@ crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
 crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__import_wallet!();
+crate::impl_client_v17__key_pool_refill!();
 crate::impl_client_v17__list_address_groupings!();
 crate::impl_client_v18__list_received_by_label!();
 crate::impl_client_v17__list_labels!();

--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -346,6 +346,13 @@ fn wallet__import_wallet() {
     let _: () = node.client.import_wallet(&dump_file_path).expect("importwallet");
 }
 
+#[test]
+fn wallet__keypool_refill() {
+    let node = Node::with_wallet(Wallet::Default, &[]);
+
+    let _: () = node.client.key_pool_refill().expect("keypoolrefill");
+}
+
 #[cfg(not(feature = "v17"))]
 #[test]
 fn wallet__list_received_by_label__modelled() {


### PR DESCRIPTION
The JSON-RPC method `keypoolrefill` does not return anything. We want to test this to catch any changes in behavior in future Core versions.

This PR adds a client function that errors if the return value is anything other than `null`, along with an integration test that calls this function.

Ref: [#116](https://github.com/rust-bitcoin/corepc/pull/116)