### PR TITLE
Implement walletlock method and test

### DIFF
--- a/client/src/client_sync/v17/mod.rs
+++ b/client/src/client_sync/v17/mod.rs
@@ -153,6 +153,7 @@ crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v17__unload_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
+crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_process_psbt!();
 
 /// Argument to the `Client::get_new_address_with_type` function.

--- a/client/src/client_sync/v17/wallet.rs
+++ b/client/src/client_sync/v17/wallet.rs
@@ -669,6 +669,22 @@ macro_rules! impl_client_v17__wallet_create_funded_psbt {
     };
 }
 
+/// Implements Bitcoin Core JSON-RPC API method `walletlock`.
+#[macro_export]
+macro_rules! impl_client_v17__wallet_lock {
+    () => {
+        impl Client {
+            pub fn wallet_lock(&self) -> Result<()> {
+                match self.call("walletlock", &[]) {
+                    Ok(serde_json::Value::Null) => Ok(()),
+                    Ok(res) => Err(Error::Returned(res.to_string())),
+                    Err(err) => Err(err.into()),
+                }
+            }
+        }
+    };
+}
+
 /// Implements Bitcoin Core JSON-RPC API method `walletprocesspsbt`.
 #[macro_export]
 macro_rules! impl_client_v17__wallet_process_psbt {

--- a/client/src/client_sync/v18/mod.rs
+++ b/client/src/client_sync/v18/mod.rs
@@ -170,4 +170,5 @@ crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v17__unload_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
+crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v19/mod.rs
+++ b/client/src/client_sync/v19/mod.rs
@@ -167,4 +167,5 @@ crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v17__unload_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
+crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v20/mod.rs
+++ b/client/src/client_sync/v20/mod.rs
@@ -167,4 +167,5 @@ crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v17__unload_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
+crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v21/mod.rs
+++ b/client/src/client_sync/v21/mod.rs
@@ -167,4 +167,5 @@ crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
+crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -167,4 +167,5 @@ crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
+crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -169,6 +169,7 @@ crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
+crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_process_psbt!();
 
 /// Argument to the `Client::get_new_address_with_type` function.

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -166,4 +166,5 @@ crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
+crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -166,4 +166,5 @@ crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
+crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -172,4 +172,5 @@ crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
+crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -168,4 +168,5 @@ crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
+crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -170,4 +170,5 @@ crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
+crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -170,6 +170,7 @@ crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
+crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_process_psbt!();
 
 /// Arg for the `getblocktemplate` method. (v29+).

--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -603,6 +603,16 @@ fn wallet__sign_message__modelled() {
     let _ = res.expect("SignMessage into model");
 }
 
+#[test]
+fn wallet__wallet_lock() {
+    let node = Node::with_wallet(Wallet::Default, &[]);
+
+    node.client.create_wallet("wallet_name").expect("createwallet");
+    node.client.encrypt_wallet("passphrase").expect("encryptwallet");
+
+    let _: () = node.client.wallet_lock().expect("walletlock");
+}
+
 fn create_load_unload_wallet() {
     let node = Node::with_wallet(Wallet::None, &[]);
 


### PR DESCRIPTION
The JSON-RPC method `walletlock` does not return anything. We want to test this to catch any changes in behavior in future Core versions.

This PR adds a client function that errors if the return value is anything other than `null`, along with an integration test that calls this function.

Ref: [#116](https://github.com/rust-bitcoin/corepc/pull/116)