### PR TITLE
Implement removeprunedfunds method and test

### DIFF
--- a/client/src/client_sync/v17/mod.rs
+++ b/client/src/client_sync/v17/mod.rs
@@ -144,6 +144,7 @@ crate::impl_client_v17__list_unspent!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v17__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();

--- a/client/src/client_sync/v17/wallet.rs
+++ b/client/src/client_sync/v17/wallet.rs
@@ -515,6 +515,18 @@ macro_rules! impl_client_v17__lock_unspent {
     };
 }
 
+/// Implements Bitcoin Core JSON-RPC API method `removeprunedfunds`.
+#[macro_export]
+macro_rules! impl_client_v17__remove_pruned_funds {
+    () => {
+        impl Client {
+            pub fn remove_pruned_funds(&self, txid: Txid) -> Result<()> {
+                self.call("removeprunedfunds", &[into_json(txid)?])
+            }
+        }
+    };
+}
+
 /// Implements Bitcoin Core JSON-RPC API method `rescanblockchain`.
 #[macro_export]
 macro_rules! impl_client_v17__rescan_blockchain {

--- a/client/src/client_sync/v18/mod.rs
+++ b/client/src/client_sync/v18/mod.rs
@@ -161,6 +161,7 @@ crate::impl_client_v17__list_wallets!();
 crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();

--- a/client/src/client_sync/v19/mod.rs
+++ b/client/src/client_sync/v19/mod.rs
@@ -157,6 +157,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v17__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();

--- a/client/src/client_sync/v20/mod.rs
+++ b/client/src/client_sync/v20/mod.rs
@@ -154,6 +154,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v17__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();

--- a/client/src/client_sync/v21/mod.rs
+++ b/client/src/client_sync/v21/mod.rs
@@ -156,6 +156,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v17__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -156,6 +156,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v17__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -158,6 +158,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -155,6 +155,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -155,6 +155,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -161,6 +161,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -157,6 +157,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -159,6 +159,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -159,6 +159,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();

--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -521,6 +521,22 @@ fn wallet__lock_unspent() {
     assert!(json.0);
 }
 
+#[test]
+fn wallet__remove_pruned_funds() {
+    let node = Node::with_wallet(Wallet::Default, &["-txindex"]);
+    node.fund_wallet();
+
+    let (_, tx) = node.create_mined_transaction();
+    let txid = tx.compute_txid();
+
+    let raw_tx = node.client.get_raw_transaction(txid).expect("getrawtransaction");
+    let tx_out_proof = node.client.get_tx_out_proof(&[txid]).expect("gettxoutproof");
+
+    let _: () = node.client.import_pruned_funds(&raw_tx.0, &tx_out_proof).expect("importprunedfunds");
+
+    let _: () = node.client.remove_pruned_funds(txid).expect("removeprunedfunds");
+}
+
 // This is tested in raw_transactions.rs `create_sign_send()`.
 #[test]
 fn wallet__sign_raw_transaction_with_wallet__modelled() {}


### PR DESCRIPTION
The JSON-RPC method `removeprunedfunds` does not return anything. We want to test this to catch any changes in behavior in future Core versions.

This PR adds a client function that errors if the return value is anything other than `null`, along with an integration test that calls this function.

Ref: [#116](https://github.com/rust-bitcoin/corepc/pull/116)