### PR TITLE
Implement `setwalletflag` method and test

### DIFF
--- a/client/src/client_sync/v19/mod.rs
+++ b/client/src/client_sync/v19/mod.rs
@@ -161,6 +161,7 @@ crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();
+crate::impl_client_v19__set_wallet_flag!();
 crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v17__unload_wallet!();

--- a/client/src/client_sync/v19/wallet.rs
+++ b/client/src/client_sync/v19/wallet.rs
@@ -18,3 +18,15 @@ macro_rules! impl_client_v19__get_balances {
         }
     };
 }
+
+/// Implements Bitcoin Core JSON-RPC API method `setwalletflag`
+#[macro_export]
+macro_rules! impl_client_v19__set_wallet_flag {
+    () => {
+        impl Client {
+            pub fn set_wallet_flag(&self, flag: &str) -> Result<SetWalletFlag> {
+                self.call("setwalletflag", &[into_json(flag)?])
+            }
+        }
+    };
+}

--- a/client/src/client_sync/v20/mod.rs
+++ b/client/src/client_sync/v20/mod.rs
@@ -158,6 +158,7 @@ crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();
+crate::impl_client_v19__set_wallet_flag!();
 crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v17__unload_wallet!();

--- a/client/src/client_sync/v21/mod.rs
+++ b/client/src/client_sync/v21/mod.rs
@@ -160,6 +160,7 @@ crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();
+crate::impl_client_v19__set_wallet_flag!();
 crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -160,6 +160,7 @@ crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();
+crate::impl_client_v19__set_wallet_flag!();
 crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -162,6 +162,7 @@ crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();
+crate::impl_client_v19__set_wallet_flag!();
 crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -159,6 +159,7 @@ crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();
+crate::impl_client_v19__set_wallet_flag!();
 crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -159,6 +159,7 @@ crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();
+crate::impl_client_v19__set_wallet_flag!();
 crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -165,6 +165,7 @@ crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();
+crate::impl_client_v19__set_wallet_flag!();
 crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -161,6 +161,7 @@ crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();
+crate::impl_client_v19__set_wallet_flag!();
 crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -163,6 +163,7 @@ crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();
+crate::impl_client_v19__set_wallet_flag!();
 crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -163,6 +163,7 @@ crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();
+crate::impl_client_v19__set_wallet_flag!();
 crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();

--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -558,6 +558,16 @@ fn wallet__send_to_address__modelled() {
     model.unwrap();
 }
 
+#[cfg(not(feature = "v18_and_below"))]
+#[test]
+fn wallet__set_wallet_flag() {
+    let node = Node::with_wallet(Wallet::Default, &[]);
+
+    let json: SetWalletFlag = node.client.set_wallet_flag("avoid_reuse").expect("setwalletflag");
+    assert_eq!(json.flag_name, "avoid_reuse");
+    assert!(json.flag_state);
+}
+
 #[test]
 fn wallet__sign_message__modelled() {
     let node = Node::with_wallet(Wallet::Default, &[]);

--- a/types/src/v19/mod.rs
+++ b/types/src/v19/mod.rs
@@ -203,7 +203,7 @@
 //! | sethdseed                          | returns nothing |                                        |
 //! | setlabel                           | returns nothing |                                        |
 //! | settxfee                           | returns boolean |                                        |
-//! | setwalletflag                      | version         | TODO                                   |
+//! | setwalletflag                      | version         |                                        |
 //! | signmessage                        | version + model |                                        |
 //! | signrawtransactionwithwallet       | version + model |                                        |
 //! | unloadwallet                       | returns nothing |                                        |
@@ -246,6 +246,7 @@ pub use self::{
     util::GetDescriptorInfo,
     wallet::{
         GetBalances, GetBalancesError, GetBalancesMine, GetBalancesWatchOnly, GetTransaction,
+        SetWalletFlag,
     },
 };
 #[doc(inline)]

--- a/types/src/v19/wallet/mod.rs
+++ b/types/src/v19/wallet/mod.rs
@@ -106,3 +106,23 @@ pub struct GetTransaction {
     /// The decoded transaction (only present when `verbose` is passed). v19 and later only.
     pub decoded: Option<Transaction>,
 }
+
+/// Result of the JSON-RPC method `setwalletflag`.
+///
+/// > setwalletflag "flag" ( value )
+/// >
+/// > Change the state of the given wallet flag for a wallet.
+/// >
+/// > Arguments:
+/// > 1. flag     (string, required) The name of the flag to change. Current available flags: avoid_reuse
+/// > 2. value    (boolean, optional, default=true) The new state.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SetWalletFlag {
+    /// The name of the flag that was modified.
+    pub flag_name: String,
+    /// The new state of the flag.
+    pub flag_state: bool,
+    /// Any warnings associated with the change. (Always optional, but docs only state this from v24).
+    pub warnings: Option<String>,
+}

