### PR TITLE
Correct method name for lockunspent client doc

### DIFF
--- a/client/src/client_sync/v17/wallet.rs
+++ b/client/src/client_sync/v17/wallet.rs
@@ -499,7 +499,7 @@ macro_rules! impl_client_v17__load_wallet {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `loadwallet`.
+/// Implements Bitcoin Core JSON-RPC API method `lockunspent`.
 #[macro_export]
 macro_rules! impl_client_v17__lock_unspent {
     () => {


### PR DESCRIPTION
Correct name of method in documentation for `lockunspent` client function.