### PR TITLE
Implement walletpassphrasechange method and test

### DIFF
--- a/client/src/client_sync/v17/mod.rs
+++ b/client/src/client_sync/v17/mod.rs
@@ -156,6 +156,7 @@ crate::impl_client_v17__unload_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_passphrase!();
+crate::impl_client_v17__wallet_passphrase_change!();
 crate::impl_client_v17__wallet_process_psbt!();
 
 /// Argument to the `Client::get_new_address_with_type` function.

--- a/client/src/client_sync/v17/wallet.rs
+++ b/client/src/client_sync/v17/wallet.rs
@@ -714,6 +714,28 @@ macro_rules! impl_client_v17__wallet_lock {
     };
 }
 
+/// Implements Bitcoin Core JSON-RPC API method `walletpassphrasechange`
+#[macro_export]
+macro_rules! impl_client_v17__wallet_passphrase_change {
+    () => {
+        impl Client {
+            pub fn wallet_passphrase_change(
+                &self,
+                old_passphrase: &str,
+                new_passphrase: &str,
+            ) -> Result<()> {
+                match self
+                    .call("walletpassphrasechange", &[old_passphrase.into(), new_passphrase.into()])
+                {
+                    Ok(serde_json::Value::Null) => Ok(()),
+                    Ok(res) => Err(Error::Returned(res.to_string())),
+                    Err(err) => Err(err.into()),
+                }
+            }
+        }
+    };
+}
+
 /// Implements Bitcoin Core JSON-RPC API method `walletprocesspsbt`.
 #[macro_export]
 macro_rules! impl_client_v17__wallet_process_psbt {

--- a/client/src/client_sync/v18/mod.rs
+++ b/client/src/client_sync/v18/mod.rs
@@ -173,4 +173,5 @@ crate::impl_client_v17__unload_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_passphrase!();
+crate::impl_client_v17__wallet_passphrase_change!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v19/mod.rs
+++ b/client/src/client_sync/v19/mod.rs
@@ -170,4 +170,5 @@ crate::impl_client_v17__unload_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_passphrase!();
+crate::impl_client_v17__wallet_passphrase_change!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v20/mod.rs
+++ b/client/src/client_sync/v20/mod.rs
@@ -170,4 +170,5 @@ crate::impl_client_v17__unload_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_passphrase!();
+crate::impl_client_v17__wallet_passphrase_change!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v21/mod.rs
+++ b/client/src/client_sync/v21/mod.rs
@@ -180,6 +180,7 @@ crate::impl_client_v21__upgrade_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_passphrase!();
+crate::impl_client_v17__wallet_passphrase_change!();
 crate::impl_client_v17__wallet_process_psbt!();
 
 /// Request object for the `importdescriptors` method.

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -178,4 +178,5 @@ crate::impl_client_v21__upgrade_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_passphrase!();
+crate::impl_client_v17__wallet_passphrase_change!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -180,6 +180,7 @@ crate::impl_client_v21__upgrade_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_passphrase!();
+crate::impl_client_v17__wallet_passphrase_change!();
 crate::impl_client_v17__wallet_process_psbt!();
 
 /// Argument to the `Client::get_new_address_with_type` function.

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -177,4 +177,5 @@ crate::impl_client_v21__upgrade_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_passphrase!();
+crate::impl_client_v17__wallet_passphrase_change!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -179,4 +179,5 @@ crate::impl_client_v21__upgrade_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_passphrase!();
+crate::impl_client_v17__wallet_passphrase_change!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -183,4 +183,5 @@ crate::impl_client_v21__upgrade_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_passphrase!();
+crate::impl_client_v17__wallet_passphrase_change!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -179,4 +179,5 @@ crate::impl_client_v21__upgrade_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_passphrase!();
+crate::impl_client_v17__wallet_passphrase_change!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -181,4 +181,5 @@ crate::impl_client_v21__upgrade_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_passphrase!();
+crate::impl_client_v17__wallet_passphrase_change!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -181,6 +181,7 @@ crate::impl_client_v21__upgrade_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_passphrase!();
+crate::impl_client_v17__wallet_passphrase_change!();
 crate::impl_client_v17__wallet_process_psbt!();
 
 /// Arg for the `getblocktemplate` method. (v29+).

--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -689,6 +689,17 @@ fn wallet__wallet_passphrase() {
     let _: () = node.client.wallet_passphrase("passphrase", timeout).expect("walletpassphrase");
 }
 
+#[test]
+fn wallet__wallet_passphrase_change() {
+    let node = Node::with_wallet(Wallet::Default, &[]);
+
+    node.client.create_wallet("wallet name").expect("createwallet");
+    node.client.encrypt_wallet("old passphrase").expect("encryptwallet");
+
+    let _: () = node.client.wallet_passphrase_change("old passphrase", "new passphrase")
+        .expect("walletpassphrasechange");
+}
+
 fn create_load_unload_wallet() {
     let node = Node::with_wallet(Wallet::None, &[]);
 


### PR DESCRIPTION
The JSON-RPC method `walletpassphrasechange` does not return anything. We want to test this to catch any changes in behavior in future Core versions.

This PR adds a client function that errors if the return value is anything other than `null`, along with an integration test that calls this function.

Ref: [#116](https://github.com/rust-bitcoin/corepc/pull/116)