--- a/types/src/v20/mod.rs
+++ b/types/src/v20/mod.rs
@@ -204,7 +204,7 @@
 //! | sethdseed                          | returns nothing |                                        |
 //! | setlabel                           | returns nothing |                                        |
 //! | settxfee                           | returns boolean |                                        |
-//! | setwalletflag                      | version         | TODO                                   |
+//! | setwalletflag                      | version         |                                        |
 //! | signmessage                        | version + model |                                        |
 //! | signrawtransactionwithwallet       | version + model |                                        |
 //! | unloadwallet                       | returns nothing |                                        |
@@ -287,6 +287,6 @@ pub use crate::{
         GetDescriptorInfo, GetMempoolAncestors, GetMempoolAncestorsVerbose, GetMempoolDescendants,
         GetMempoolDescendantsVerbose, GetMempoolEntry, GetMempoolInfo, GetNetworkInfo, GetPeerInfo,
         GetRpcInfo, MapMempoolEntryError, MempoolEntry, MempoolEntryError, MempoolEntryFees,
-        MempoolEntryFeesError, PeerInfo, Softfork, SoftforkType,
+        MempoolEntryFeesError, PeerInfo, SetWalletFlag, Softfork, SoftforkType,
     },
 };

--- a/types/src/v21/mod.rs
+++ b/types/src/v21/mod.rs
@@ -209,7 +209,7 @@
 //! | sethdseed                          | returns nothing |                                        |
 //! | setlabel                           | returns nothing |                                        |
 //! | settxfee                           | returns boolean |                                        |
-//! | setwalletflag                      | version         | TODO                                   |
+//! | setwalletflag                      | version         |                                        |
 //! | signmessage                        | version + model |                                        |
 //! | signrawtransactionwithwallet       | version + model |                                        |
 //! | unloadwallet                       | returns nothing |                                        |
@@ -292,6 +292,7 @@ pub use crate::{
         GetChainTxStats, GetDescriptorInfo, GetMempoolAncestors, GetMempoolAncestorsVerbose,
         GetMempoolDescendants, GetMempoolDescendantsVerbose, GetRpcInfo, MapMempoolEntryError,
         MempoolEntry, MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, PeerInfo,
+        SetWalletFlag,
     },
     v20::{Banned, CreateMultisig, GetTransaction, GetTransactionDetail, ListBanned, Logging},
 };

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -219,7 +219,7 @@
 //! | sethdseed                          | returns nothing |                                        |
 //! | setlabel                           | returns nothing |                                        |
 //! | settxfee                           | returns boolean |                                        |
-//! | setwalletflag                      | version         | TODO                                   |
+//! | setwalletflag                      | version         |                                        |
 //! | signmessage                        | version + model |                                        |
 //! | signrawtransactionwithwallet       | version + model |                                        |
 //! | unloadwallet                       | returns nothing |                                        |
