### PR TITLE
Implement walletpassphrase method and test

### DIFF
--- a/client/src/client_sync/v17/mod.rs
+++ b/client/src/client_sync/v17/mod.rs
@@ -155,6 +155,7 @@ crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v17__unload_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
+crate::impl_client_v17__wallet_passphrase!();
 crate::impl_client_v17__wallet_process_psbt!();
 
 /// Argument to the `Client::get_new_address_with_type` function.

--- a/client/src/client_sync/v17/wallet.rs
+++ b/client/src/client_sync/v17/wallet.rs
@@ -666,6 +666,22 @@ macro_rules! impl_client_v17__unload_wallet {
     };
 }
 
+/// Implements Bitcoin Core JSON-RPC API method `walletpassphrase`
+#[macro_export]
+macro_rules! impl_client_v17__wallet_passphrase {
+    () => {
+        impl Client {
+            pub fn wallet_passphrase(&self, passphrase: &str, timeout: u64) -> Result<()> {
+                match self.call("walletpassphrase", &[passphrase.into(), timeout.into()]) {
+                    Ok(serde_json::Value::Null) => Ok(()),
+                    Ok(res) => Err(Error::Returned(res.to_string())),
+                    Err(err) => Err(err.into()),
+                }
+            }
+        }
+    };
+}
+
 /// Implements Bitcoin Core JSON-RPC API method `walletcreatefundedpsbt`.
 #[macro_export]
 macro_rules! impl_client_v17__wallet_create_funded_psbt {

--- a/client/src/client_sync/v18/mod.rs
+++ b/client/src/client_sync/v18/mod.rs
@@ -172,4 +172,5 @@ crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v17__unload_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
+crate::impl_client_v17__wallet_passphrase!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v19/mod.rs
+++ b/client/src/client_sync/v19/mod.rs
@@ -169,4 +169,5 @@ crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v17__unload_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
+crate::impl_client_v17__wallet_passphrase!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v20/mod.rs
+++ b/client/src/client_sync/v20/mod.rs
@@ -169,4 +169,5 @@ crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v17__unload_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
+crate::impl_client_v17__wallet_passphrase!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v21/mod.rs
+++ b/client/src/client_sync/v21/mod.rs
@@ -169,4 +169,5 @@ crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
+crate::impl_client_v17__wallet_passphrase!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -169,4 +169,5 @@ crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
+crate::impl_client_v17__wallet_passphrase!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -171,6 +171,7 @@ crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
+crate::impl_client_v17__wallet_passphrase!();
 crate::impl_client_v17__wallet_process_psbt!();
 
 /// Argument to the `Client::get_new_address_with_type` function.

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -168,4 +168,5 @@ crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
+crate::impl_client_v17__wallet_passphrase!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -168,4 +168,5 @@ crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
+crate::impl_client_v17__wallet_passphrase!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -174,4 +174,5 @@ crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
+crate::impl_client_v17__wallet_passphrase!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -170,4 +170,5 @@ crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
+crate::impl_client_v17__wallet_passphrase!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -172,4 +172,5 @@ crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
+crate::impl_client_v17__wallet_passphrase!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -172,6 +172,7 @@ crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
+crate::impl_client_v17__wallet_passphrase!();
 crate::impl_client_v17__wallet_process_psbt!();
 
 /// Arg for the `getblocktemplate` method. (v29+).

--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -622,6 +622,17 @@ fn wallet__wallet_lock() {
     let _: () = node.client.wallet_lock().expect("walletlock");
 }
 
+#[test]
+fn wallet__wallet_passphrase() {
+    let node = Node::with_wallet(Wallet::Default, &[]);
+
+    node.client.create_wallet("wallet_name").expect("createwallet");
+    node.client.encrypt_wallet("passphrase").expect("encryptwallet");
+
+    let timeout = 60u64;
+    let _: () = node.client.wallet_passphrase("passphrase", timeout).expect("walletpassphrase");
+}
+
 fn create_load_unload_wallet() {
     let node = Node::with_wallet(Wallet::None, &[]);
 


### PR DESCRIPTION
The JSON-RPC method `walletpassphrase` does not return anything. We want to test this to catch any changes in behavior in future Core versions.

This PR adds a client function that errors if the return value is anything other than `null`, along with an integration test that calls this function.

Ref: [#116](https://github.com/rust-bitcoin/corepc/pull/116)