@@ -302,6 +302,7 @@ pub use crate::{
         GetChainTxStats, GetDescriptorInfo, GetMempoolAncestors, GetMempoolAncestorsVerbose,
         GetMempoolDescendants, GetMempoolDescendantsVerbose, GetRpcInfo, MapMempoolEntryError,
         MempoolEntry, MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, PeerInfo,
+        SetWalletFlag,
     },
     v20::{CreateMultisig, GetTransaction, GetTransactionDetail},
     v21::{

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -212,7 +212,7 @@
 //! | sethdseed                          | returns nothing |                                        |
 //! | setlabel                           | returns nothing |                                        |
 //! | settxfee                           | returns boolean |                                        |
-//! | setwalletflag                      | version         | TODO                                   |
+//! | setwalletflag                      | version         |                                        |
 //! | signmessage                        | version + model |                                        |
 //! | signrawtransactionwithwallet       | version + model |                                        |
 //! | unloadwallet                       | returns nothing |                                        |
@@ -301,8 +301,8 @@ pub use crate::{
         GetBlockFilterError, GetBlockchainInfoError, GetChainTxStats, GetDescriptorInfo,
         GetMempoolAncestors, GetMempoolAncestorsVerbose, GetMempoolDescendants,
         GetMempoolDescendantsVerbose, GetRpcInfo, MapMempoolEntryError, MempoolEntry,
-        MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, PeerInfo, Softfork,
-        SoftforkType,
+        MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, PeerInfo, SetWalletFlag,
+        Softfork, SoftforkType,
     },
     v20::GetTransactionDetail,
     v21::{GetNetworkInfo, UnloadWallet},

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -215,7 +215,7 @@
 //! | sethdseed                          | returns nothing |                                        |
 //! | setlabel                           | returns nothing |                                        |
 //! | settxfee                           | returns boolean |                                        |
-//! | setwalletflag                      | version         | TODO                                   |
+//! | setwalletflag                      | version         |                                        |
 //! | signmessage                        | version + model |                                        |
 //! | signrawtransactionwithwallet       | version + model |                                        |
 //! | simulaterawtransaction             | version + model | TODO                                   |
@@ -302,8 +302,8 @@ pub use crate::{
         GetBlockFilterError, GetBlockchainInfoError, GetChainTxStats, GetDescriptorInfo,
         GetMempoolAncestors, GetMempoolAncestorsVerbose, GetMempoolDescendants,
         GetMempoolDescendantsVerbose, GetRpcInfo, MapMempoolEntryError, MempoolEntry,
-        MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, PeerInfo, Softfork,
-        SoftforkType,
+        MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, PeerInfo, SetWalletFlag,
+        Softfork, SoftforkType,
     },
     v21::{GetNetworkInfo, UnloadWallet},
     v22::{Banned, ListBanned, ScriptPubkey},

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -216,7 +216,7 @@
 //! | sethdseed                          | returns nothing |                                        |
 //! | setlabel                           | returns nothing |                                        |
 //! | settxfee                           | returns boolean |                                        |
-//! | setwalletflag                      | version         | TODO                                   |
+//! | setwalletflag                      | version         |                                        |
 //! | signmessage                        | version + model |                                        |
 //! | signrawtransactionwithwallet       | version + model |                                        |
 //! | simulaterawtransaction             | version + model | TODO                                   |
@@ -295,8 +295,8 @@ pub use crate::{
         GetBlockFilterError, GetBlockchainInfoError, GetChainTxStats, GetDescriptorInfo,
         GetMempoolAncestors, GetMempoolAncestorsVerbose, GetMempoolDescendants,
         GetMempoolDescendantsVerbose, GetRpcInfo, MapMempoolEntryError, MempoolEntry,
-        MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, PeerInfo, Softfork,
-        SoftforkType,
+        MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, PeerInfo, SetWalletFlag,
+        Softfork, SoftforkType,
     },
     v21::GetNetworkInfo,
     v22::{Banned, ListBanned, ScriptPubkey},

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -224,7 +224,7 @@
 //! | sethdseed                          | returns nothing |                                        |
 //! | setlabel                           | returns nothing |                                        |
 //! | settxfee                           | returns boolean |                                        |
-//! | setwalletflag                      | version         | TODO                                   |
+//! | setwalletflag                      | version         |                                        |
 //! | signmessage                        | version + model |                                        |
 //! | signrawtransactionwithwallet       | version + model |                                        |
 //! | simulaterawtransaction             | version + model | TODO                                   |
@@ -316,7 +316,7 @@ pub use crate::{
         GetChainTxStats, GetDescriptorInfo, GetMempoolAncestors, GetMempoolAncestorsVerbose,
         GetMempoolDescendants, GetMempoolDescendantsVerbose, GetRpcInfo, MapMempoolEntryError,
         MempoolEntry, MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, PeerInfo,
-        Softfork, SoftforkType,
+        SetWalletFlag, Softfork, SoftforkType,
     },
     v21::GetNetworkInfo,
     v22::{Banned, ListBanned, ScriptPubkey},

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -224,7 +224,7 @@
 //! | sethdseed                          | returns nothing |                                        |
 //! | setlabel                           | returns nothing |                                        |
 //! | settxfee                           | returns boolean |                                        |
-//! | setwalletflag                      | version         | TODO                                   |
+//! | setwalletflag                      | version         |                                        |
 //! | signmessage                        | version + model |                                        |
 //! | signrawtransactionwithwallet       | version + model |                                        |
 //! | simulaterawtransaction             | version + model | TODO                                   |
@@ -293,7 +293,7 @@ pub use crate::{
         GetChainTxStats, GetDescriptorInfo, GetMempoolAncestors, GetMempoolAncestorsVerbose,
         GetMempoolDescendants, GetMempoolDescendantsVerbose, GetRpcInfo, MapMempoolEntryError,
         MempoolEntry, MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, PeerInfo,
-        Softfork, SoftforkType,
+        SetWalletFlag, Softfork, SoftforkType,
     },
     v21::GetNetworkInfo,
     v22::{Banned, ListBanned, ScriptPubkey},

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -226,7 +226,7 @@
 //! | sethdseed                          | returns nothing |                                        |
 //! | setlabel                           | returns nothing |                                        |
 //! | settxfee                           | returns boolean |                                        |
-//! | setwalletflag                      | version         | TODO                                   |
+//! | setwalletflag                      | version         |                                        |
 //! | signmessage                        | version + model |                                        |
 //! | signrawtransactionwithwallet       | version + model |                                        |
 //! | simulaterawtransaction             | version + model | TODO                                   |
@@ -314,7 +314,7 @@ pub use crate::{
         GetChainTxStats, GetDescriptorInfo, GetMempoolAncestors, GetMempoolAncestorsVerbose,
         GetMempoolDescendants, GetMempoolDescendantsVerbose, GetRpcInfo, MapMempoolEntryError,
         MempoolEntry, MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, PeerInfo,
-        Softfork, SoftforkType,
+        SetWalletFlag, Softfork, SoftforkType,
     },
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, SaveMempool},

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -227,7 +227,7 @@
 //! | sethdseed                          | returns nothing |                                        |
 //! | setlabel                           | returns nothing |                                        |
 //! | settxfee                           | returns boolean |                                        |
-//! | setwalletflag                      | version         | TODO                                   |
+//! | setwalletflag                      | version         |                                        |
 //! | signmessage                        | version + model |                                        |
 //! | signrawtransactionwithwallet       | version + model |                                        |
 //! | simulaterawtransaction             | version + model | TODO                                   |
@@ -311,8 +311,8 @@ pub use crate::{
         GetBalancesWatchOnly, GetBlockFilter, GetBlockFilterError, GetChainTxStats,
         GetMempoolAncestors, GetMempoolAncestorsVerbose, GetMempoolDescendants,
         GetMempoolDescendantsVerbose, GetRpcInfo, MapMempoolEntryError, MempoolEntry,
-        MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, PeerInfo, Softfork,
-        SoftforkType,
+        MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, PeerInfo, SetWalletFlag,
+        Softfork, SoftforkType,
     },
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, SaveMempool},

--- a/verify/src/method/v19.rs
+++ b/verify/src/method/v19.rs
@@ -147,7 +147,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("sethdseed", "set_hd_seed"),
     Method::new_nothing("setlabel", "set_label"),
     Method::new_bool("settxfee", "set_tx_fee"),
-    Method::new_modelled("setwalletflag", "SetWalletFlag", "set_wallet_flag"),
+    Method::new_no_model("setwalletflag", "SetWalletFlag", "set_wallet_flag"),
     Method::new_modelled("signmessage", "SignMessage", "sign_message"),
     Method::new_modelled(
         "signrawtransactionwithwallet",

--- a/verify/src/method/v20.rs
+++ b/verify/src/method/v20.rs
@@ -148,7 +148,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("sethdseed", "set_hd_seed"),
     Method::new_nothing("setlabel", "set_label"),
     Method::new_bool("settxfee", "set_tx_fee"),
-    Method::new_modelled("setwalletflag", "SetWalletFlag", "set_wallet_flag"),
+    Method::new_no_model("setwalletflag", "SetWalletFlag", "set_wallet_flag"),
     Method::new_modelled("signmessage", "SignMessage", "sign_message"),
     Method::new_modelled(
         "signrawtransactionwithwallet",

--- a/verify/src/method/v21.rs
+++ b/verify/src/method/v21.rs
@@ -153,7 +153,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("sethdseed", "set_hd_seed"),
     Method::new_nothing("setlabel", "set_label"),
     Method::new_bool("settxfee", "set_tx_fee"),
-    Method::new_modelled("setwalletflag", "SetWalletFlag", "set_wallet_flag"),
+    Method::new_no_model("setwalletflag", "SetWalletFlag", "set_wallet_flag"),
     Method::new_modelled("signmessage", "SignMessage", "sign_message"),
     Method::new_modelled(
         "signrawtransactionwithwallet",

--- a/verify/src/method/v22.rs
+++ b/verify/src/method/v22.rs
@@ -156,7 +156,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("sethdseed", "set_hd_seed"),
     Method::new_nothing("setlabel", "set_label"),
     Method::new_bool("settxfee", "set_tx_fee"),
-    Method::new_modelled("setwalletflag", "SetWalletFlag", "set_wallet_flag"),
+    Method::new_no_model("setwalletflag", "SetWalletFlag", "set_wallet_flag"),
     Method::new_modelled("signmessage", "SignMessage", "sign_message"),
     Method::new_modelled(
         "signrawtransactionwithwallet",

--- a/verify/src/method/v23.rs
+++ b/verify/src/method/v23.rs
@@ -154,7 +154,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("sethdseed", "set_hd_seed"),
     Method::new_nothing("setlabel", "set_label"),
     Method::new_bool("settxfee", "set_tx_fee"),
-    Method::new_modelled("setwalletflag", "SetWalletFlag", "set_wallet_flag"),
+    Method::new_no_model("setwalletflag", "SetWalletFlag", "set_wallet_flag"),
     Method::new_modelled("signmessage", "SignMessage", "sign_message"),
     Method::new_modelled(
         "signrawtransactionwithwallet",

--- a/verify/src/method/v24.rs
+++ b/verify/src/method/v24.rs
@@ -157,7 +157,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("sethdseed", "set_hd_seed"),
     Method::new_nothing("setlabel", "set_label"),
     Method::new_bool("settxfee", "set_tx_fee"),
-    Method::new_modelled("setwalletflag", "SetWalletFlag", "set_wallet_flag"),
+    Method::new_no_model("setwalletflag", "SetWalletFlag", "set_wallet_flag"),
     Method::new_modelled("signmessage", "SignMessage", "sign_message"),
     Method::new_modelled(
         "signrawtransactionwithwallet",

--- a/verify/src/method/v25.rs
+++ b/verify/src/method/v25.rs
@@ -158,7 +158,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("sethdseed", "set_hd_seed"),
     Method::new_nothing("setlabel", "set_label"),
     Method::new_bool("settxfee", "set_tx_fee"),
-    Method::new_modelled("setwalletflag", "SetWalletFlag", "set_wallet_flag"),
+    Method::new_no_model("setwalletflag", "SetWalletFlag", "set_wallet_flag"),
     Method::new_modelled("signmessage", "SignMessage", "sign_message"),
     Method::new_modelled(
         "signrawtransactionwithwallet",

--- a/verify/src/method/v26.rs
+++ b/verify/src/method/v26.rs
@@ -165,7 +165,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("sethdseed", "set_hd_seed"),
     Method::new_nothing("setlabel", "set_label"),
     Method::new_bool("settxfee", "set_tx_fee"),
-    Method::new_modelled("setwalletflag", "SetWalletFlag", "set_wallet_flag"),
+    Method::new_no_model("setwalletflag", "SetWalletFlag", "set_wallet_flag"),
     Method::new_modelled("signmessage", "SignMessage", "sign_message"),
     Method::new_modelled(
         "signrawtransactionwithwallet",

--- a/verify/src/method/v27.rs
+++ b/verify/src/method/v27.rs
@@ -168,7 +168,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("sethdseed", "set_hd_seed"),
     Method::new_nothing("setlabel", "set_label"),
     Method::new_bool("settxfee", "set_tx_fee"),
-    Method::new_modelled("setwalletflag", "SetWalletFlag", "set_wallet_flag"),
+    Method::new_no_model("setwalletflag", "SetWalletFlag", "set_wallet_flag"),
     Method::new_modelled("signmessage", "SignMessage", "sign_message"),
     Method::new_modelled(
         "signrawtransactionwithwallet",

--- a/verify/src/method/v28.rs
+++ b/verify/src/method/v28.rs
@@ -170,7 +170,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("sethdseed", "set_hd_seed"),
     Method::new_nothing("setlabel", "set_label"),
     Method::new_bool("settxfee", "set_tx_fee"),
-    Method::new_modelled("setwalletflag", "SetWalletFlag", "set_wallet_flag"),
+    Method::new_no_model("setwalletflag", "SetWalletFlag", "set_wallet_flag"),
     Method::new_modelled("signmessage", "SignMessage", "sign_message"),
     Method::new_modelled(
         "signrawtransactionwithwallet",

--- a/verify/src/method/v29.rs
+++ b/verify/src/method/v29.rs
@@ -171,7 +171,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("sethdseed", "set_hd_seed"),
     Method::new_nothing("setlabel", "set_label"),
     Method::new_bool("settxfee", "set_tx_fee"),
-    Method::new_modelled("setwalletflag", "SetWalletFlag", "set_wallet_flag"),
+    Method::new_no_model("setwalletflag", "SetWalletFlag", "set_wallet_flag"),
     Method::new_modelled("signmessage", "SignMessage", "sign_message"),
     Method::new_modelled(
         "signrawtransactionwithwallet",


### PR DESCRIPTION
Add the type to v19, client macro, test and reexports. There are no changes to the RPC up to v29.

Update verify to `new_no_model`.

Remove `TODO` from types table.