### PR TITLE
Address all `TODO` in v21

### DIFF
--- a/client/src/client_sync/v21/generating.rs
+++ b/client/src/client_sync/v21/generating.rs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Macros for implementing JSON-RPC methods on a client.
+//!
+//! Specifically this is methods found under the `== Generating ==` section of the
+//! API docs of Bitcoin Core `v0.21`.
+//!
+//! All macros require `Client` to be in scope.
+//!
+//! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
+
+/// Implements Bitcoin Core JSON-RPC API method `generateblock`
+#[macro_export]
+macro_rules! impl_client_v21__generate_block {
+    () => {
+        impl Client {
+            pub fn generate_block(
+                &self,
+                output: &str,
+                transactions: &[String],
+            ) -> Result<GenerateBlock> {
+                self.call("generateblock", &[into_json(output)?, into_json(transactions)?])
+            }
+        }
+    };
+}

--- a/client/src/client_sync/v21/mod.rs
+++ b/client/src/client_sync/v21/mod.rs
@@ -128,6 +128,7 @@ crate::impl_client_v17__add_multisig_address!();
 crate::impl_client_v17__backup_wallet!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v17__create_wallet!();
+crate::impl_client_v21__create_wallet_with_descriptors!();
 crate::impl_client_v17__dump_priv_key!();
 crate::impl_client_v17__dump_wallet!();
 crate::impl_client_v17__encrypt_wallet!();

--- a/client/src/client_sync/v21/mod.rs
+++ b/client/src/client_sync/v21/mod.rs
@@ -13,6 +13,7 @@ use std::path::Path;
 
 use bitcoin::address::{Address, NetworkChecked};
 use bitcoin::{sign_message, Amount, Block, BlockHash, PublicKey, Txid};
+use serde::{Deserialize, Serialize};
 
 use crate::client_sync::into_json;
 use crate::types::v21::*;
@@ -144,6 +145,7 @@ crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
+crate::impl_client_v21__import_descriptors!();
 crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();
@@ -175,3 +177,13 @@ crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_process_psbt!();
+
+/// Request object for the `importdescriptors` method.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ImportDescriptorsRequest {
+    /// Descriptor to import.
+    pub desc: String,
+    /// Time from which to start rescanning the blockchain for this descriptor, in UNIX epoch time or "now".
+    pub timestamp: serde_json::Value,
+}

--- a/client/src/client_sync/v21/mod.rs
+++ b/client/src/client_sync/v21/mod.rs
@@ -176,6 +176,7 @@ crate::impl_client_v19__set_wallet_flag!();
 crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
+crate::impl_client_v21__upgrade_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v21/mod.rs
+++ b/client/src/client_sync/v21/mod.rs
@@ -5,6 +5,7 @@
 //! We ignore option arguments unless they effect the shape of the returned JSON data.
 
 mod generating;
+mod util;
 mod wallet;
 
 use std::collections::BTreeMap;
@@ -115,6 +116,7 @@ crate::impl_client_v17__create_multisig!();
 crate::impl_client_v18__derive_addresses!();
 crate::impl_client_v17__estimate_smart_fee!();
 crate::impl_client_v18__get_descriptor_info!();
+crate::impl_client_v21__get_index_info!();
 crate::impl_client_v17__sign_message_with_priv_key!();
 crate::impl_client_v17__validate_address!();
 crate::impl_client_v17__verify_message!();

--- a/client/src/client_sync/v21/mod.rs
+++ b/client/src/client_sync/v21/mod.rs
@@ -164,6 +164,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v17__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v21__psbt_bump_fee!();
 crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v21__send!();

--- a/client/src/client_sync/v21/mod.rs
+++ b/client/src/client_sync/v21/mod.rs
@@ -4,6 +4,7 @@
 //!
 //! We ignore option arguments unless they effect the shape of the returned JSON data.
 
+mod generating;
 mod wallet;
 
 use std::collections::BTreeMap;
@@ -61,6 +62,7 @@ crate::impl_client_v17__stop!();
 crate::impl_client_v17__uptime!();
 
 // == Generating ==
+crate::impl_client_v21__generate_block!();
 crate::impl_client_v17__generate_to_address!();
 crate::impl_client_v20__generate_to_descriptor!();
 crate::impl_client_v17__invalidate_block!();

--- a/client/src/client_sync/v21/mod.rs
+++ b/client/src/client_sync/v21/mod.rs
@@ -166,6 +166,7 @@ crate::impl_client_v17__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
 crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
+crate::impl_client_v21__send!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();
 crate::impl_client_v17__set_hd_seed!();

--- a/client/src/client_sync/v21/util.rs
+++ b/client/src/client_sync/v21/util.rs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Macros for implementing JSON-RPC methods on a client.
+//!
+//! Specifically this is methods found under the `== Util ==` section of the
+//! API docs of Bitcoin Core `v0.21`.
+//!
+//! All macros require `Client` to be in scope.
+//!
+//! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
+
+/// Implements Bitcoin Core JSON-RPC API method `getindexinfo`.
+#[macro_export]
+macro_rules! impl_client_v21__get_index_info {
+    () => {
+        impl Client {
+            pub fn get_index_info(&self) -> Result<GetIndexInfo> { self.call("getindexinfo", &[]) }
+        }
+    };
+}

--- a/client/src/client_sync/v21/wallet.rs
+++ b/client/src/client_sync/v21/wallet.rs
@@ -30,6 +30,21 @@ macro_rules! impl_client_v21__create_wallet_with_descriptors {
     };
 }
 
+/// Implements Bitcoin Core JSON-RPC API method `importdescriptors`
+#[macro_export]
+macro_rules! impl_client_v21__import_descriptors {
+    () => {
+        impl Client {
+            pub fn import_descriptors(
+                &self,
+                requests: &[ImportDescriptorsRequest],
+            ) -> Result<ImportDescriptors> {
+                self.call("importdescriptors", &[into_json(requests)?])
+            }
+        }
+    };
+}
+
 /// Implements Bitcoin Core JSON-RPC API method `unloadwallet`
 #[macro_export]
 macro_rules! impl_client_v21__unload_wallet {

--- a/client/src/client_sync/v21/wallet.rs
+++ b/client/src/client_sync/v21/wallet.rs
@@ -45,6 +45,18 @@ macro_rules! impl_client_v21__import_descriptors {
     };
 }
 
+/// Implements Bitcoin Core JSON-RPC API method `send`.
+#[macro_export]
+macro_rules! impl_client_v21__send {
+    () => {
+        impl Client {
+            pub fn send(&self, outputs: &BTreeMap<String, f64>) -> Result<Send> {
+                self.call("send", &[into_json(outputs)?])
+            }
+        }
+    };
+}
+
 /// Implements Bitcoin Core JSON-RPC API method `unloadwallet`
 #[macro_export]
 macro_rules! impl_client_v21__unload_wallet {

--- a/client/src/client_sync/v21/wallet.rs
+++ b/client/src/client_sync/v21/wallet.rs
@@ -9,6 +9,27 @@
 //!
 //! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
 
+/// Implements Bitcoin Core JSON-RPC API method `createwallet` with descriptors=true (descriptor wallet)
+#[macro_export]
+macro_rules! impl_client_v21__create_wallet_with_descriptors {
+    () => {
+        impl Client {
+            pub fn create_wallet_with_descriptors(&self, wallet: &str) -> Result<CreateWallet> {
+                let args = [
+                    wallet.into(),
+                    false.into(),            // disable_private_keys
+                    false.into(),            // blank
+                    serde_json::Value::Null, // passphrase
+                    false.into(),            // avoid_reuse
+                    true.into(),             // descriptors=true
+                    serde_json::Value::Null, // load_on_startup
+                ];
+                self.call("createwallet", &args)
+            }
+        }
+    };
+}
+
 /// Implements Bitcoin Core JSON-RPC API method `unloadwallet`
 #[macro_export]
 macro_rules! impl_client_v21__unload_wallet {

--- a/client/src/client_sync/v21/wallet.rs
+++ b/client/src/client_sync/v21/wallet.rs
@@ -80,3 +80,15 @@ macro_rules! impl_client_v21__unload_wallet {
         }
     };
 }
+
+/// Implements Bitcoin Core JSON-RPC API method `upgradewallet`.
+#[macro_export]
+macro_rules! impl_client_v21__upgrade_wallet {
+    () => {
+        impl Client {
+            pub fn upgrade_wallet(&self) -> Result<UpgradeWallet> {
+                self.call("upgradewallet", &[])
+            }
+        }
+    };
+}

--- a/client/src/client_sync/v21/wallet.rs
+++ b/client/src/client_sync/v21/wallet.rs
@@ -45,6 +45,18 @@ macro_rules! impl_client_v21__import_descriptors {
     };
 }
 
+/// Implements Bitcoin Core JSON-RPC API method `psbtbumpfee`.
+#[macro_export]
+macro_rules! impl_client_v21__psbt_bump_fee {
+    () => {
+        impl Client {
+            pub fn psbt_bump_fee(&self, txid: &bitcoin::Txid) -> Result<PsbtBumpFee> {
+                self.call("psbtbumpfee", &[into_json(txid)?])
+            }
+        }
+    };
+}
+
 /// Implements Bitcoin Core JSON-RPC API method `send`.
 #[macro_export]
 macro_rules! impl_client_v21__send {

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -114,6 +114,7 @@ crate::impl_client_v17__create_multisig!();
 crate::impl_client_v18__derive_addresses!();
 crate::impl_client_v17__estimate_smart_fee!();
 crate::impl_client_v18__get_descriptor_info!();
+crate::impl_client_v21__get_index_info!();
 crate::impl_client_v17__sign_message_with_priv_key!();
 crate::impl_client_v17__validate_address!();
 crate::impl_client_v17__verify_message!();

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -162,6 +162,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v17__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v21__psbt_bump_fee!();
 crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v21__send!();

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -21,6 +21,7 @@ pub use crate::client_sync::{
         AddNodeCommand, AddressType, ImportMultiRequest, ImportMultiScriptPubKey, ImportMultiTimestamp, Input, Output, SetBanCommand, TemplateRequest,
         TemplateRules, WalletCreateFundedPsbtInput,
     },
+    v21::ImportDescriptorsRequest,
 };
 
 crate::define_jsonrpc_minreq_client!("v22");
@@ -142,6 +143,7 @@ crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
+crate::impl_client_v21__import_descriptors!();
 crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -126,6 +126,7 @@ crate::impl_client_v17__add_multisig_address!();
 crate::impl_client_v17__backup_wallet!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v17__create_wallet!();
+crate::impl_client_v21__create_wallet_with_descriptors!();
 crate::impl_client_v17__dump_priv_key!();
 crate::impl_client_v17__dump_wallet!();
 crate::impl_client_v17__encrypt_wallet!();

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -61,6 +61,7 @@ crate::impl_client_v17__stop!();
 crate::impl_client_v17__uptime!();
 
 // == Generating ==
+crate::impl_client_v21__generate_block!();
 crate::impl_client_v17__generate_to_address!();
 crate::impl_client_v20__generate_to_descriptor!();
 crate::impl_client_v17__invalidate_block!();

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -174,6 +174,7 @@ crate::impl_client_v19__set_wallet_flag!();
 crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
+crate::impl_client_v21__upgrade_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -164,6 +164,7 @@ crate::impl_client_v17__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
 crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
+crate::impl_client_v21__send!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();
 crate::impl_client_v17__set_hd_seed!();

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -128,6 +128,7 @@ crate::impl_client_v17__add_multisig_address!();
 crate::impl_client_v17__backup_wallet!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v23__create_wallet!();
+crate::impl_client_v21__create_wallet_with_descriptors!();
 crate::impl_client_v17__dump_priv_key!();
 crate::impl_client_v17__dump_wallet!();
 crate::impl_client_v17__encrypt_wallet!();

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -176,6 +176,7 @@ crate::impl_client_v19__set_wallet_flag!();
 crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
+crate::impl_client_v21__upgrade_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -166,6 +166,7 @@ crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
 crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
+crate::impl_client_v21__send!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();
 crate::impl_client_v17__set_hd_seed!();

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -23,6 +23,7 @@ pub use crate::client_sync::{
         AddNodeCommand, ImportMultiRequest, ImportMultiScriptPubKey, ImportMultiTimestamp, Input, Output, SetBanCommand, TemplateRequest, TemplateRules,
         WalletCreateFundedPsbtInput,
     },
+    v21::ImportDescriptorsRequest,
 };
 
 crate::define_jsonrpc_minreq_client!("v23");
@@ -144,6 +145,7 @@ crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
+crate::impl_client_v21__import_descriptors!();
 crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -116,6 +116,7 @@ crate::impl_client_v17__create_multisig!();
 crate::impl_client_v18__derive_addresses!();
 crate::impl_client_v17__estimate_smart_fee!();
 crate::impl_client_v18__get_descriptor_info!();
+crate::impl_client_v21__get_index_info!();
 crate::impl_client_v17__sign_message_with_priv_key!();
 crate::impl_client_v17__validate_address!();
 crate::impl_client_v17__verify_message!();

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -164,6 +164,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v21__psbt_bump_fee!();
 crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v21__send!();

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -63,6 +63,7 @@ crate::impl_client_v17__stop!();
 crate::impl_client_v17__uptime!();
 
 // == Generating ==
+crate::impl_client_v21__generate_block!();
 crate::impl_client_v17__generate_to_address!();
 crate::impl_client_v20__generate_to_descriptor!();
 crate::impl_client_v17__invalidate_block!();

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -173,6 +173,7 @@ crate::impl_client_v19__set_wallet_flag!();
 crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
+crate::impl_client_v21__upgrade_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -161,6 +161,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v21__psbt_bump_fee!();
 crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v21__send!();

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -113,6 +113,7 @@ crate::impl_client_v17__create_multisig!();
 crate::impl_client_v18__derive_addresses!();
 crate::impl_client_v17__estimate_smart_fee!();
 crate::impl_client_v18__get_descriptor_info!();
+crate::impl_client_v21__get_index_info!();
 crate::impl_client_v17__sign_message_with_priv_key!();
 crate::impl_client_v17__validate_address!();
 crate::impl_client_v17__verify_message!();

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -125,6 +125,7 @@ crate::impl_client_v17__add_multisig_address!();
 crate::impl_client_v17__backup_wallet!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v23__create_wallet!();
+crate::impl_client_v21__create_wallet_with_descriptors!();
 crate::impl_client_v17__dump_priv_key!();
 crate::impl_client_v17__dump_wallet!();
 crate::impl_client_v17__encrypt_wallet!();

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -60,6 +60,7 @@ crate::impl_client_v17__stop!();
 crate::impl_client_v17__uptime!();
 
 // == Generating ==
+crate::impl_client_v21__generate_block!();
 crate::impl_client_v17__generate_to_address!();
 crate::impl_client_v20__generate_to_descriptor!();
 crate::impl_client_v17__invalidate_block!();

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -19,6 +19,7 @@ pub use crate::client_sync::{
         AddNodeCommand, ImportMultiRequest, ImportMultiScriptPubKey, ImportMultiTimestamp, Input, Output, SetBanCommand, TemplateRequest, TemplateRules,
         WalletCreateFundedPsbtInput,
     },
+    v21::ImportDescriptorsRequest,
     v23::AddressType,
 };
 
@@ -141,6 +142,7 @@ crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
+crate::impl_client_v21__import_descriptors!();
 crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -163,6 +163,7 @@ crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
 crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
+crate::impl_client_v21__send!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();
 crate::impl_client_v17__set_hd_seed!();

--- a/client/src/client_sync/v25/generating.rs
+++ b/client/src/client_sync/v25/generating.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Macros for implementing JSON-RPC methods on a client.
+//!
+//! Specifically this is methods found under the `== Generating ==` section of the
+//! API docs of Bitcoin Core `v25`.
+//!
+//! All macros require `Client` to be in scope.
+//!
+//! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
+
+/// Implements Bitcoin Core JSON-RPC API method `generateblock`
+#[macro_export]
+macro_rules! impl_client_v25__generate_block {
+    () => {
+        impl Client {
+            pub fn generate_block(
+                &self,
+                output: &str,
+                transactions: &[String],
+                submit: bool,
+            ) -> Result<GenerateBlock> {
+                self.call(
+                    "generateblock",
+                    &[into_json(output)?, into_json(transactions)?, into_json(submit)?],
+                )
+            }
+        }
+    };
+}

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -127,6 +127,7 @@ crate::impl_client_v17__add_multisig_address!();
 crate::impl_client_v17__backup_wallet!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v23__create_wallet!();
+crate::impl_client_v21__create_wallet_with_descriptors!();
 crate::impl_client_v17__dump_priv_key!();
 crate::impl_client_v17__dump_wallet!();
 crate::impl_client_v17__encrypt_wallet!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -163,6 +163,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v21__psbt_bump_fee!();
 crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v21__send!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -115,6 +115,7 @@ crate::impl_client_v17__create_multisig!();
 crate::impl_client_v18__derive_addresses!();
 crate::impl_client_v17__estimate_smart_fee!();
 crate::impl_client_v18__get_descriptor_info!();
+crate::impl_client_v21__get_index_info!();
 crate::impl_client_v17__sign_message_with_priv_key!();
 crate::impl_client_v17__validate_address!();
 crate::impl_client_v17__verify_message!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -4,6 +4,8 @@
 //!
 //! We ignore option arguments unless they effect the shape of the returned JSON data.
 
+pub mod generating;
+
 use std::collections::BTreeMap;
 use std::path::Path;
 
@@ -60,6 +62,7 @@ crate::impl_client_v17__stop!();
 crate::impl_client_v17__uptime!();
 
 // == Generating ==
+crate::impl_client_v25__generate_block!();
 crate::impl_client_v17__generate_to_address!();
 crate::impl_client_v20__generate_to_descriptor!();
 crate::impl_client_v17__invalidate_block!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -165,6 +165,7 @@ crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
 crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
+crate::impl_client_v21__send!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();
 crate::impl_client_v17__set_hd_seed!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -175,6 +175,7 @@ crate::impl_client_v19__set_wallet_flag!();
 crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
+crate::impl_client_v21__upgrade_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -21,6 +21,7 @@ pub use crate::client_sync::{
         AddNodeCommand, ImportMultiRequest, ImportMultiScriptPubKey, ImportMultiTimestamp, Input, Output, SetBanCommand, TemplateRequest, TemplateRules,
         WalletCreateFundedPsbtInput,
     },
+    v21::ImportDescriptorsRequest,
     v23::AddressType,
 };
 
@@ -143,6 +144,7 @@ crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
+crate::impl_client_v21__import_descriptors!();
 crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -179,6 +179,7 @@ crate::impl_client_v19__set_wallet_flag!();
 crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
+crate::impl_client_v21__upgrade_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -119,6 +119,7 @@ crate::impl_client_v17__create_multisig!();
 crate::impl_client_v18__derive_addresses!();
 crate::impl_client_v17__estimate_smart_fee!();
 crate::impl_client_v18__get_descriptor_info!();
+crate::impl_client_v21__get_index_info!();
 crate::impl_client_v17__sign_message_with_priv_key!();
 crate::impl_client_v17__validate_address!();
 crate::impl_client_v17__verify_message!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -169,6 +169,7 @@ crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
 crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
+crate::impl_client_v21__send!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();
 crate::impl_client_v17__set_hd_seed!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -131,6 +131,7 @@ crate::impl_client_v17__add_multisig_address!();
 crate::impl_client_v17__backup_wallet!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v23__create_wallet!();
+crate::impl_client_v21__create_wallet_with_descriptors!();
 crate::impl_client_v17__dump_priv_key!();
 crate::impl_client_v17__dump_wallet!();
 crate::impl_client_v17__encrypt_wallet!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -167,6 +167,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v21__psbt_bump_fee!();
 crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v21__send!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -23,6 +23,7 @@ pub use crate::client_sync::{
         AddNodeCommand, ImportMultiRequest, ImportMultiScriptPubKey, ImportMultiTimestamp, Input, Output, SetBanCommand, TemplateRequest, TemplateRules,
         WalletCreateFundedPsbtInput,
     },
+    v21::ImportDescriptorsRequest,
     v23::AddressType,
 };
 
@@ -147,6 +148,7 @@ crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
+crate::impl_client_v21__import_descriptors!();
 crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -64,6 +64,7 @@ crate::impl_client_v17__stop!();
 crate::impl_client_v17__uptime!();
 
 // == Generating ==
+crate::impl_client_v25__generate_block!();
 crate::impl_client_v17__generate_to_address!();
 crate::impl_client_v20__generate_to_descriptor!();
 crate::impl_client_v17__invalidate_block!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -60,6 +60,7 @@ crate::impl_client_v17__stop!();
 crate::impl_client_v17__uptime!();
 
 // == Generating ==
+crate::impl_client_v25__generate_block!();
 crate::impl_client_v17__generate_to_address!();
 crate::impl_client_v20__generate_to_descriptor!();
 crate::impl_client_v17__invalidate_block!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -19,6 +19,7 @@ pub use crate::client_sync::{
         AddNodeCommand, ImportMultiRequest, ImportMultiScriptPubKey, ImportMultiTimestamp, Input, Output, SetBanCommand, TemplateRequest, TemplateRules,
         WalletCreateFundedPsbtInput,
     },
+    v21::ImportDescriptorsRequest,
     v23::AddressType,
 };
 
@@ -143,6 +144,7 @@ crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
+crate::impl_client_v21__import_descriptors!();
 crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -127,6 +127,7 @@ crate::impl_client_v17__add_multisig_address!();
 crate::impl_client_v17__backup_wallet!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v23__create_wallet!();
+crate::impl_client_v21__create_wallet_with_descriptors!();
 crate::impl_client_v17__dump_priv_key!();
 crate::impl_client_v17__dump_wallet!();
 crate::impl_client_v17__encrypt_wallet!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -163,6 +163,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v21__psbt_bump_fee!();
 crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v21__send!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -115,6 +115,7 @@ crate::impl_client_v17__create_multisig!();
 crate::impl_client_v18__derive_addresses!();
 crate::impl_client_v17__estimate_smart_fee!();
 crate::impl_client_v18__get_descriptor_info!();
+crate::impl_client_v21__get_index_info!();
 crate::impl_client_v17__sign_message_with_priv_key!();
 crate::impl_client_v17__validate_address!();
 crate::impl_client_v17__verify_message!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -165,6 +165,7 @@ crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
 crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
+crate::impl_client_v21__send!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();
 crate::impl_client_v17__set_hd_seed!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -175,6 +175,7 @@ crate::impl_client_v19__set_wallet_flag!();
 crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
+crate::impl_client_v21__upgrade_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -21,6 +21,7 @@ pub use crate::client_sync::{
         AddNodeCommand, ImportMultiRequest, ImportMultiScriptPubKey, ImportMultiTimestamp, Input, Output, SetBanCommand, TemplateRequest, TemplateRules,
         WalletCreateFundedPsbtInput,
     },
+    v21::ImportDescriptorsRequest,
     v23::AddressType,
 };
 
@@ -145,6 +146,7 @@ crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
+crate::impl_client_v21__import_descriptors!();
 crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -165,6 +165,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v21__psbt_bump_fee!();
 crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v21__send!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -117,6 +117,7 @@ crate::impl_client_v17__create_multisig!();
 crate::impl_client_v18__derive_addresses!();
 crate::impl_client_v17__estimate_smart_fee!();
 crate::impl_client_v18__get_descriptor_info!();
+crate::impl_client_v21__get_index_info!();
 crate::impl_client_v17__sign_message_with_priv_key!();
 crate::impl_client_v17__validate_address!();
 crate::impl_client_v17__verify_message!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -62,6 +62,7 @@ crate::impl_client_v17__stop!();
 crate::impl_client_v17__uptime!();
 
 // == Generating ==
+crate::impl_client_v25__generate_block!();
 crate::impl_client_v17__generate_to_address!();
 crate::impl_client_v20__generate_to_descriptor!();
 crate::impl_client_v17__invalidate_block!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -177,6 +177,7 @@ crate::impl_client_v19__set_wallet_flag!();
 crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
+crate::impl_client_v21__upgrade_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -129,6 +129,7 @@ crate::impl_client_v17__add_multisig_address!();
 crate::impl_client_v17__backup_wallet!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v23__create_wallet!();
+crate::impl_client_v21__create_wallet_with_descriptors!();
 crate::impl_client_v17__dump_priv_key!();
 crate::impl_client_v17__dump_wallet!();
 crate::impl_client_v17__encrypt_wallet!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -167,6 +167,7 @@ crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
 crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
+crate::impl_client_v21__send!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();
 crate::impl_client_v17__set_hd_seed!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -165,6 +165,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v21__psbt_bump_fee!();
 crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v21__send!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -20,6 +20,7 @@ use crate::types::v29::*;
 #[rustfmt::skip]                // Keep public re-exports separate.
 pub use crate::client_sync::{
     v17::{AddNodeCommand, ImportMultiRequest, ImportMultiScriptPubKey, ImportMultiTimestamp, Input, Output, SetBanCommand, WalletCreateFundedPsbtInput,},
+    v21::ImportDescriptorsRequest,
     v23::AddressType,
 };
 
@@ -145,6 +146,7 @@ crate::impl_client_v17__get_transaction!();
 crate::impl_client_v17__get_unconfirmed_balance!();
 crate::impl_client_v17__get_wallet_info!();
 crate::impl_client_v17__import_address!();
+crate::impl_client_v21__import_descriptors!();
 crate::impl_client_v17__import_multi!();
 crate::impl_client_v17__import_privkey!();
 crate::impl_client_v17__import_pruned_funds!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -117,6 +117,7 @@ crate::impl_client_v17__create_multisig!();
 crate::impl_client_v18__derive_addresses!();
 crate::impl_client_v17__estimate_smart_fee!();
 crate::impl_client_v18__get_descriptor_info!();
+crate::impl_client_v21__get_index_info!();
 crate::impl_client_v17__sign_message_with_priv_key!();
 crate::impl_client_v17__validate_address!();
 crate::impl_client_v17__verify_message!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -62,6 +62,7 @@ crate::impl_client_v17__stop!();
 crate::impl_client_v17__uptime!();
 
 // == Generating ==
+crate::impl_client_v25__generate_block!();
 crate::impl_client_v17__generate_to_address!();
 crate::impl_client_v20__generate_to_descriptor!();
 crate::impl_client_v17__invalidate_block!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -177,6 +177,7 @@ crate::impl_client_v19__set_wallet_flag!();
 crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
+crate::impl_client_v21__upgrade_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
 crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_process_psbt!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -129,6 +129,7 @@ crate::impl_client_v17__add_multisig_address!();
 crate::impl_client_v17__backup_wallet!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v23__create_wallet!();
+crate::impl_client_v21__create_wallet_with_descriptors!();
 crate::impl_client_v17__dump_priv_key!();
 crate::impl_client_v17__dump_wallet!();
 crate::impl_client_v17__encrypt_wallet!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -167,6 +167,7 @@ crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
 crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
+crate::impl_client_v21__send!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();
 crate::impl_client_v17__set_hd_seed!();

--- a/integration_test/tests/util.rs
+++ b/integration_test/tests/util.rs
@@ -63,6 +63,13 @@ fn util__get_descriptor_info() {
     let _: GetDescriptorInfo = node.client.get_descriptor_info(descriptor).expect("getdescriptorinfo");
 }
 
+#[cfg(not(feature = "v20_and_below"))]
+#[test]
+fn util__get_index_info() {
+    let node = Node::with_wallet(Wallet::Default, &[]);
+    let _: GetIndexInfo = node.client.get_index_info().expect("getindexinfo");
+}
+
 #[test]
 fn util__sign_message_with_priv_key__modelled() {
     let node = Node::with_wallet(Wallet::Default, &[]);

--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -697,3 +697,11 @@ fn create_load_unload_wallet() {
 
     let _: LoadWallet = node.client.load_wallet(&wallet).expect("loadwallet");
 }
+
+#[cfg(not(feature = "v20_and_below"))]
+#[test]
+fn wallet__upgrade_wallet() {
+    let node = Node::with_wallet(Wallet::Default, &[]);
+
+    let _: UpgradeWallet = node.client.upgrade_wallet().expect("upgradewallet");
+}

--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -566,6 +566,23 @@ fn wallet__unload_wallet() {
     create_load_unload_wallet();
 }
 
+#[cfg(not(feature = "v20_and_below"))]
+#[test]
+fn wallet__send__modelled() {
+    use std::collections::BTreeMap;
+
+    let node = Node::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+    let address = node.client.new_address().expect("failed to create new address");
+
+    let mut outputs = BTreeMap::new();
+    outputs.insert(address.to_string(), 0.001);
+
+    let json: Send = node.client.send(&outputs).expect("send");
+    let model: Result<mtype::Send, SendError> = json.into_model();
+    model.unwrap();
+}
+
 #[test]
 fn wallet__send_to_address__modelled() {
     let node = Node::with_wallet(Wallet::Default, &[]);

--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -541,6 +541,25 @@ fn wallet__lock_unspent() {
     assert!(json.0);
 }
 
+#[cfg(not(feature = "v20_and_below"))]
+#[test]
+fn wallet__psbt_bump_fee__modelled() {
+    let node = Node::with_wallet(Wallet::Default, &[]);
+    let address = node.client.new_address().expect("failed to create new address");
+    let _ = node.client.generate_to_address(101, &address).expect("generatetoaddress");
+
+    let txid = node
+        .client
+        .send_to_address_rbf(&address, Amount::from_sat(10_000))
+        .expect("sendtoaddress")
+        .txid()
+        .unwrap();
+
+    let json: PsbtBumpFee = node.client.psbt_bump_fee(&txid).expect("psbtbumpfee");
+    let model: Result<mtype::PsbtBumpFee, PsbtBumpFeeError> = json.into_model();
+    model.unwrap();
+}
+
 #[test]
 fn wallet__remove_pruned_funds() {
     let node = Node::with_wallet(Wallet::Default, &["-txindex"]);

--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -311,6 +311,26 @@ fn wallet__import_address() {
 }
 
 #[test]
+#[cfg(not(feature = "v20_and_below"))]
+fn wallet__import_descriptors() {
+    use node::{serde_json, ImportDescriptorsRequest};
+
+    let node = Node::with_wallet(Wallet::None, &[]);
+    let wallet_name = "desc_wallet";
+    node.client.create_wallet_with_descriptors(wallet_name).expect("create descriptor wallet");
+
+    let address = node.client.new_address().expect("failed to get new address");
+    let descriptor = format!("addr({})", address);
+
+    let request = ImportDescriptorsRequest {
+        desc: descriptor,
+        timestamp: serde_json::Value::String("now".to_string()),
+    };
+
+    let _: ImportDescriptors = node.client.import_descriptors(&[request]).expect("importdescriptors");
+}
+
+#[test]
 fn wallet__import_pruned_funds() {
     let node = Node::with_wallet(Wallet::Default, &["-txindex"]);
     node.fund_wallet();

--- a/types/src/model/generating.rs
+++ b/types/src/model/generating.rs
@@ -5,7 +5,7 @@
 //! These structs model the types returned by the JSON-RPC API but have concrete types
 //! and are not specific to a specific version of Bitcoin Core.
 
-use bitcoin::BlockHash;
+use bitcoin::{Block, BlockHash};
 use serde::{Deserialize, Serialize};
 
 /// Models the result of JSON-RPC method `generate`.
@@ -19,6 +19,16 @@ impl Generate {
 
     /// Returns true if 0 blocks were generated.
     pub fn is_empty(&self) -> bool { self.0.is_empty() }
+}
+
+/// Models the result of JSON-RPC method `generateblock`.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct GenerateBlock {
+    /// Hash of generated block.
+    pub hash: BlockHash,
+    /// Hex of generated block, only present when submit=false.
+    pub hex: Option<Block>,
 }
 
 /// Models the result of JSON-RPC method `generatetoaddress`.

--- a/types/src/model/mod.rs
+++ b/types/src/model/mod.rs
@@ -59,7 +59,7 @@ pub use self::{
         ListLockUnspent, ListLockUnspentItem, ListReceivedByAddress, ListReceivedByAddressItem,
         ListReceivedByLabel, ListReceivedByLabelItem, ListSinceBlock, ListSinceBlockTransaction,
         ListTransactions, ListTransactionsItem, ListUnspent, ListUnspentItem, ListWallets,
-        LoadWallet, RescanBlockchain, ScriptType, Send, SendMany, SendToAddress, SignMessage,
-        TransactionCategory, UnloadWallet, WalletCreateFundedPsbt, WalletProcessPsbt,
+        LoadWallet, PsbtBumpFee, RescanBlockchain, ScriptType, Send, SendMany, SendToAddress,
+        SignMessage, TransactionCategory, UnloadWallet, WalletCreateFundedPsbt, WalletProcessPsbt,
     },
 };

--- a/types/src/model/mod.rs
+++ b/types/src/model/mod.rs
@@ -30,7 +30,7 @@ pub use self::{
         GetRawMempool, GetRawMempoolVerbose, GetTxOut, GetTxOutSetInfo, MempoolEntry,
         MempoolEntryFees, ReceiveActivity, Softfork, SoftforkType, SpendActivity, VerifyTxOutProof,
     },
-    generating::{Generate, GenerateToAddress, GenerateToDescriptor},
+    generating::{Generate, GenerateBlock, GenerateToAddress, GenerateToDescriptor},
     mining::{
         BlockTemplateTransaction, GetBlockTemplate, GetMiningInfo, GetPrioritisedTransactions,
         NextBlockInfo, PrioritisedTransaction,

--- a/types/src/model/mod.rs
+++ b/types/src/model/mod.rs
@@ -59,7 +59,7 @@ pub use self::{
         ListLockUnspent, ListLockUnspentItem, ListReceivedByAddress, ListReceivedByAddressItem,
         ListReceivedByLabel, ListReceivedByLabelItem, ListSinceBlock, ListSinceBlockTransaction,
         ListTransactions, ListTransactionsItem, ListUnspent, ListUnspentItem, ListWallets,
-        LoadWallet, RescanBlockchain, ScriptType, SendMany, SendToAddress, SignMessage,
+        LoadWallet, RescanBlockchain, ScriptType, Send, SendMany, SendToAddress, SignMessage,
         TransactionCategory, UnloadWallet, WalletCreateFundedPsbt, WalletProcessPsbt,
     },
 };

--- a/types/src/model/wallet.rs
+++ b/types/src/model/wallet.rs
@@ -722,6 +722,21 @@ pub struct RescanBlockchain {
     pub stop_height: u32,
 }
 
+/// Models the result of JSON-RPC method `send`.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Send {
+    /// If the transaction has a complete set of signatures.
+    pub complete: bool,
+    /// The transaction id for the send.
+    pub txid: Option<Txid>,
+    /// If add_to_wallet is false, the hex-encoded raw transaction with signature(s).
+    pub hex: Option<Transaction>,
+    /// If more signatures are needed, or if add_to_wallet is false, the base64-encoded (partially)
+    /// signed transaction.
+    pub psbt: Option<Psbt>,
+}
+
 /// Models the result of JSON-RPC method `sendmany`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]

--- a/types/src/model/wallet.rs
+++ b/types/src/model/wallet.rs
@@ -722,6 +722,20 @@ pub struct RescanBlockchain {
     pub stop_height: u32,
 }
 
+/// Models the result of JSON-RPC method `psbtbumpfee`.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PsbtBumpFee {
+    /// The base64-encoded unsigned PSBT of the new transaction.
+    pub psbt: Psbt,
+    /// The fee of the replaced transaction.
+    pub original_fee: Amount,
+    /// The fee of the new transaction.
+    pub fee: Amount,
+    /// Errors encountered during processing (may be empty).
+    pub errors: Vec<String>,
+}
+
 /// Models the result of JSON-RPC method `send`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]

--- a/types/src/v21/generating/error.rs
+++ b/types/src/v21/generating/error.rs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: CC0-1.0
+
+use core::fmt;
+
+use bitcoin::hex;
+
+use crate::error::write_err;
+
+/// Error when converting a `GenerateBlock` type into the model type.
+#[derive(Debug)]
+pub enum GenerateBlockError {
+    /// Conversion of the `hash` field failed.
+    Hash(hex::HexToArrayError),
+}
+
+impl fmt::Display for GenerateBlockError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use GenerateBlockError::*;
+
+        match *self {
+            Hash(ref e) => write_err!(f, "conversion of the `hash` field failed"; e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for GenerateBlockError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use GenerateBlockError::*;
+
+        match *self {
+            Hash(ref e) => Some(e),
+        }
+    }
+}

--- a/types/src/v21/generating/into.rs
+++ b/types/src/v21/generating/into.rs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! The JSON-RPC API for Bitcoin Core `v0.21` - generating.
+//!
+//! Types for methods found under the `== Generating ==` section of the API docs.
+
+use bitcoin::BlockHash;
+
+use super::{GenerateBlock, GenerateBlockError};
+use crate::model;
+
+impl GenerateBlock {
+    /// Converts version specific type to a version nonspecific, more strongly typed type.
+    pub fn into_model(self) -> Result<model::GenerateBlock, GenerateBlockError> {
+        use GenerateBlockError as E;
+
+        let hash = self.hash.parse::<BlockHash>().map_err(E::Hash)?;
+        Ok(model::GenerateBlock {
+            hash,
+            hex: None, // v25 and later only.
+        })
+    }
+}

--- a/types/src/v21/generating/mod.rs
+++ b/types/src/v21/generating/mod.rs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! The JSON-RPC API for Bitcoin Core `v0.21` - generating.
+//!
+//! Types for methods found under the `== Generating ==` section of the API docs.
+
+mod error;
+mod into;
+
+use serde::{Deserialize, Serialize};
+
+pub use self::error::GenerateBlockError;
+
+/// Result of JSON-RPC method `generateblock`.
+///
+/// > Mine a block with a set of ordered transactions immediately to a specified address or descriptor (before the RPC call returns)
+/// >
+/// > Arguments:
+/// > 1. output               (string, required) The address or descriptor to send the newly generated bitcoin to.
+/// > 2. transactions         (json array, required) An array of hex strings which are either txids or raw transactions.
+/// >                        Txids must reference transactions currently in the mempool.
+/// >                        All transactions must be valid and in valid order, otherwise the block will be rejected.
+/// >      [
+/// >        "rawtx/txid",    (string)
+/// >        ...
+/// >      ]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct GenerateBlock {
+    /// Hash of generated block
+    pub hash: String,
+}

--- a/types/src/v21/mod.rs
+++ b/types/src/v21/mod.rs
@@ -148,7 +148,7 @@
 //! | deriveaddresses                    | version + model |                                        |
 //! | estimatesmartfee                   | version + model |                                        |
 //! | getdescriptorinfo                  | version         |                                        |
-//! | getindexinfo                       | version         | TODO                                   |
+//! | getindexinfo                       | version         |                                        |
 //! | signmessagewithprivkey             | version + model |                                        |
 //! | validateaddress                    | version + model |                                        |
 //! | verifymessage                      | version         |                                        |
@@ -235,6 +235,7 @@
 mod blockchain;
 mod generating;
 mod network;
+mod util;
 mod wallet;
 
 #[doc(inline)]
@@ -245,6 +246,7 @@ pub use self::{
     },
     generating::{GenerateBlock, GenerateBlockError},
     network::{GetNetworkInfo, GetPeerInfo},
+    util::{GetIndexInfo, GetIndexInfoName},
     wallet::UnloadWallet,
 };
 #[doc(inline)]

--- a/types/src/v21/mod.rs
+++ b/types/src/v21/mod.rs
@@ -213,7 +213,7 @@
 //! | signmessage                        | version + model |                                        |
 //! | signrawtransactionwithwallet       | version + model |                                        |
 //! | unloadwallet                       | returns nothing |                                        |
-//! | upgradewallet                      | version         | TODO                                   |
+//! | upgradewallet                      | version         |                                        |
 //! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
 //! | walletlock                         | returns nothing |                                        |
 //! | walletpassphrase                   | returns nothing |                                        |
@@ -249,7 +249,7 @@ pub use self::{
     util::{GetIndexInfo, GetIndexInfoName},
     wallet::{
         ImportDescriptors, ImportDescriptorsResult, PsbtBumpFee, PsbtBumpFeeError, Send, SendError,
-        UnloadWallet,
+        UnloadWallet, UpgradeWallet,
     },
 };
 #[doc(inline)]

--- a/types/src/v21/mod.rs
+++ b/types/src/v21/mod.rs
@@ -181,7 +181,7 @@
 //! | getunconfirmedbalance              | version + model | UNTESTED                               |
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
-//! | importdescriptors                  | version         | TODO                                   |
+//! | importdescriptors                  | version         |                                        |
 //! | importmulti                        | version         |                                        |
 //! | importprivkey                      | returns nothing |                                        |
 //! | importprunedfunds                  | returns nothing |                                        |
@@ -247,7 +247,7 @@ pub use self::{
     generating::{GenerateBlock, GenerateBlockError},
     network::{GetNetworkInfo, GetPeerInfo},
     util::{GetIndexInfo, GetIndexInfoName},
-    wallet::UnloadWallet,
+    wallet::{ImportDescriptors, ImportDescriptorsResult, UnloadWallet},
 };
 #[doc(inline)]
 pub use crate::{

--- a/types/src/v21/mod.rs
+++ b/types/src/v21/mod.rs
@@ -191,7 +191,7 @@
 //! | listaddressgroupings               | version + model | UNTESTED                               |
 //! | listlabels                         | version + model | UNTESTED                               |
 //! | listlockunspent                    | version + model | UNTESTED                               |
-//! | psbtbumpfee                        | version + model | TODO                                   |
+//! | psbtbumpfee                        | version + model |                                        |
 //! | listreceivedbyaddress              | version + model | UNTESTED                               |
 //! | listreceivedbylabel                | version + model |                                        |
 //! | listsinceblock                     | version + model | UNTESTED                               |
@@ -247,7 +247,10 @@ pub use self::{
     generating::{GenerateBlock, GenerateBlockError},
     network::{GetNetworkInfo, GetPeerInfo},
     util::{GetIndexInfo, GetIndexInfoName},
-    wallet::{ImportDescriptors, ImportDescriptorsResult, Send, SendError, UnloadWallet},
+    wallet::{
+        ImportDescriptors, ImportDescriptorsResult, PsbtBumpFee, PsbtBumpFeeError, Send, SendError,
+        UnloadWallet,
+    },
 };
 #[doc(inline)]
 pub use crate::{

--- a/types/src/v21/mod.rs
+++ b/types/src/v21/mod.rs
@@ -203,7 +203,7 @@
 //! | lockunspent                        | version         |                                        |
 //! | removeprunedfunds                  | returns nothing |                                        |
 //! | rescanblockchain                   | version + model | UNTESTED                               |
-//! | send                               | version + model | TODO                                   |
+//! | send                               | version + model |                                        |
 //! | sendmany                           | version + model | UNTESTED                               |
 //! | sendtoaddress                      | version + model |                                        |
 //! | sethdseed                          | returns nothing |                                        |
@@ -247,7 +247,7 @@ pub use self::{
     generating::{GenerateBlock, GenerateBlockError},
     network::{GetNetworkInfo, GetPeerInfo},
     util::{GetIndexInfo, GetIndexInfoName},
-    wallet::{ImportDescriptors, ImportDescriptorsResult, UnloadWallet},
+    wallet::{ImportDescriptors, ImportDescriptorsResult, Send, SendError, UnloadWallet},
 };
 #[doc(inline)]
 pub use crate::{

--- a/types/src/v21/mod.rs
+++ b/types/src/v21/mod.rs
@@ -73,7 +73,7 @@
 //!
 //! | JSON-RPC Method Name               | Returns         | Notes                                  |
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
-//! | generateblock                      | version + model | TODO                                   |
+//! | generateblock                      | version + model |                                        |
 //! | generatetoaddress                  | version + model |                                        |
 //! | generatetodescriptor               | version + model |                                        |
 //!
@@ -233,6 +233,7 @@
 
 // JSON-RPC types by API section.
 mod blockchain;
+mod generating;
 mod network;
 mod wallet;
 
@@ -242,6 +243,7 @@ pub use self::{
         Bip9SoftforkInfo, GetBlockchainInfo, GetMempoolEntry, GetMempoolInfo, Softfork,
         SoftforkType,
     },
+    generating::{GenerateBlock, GenerateBlockError},
     network::{GetNetworkInfo, GetPeerInfo},
     wallet::UnloadWallet,
 };

--- a/types/src/v21/util.rs
+++ b/types/src/v21/util.rs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! The JSON-RPC API for Bitcoin Core `v0.21` - util.
+//!
+//! Types for methods found under the `== Util ==` section of the API docs.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Result of JSON-RPC method `getindexinfo`.
+///
+/// > Returns the status of one or all available indices currently running in the node.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct GetIndexInfo(pub BTreeMap<String, GetIndexInfoName>);
+
+/// `name` field of `getindexinfo`.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct GetIndexInfoName {
+    /// Whether the index is synced or not.
+    pub synced: bool,
+    /// The block height to which the index is synced.
+    pub best_block_height: u32,
+}

--- a/types/src/v21/wallet/error.rs
+++ b/types/src/v21/wallet/error.rs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: CC0-1.0
+
+use core::fmt;
+
+use bitcoin::consensus::encode;
+use bitcoin::hex;
+use bitcoin::psbt::PsbtParseError;
+
+use crate::error::write_err;
+use crate::NumericError;
+
+/// Error when converting a `Send` type into the model type.
+#[derive(Debug)]
+pub enum SendError {
+    /// Conversion of the `txid` field failed.
+    Txid(hex::HexToArrayError),
+    /// Conversion of the `hex` field failed.
+    Hex(encode::FromHexError),
+    /// Conversion of the `psbt` field failed.
+    Psbt(PsbtParseError),
+    /// Conversion of numeric type to expected type failed.
+    Numeric(NumericError),
+}
+
+impl fmt::Display for SendError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use SendError as E;
+
+        match *self {
+            E::Txid(ref e) => write_err!(f, "conversion of the `txid` field failed"; e),
+            E::Hex(ref e) => write_err!(f, "conversion of the `hex` field failed"; e),
+            E::Psbt(ref e) => write_err!(f, "conversion of the `psbt` field failed"; e),
+            E::Numeric(ref e) => write_err!(f, "numeric"; e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for SendError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use SendError as E;
+
+        match *self {
+            E::Txid(ref e) => Some(e),
+            E::Hex(ref e) => Some(e),
+            E::Psbt(ref e) => Some(e),
+            E::Numeric(ref e) => Some(e),
+        }
+    }
+}
+
+impl From<NumericError> for SendError {
+    fn from(e: NumericError) -> Self { Self::Numeric(e) }
+}

--- a/types/src/v21/wallet/error.rs
+++ b/types/src/v21/wallet/error.rs
@@ -2,12 +2,50 @@
 
 use core::fmt;
 
+use bitcoin::amount::ParseAmountError;
 use bitcoin::consensus::encode;
 use bitcoin::hex;
 use bitcoin::psbt::PsbtParseError;
 
 use crate::error::write_err;
 use crate::NumericError;
+
+/// Error when converting a `BumpFee` type into the model type.
+#[derive(Debug)]
+pub enum PsbtBumpFeeError {
+    /// Conversion of the `psbt` field failed.
+    Psbt(PsbtParseError),
+    /// Conversion of the `original_fee` field failed.
+    OriginalFee(ParseAmountError),
+    /// Conversion of the `fee` field failed.
+    Fee(ParseAmountError),
+}
+
+impl fmt::Display for PsbtBumpFeeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use PsbtBumpFeeError as E;
+
+        match *self {
+            E::Psbt(ref e) => write_err!(f, "conversion of the `psbt` field failed"; e),
+            E::OriginalFee(ref e) =>
+                write_err!(f, "conversion of the `original_fee` field failed"; e),
+            E::Fee(ref e) => write_err!(f, "conversion of the `fee` field failed"; e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for PsbtBumpFeeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use PsbtBumpFeeError as E;
+
+        match *self {
+            E::Psbt(ref e) => Some(e),
+            E::OriginalFee(ref e) => Some(e),
+            E::Fee(ref e) => Some(e),
+        }
+    }
+}
 
 /// Error when converting a `Send` type into the model type.
 #[derive(Debug)]

--- a/types/src/v21/wallet/into.rs
+++ b/types/src/v21/wallet/into.rs
@@ -1,12 +1,25 @@
 // SPDX-License-Identifier: CC0-1.0
 
-use super::{Send, SendError, UnloadWallet};
+use super::{PsbtBumpFee, PsbtBumpFeeError, Send, SendError, UnloadWallet};
 use crate::model;
 
 impl UnloadWallet {
     /// Converts version specific type to a version nonspecific, more strongly typed type.
     pub fn into_model(self) -> model::UnloadWallet {
         model::UnloadWallet { warnings: vec![self.warning] }
+    }
+}
+
+impl PsbtBumpFee {
+    /// Converts version specific type to a version nonspecific, more strongly typed type.
+    pub fn into_model(self) -> Result<model::PsbtBumpFee, PsbtBumpFeeError> {
+        use PsbtBumpFeeError as E;
+
+        let psbt = self.psbt.parse().map_err(E::Psbt)?;
+        let original_fee = bitcoin::Amount::from_btc(self.original_fee).map_err(E::OriginalFee)?;
+        let fee = bitcoin::Amount::from_btc(self.fee).map_err(E::Fee)?;
+        let errors = self.errors;
+        Ok(model::PsbtBumpFee { psbt, original_fee, fee, errors })
     }
 }
 

--- a/types/src/v21/wallet/into.rs
+++ b/types/src/v21/wallet/into.rs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: CC0-1.0
+
+use super::UnloadWallet;
+use crate::model;
+
+impl UnloadWallet {
+    /// Converts version specific type to a version nonspecific, more strongly typed type.
+    pub fn into_model(self) -> model::UnloadWallet {
+        model::UnloadWallet { warnings: vec![self.warning] }
+    }
+}

--- a/types/src/v21/wallet/into.rs
+++ b/types/src/v21/wallet/into.rs
@@ -1,11 +1,31 @@
 // SPDX-License-Identifier: CC0-1.0
 
-use super::UnloadWallet;
+use super::{Send, SendError, UnloadWallet};
 use crate::model;
 
 impl UnloadWallet {
     /// Converts version specific type to a version nonspecific, more strongly typed type.
     pub fn into_model(self) -> model::UnloadWallet {
         model::UnloadWallet { warnings: vec![self.warning] }
+    }
+}
+
+impl Send {
+    /// Converts version specific type to a version nonspecific, more strongly typed type.
+    pub fn into_model(self) -> Result<model::Send, SendError> {
+        use SendError as E;
+
+        let txid = self.txid.as_ref().map(|s| s.parse()).transpose().map_err(E::Txid)?;
+
+        let hex = self
+            .hex
+            .as_ref()
+            .map(|h| bitcoin::consensus::encode::deserialize_hex(h))
+            .transpose()
+            .map_err(E::Hex)?;
+
+        let psbt = self.psbt.as_ref().map(|p| p.parse()).transpose().map_err(E::Psbt)?;
+
+        Ok(model::Send { complete: self.complete, txid, hex, psbt })
     }
 }

--- a/types/src/v21/wallet/mod.rs
+++ b/types/src/v21/wallet/mod.rs
@@ -4,9 +4,12 @@
 //!
 //! Types for methods found under the `== Wallet ==` section of the API docs.
 
+mod error;
 mod into;
 
 use serde::{Deserialize, Serialize};
+
+pub use self::error::SendError;
 
 /// Result of JSON-RPC method `importdescriptors`.
 ///
@@ -59,6 +62,29 @@ pub struct ImportDescriptorsResult {
     pub warnings: Option<Vec<String>>,
     /// Error object, if any.
     pub error: Option<serde_json::Value>,
+}
+
+/// Result of JSON-RPC method `send`.
+///
+/// > EXPERIMENTAL warning: this call may be changed in future releases.
+/// >
+/// > Send a transaction.
+/// >
+/// > Arguments:
+/// > 1. outputs (json array, required) The outputs (key-value pairs), where none of the keys are duplicated.
+/// >    That is, each address can only appear once and there can only be one 'data' object.
+/// >    For convenience, a dictionary, which holds the key-value pairs directly, is also accepted.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Send {
+    /// If the transaction has a complete set of signatures.
+    pub complete: bool,
+    /// The transaction id for the send.
+    pub txid: Option<String>,
+    /// If add_to_wallet is false, the hex-encoded raw transaction with signature(s).
+    pub hex: Option<String>,
+    /// If more signatures are needed, or if add_to_wallet is false, the base64-encoded (partially) signed transaction.
+    pub psbt: Option<String>,
 }
 
 /// Result of the JSON-RPC method `unloadwallet`.

--- a/types/src/v21/wallet/mod.rs
+++ b/types/src/v21/wallet/mod.rs
@@ -8,6 +8,59 @@ mod into;
 
 use serde::{Deserialize, Serialize};
 
+/// Result of JSON-RPC method `importdescriptors`.
+///
+/// > Import descriptors. This will trigger a rescan of the blockchain based on the earliest
+/// > timestamp of all descriptors being imported. Requires a new wallet backup.
+/// >
+/// > Note: This call can take over an hour to complete if using an early timestamp; during that
+/// > time, other rpc calls may report that the imported keys, addresses or scripts exist but
+/// > related transactions are still missing.
+/// >
+/// > Arguments:
+/// > 1. requests (json array, required) Data to be imported
+/// >    [
+/// >      { (json object)
+/// >        "desc": "str", (string, required) Descriptor to import.
+/// >        "active": bool, (boolean, optional, default=false) Set this descriptor to be the
+/// >            active descriptor for the corresponding output type/externality.
+/// >        "range": n or \[n,n\], (numeric or array) If a ranged descriptor is used, this
+/// >            specifies the end or the range (in the form \[begin,end\]) to import.
+/// >        "next_index": n, (numeric) If a ranged descriptor is set to active, this specifies
+/// >            the next index to generate addresses from.
+/// >        "timestamp": timestamp | "now", (integer / string, required) Time from which to
+/// >            start rescanning the blockchain for this descriptor, in UNIX epoch time.
+/// >            Use the string "now" to substitute the current synced blockchain time.
+/// >            "now" can be specified to bypass scanning, for outputs which are known to never
+/// >            have been used, and 0 can be specified to scan the entire blockchain. Blocks up
+/// >            to 2 hours before the earliest timestamp of all descriptors being imported will
+/// >            be scanned.
+/// >        "internal": bool, (boolean, optional, default=false) Whether matching outputs should
+/// >            be treated as not incoming payments (e.g. change).
+/// >        "label": "str", (string, optional, default='') Label to assign to the address, only
+/// >            allowed with internal=false.
+/// >      },
+/// >      ...
+/// >    ]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ImportDescriptors(
+    /// Response is an array with the same size as the input that has the execution result.
+    pub Vec<ImportDescriptorsResult>,
+);
+
+/// Result object for each descriptor import in `importdescriptors`.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ImportDescriptorsResult {
+    /// Whether the import was successful.
+    pub success: bool,
+    /// Warnings, if any.
+    pub warnings: Option<Vec<String>>,
+    /// Error object, if any.
+    pub error: Option<serde_json::Value>,
+}
+
 /// Result of the JSON-RPC method `unloadwallet`.
 ///
 /// > unloadwallet ( "wallet_name" load_on_startup )

--- a/types/src/v21/wallet/mod.rs
+++ b/types/src/v21/wallet/mod.rs
@@ -4,9 +4,9 @@
 //!
 //! Types for methods found under the `== Wallet ==` section of the API docs.
 
-use serde::{Deserialize, Serialize};
+mod into;
 
-use crate::model;
+use serde::{Deserialize, Serialize};
 
 /// Result of the JSON-RPC method `unloadwallet`.
 ///
@@ -19,11 +19,4 @@ use crate::model;
 pub struct UnloadWallet {
     /// Warning messages, if any, related to unloading the wallet.
     pub warning: String,
-}
-
-impl UnloadWallet {
-    /// Converts version specific type to a version nonspecific, more strongly typed type.
-    pub fn into_model(self) -> model::UnloadWallet {
-        model::UnloadWallet { warnings: vec![self.warning] }
-    }
 }

--- a/types/src/v21/wallet/mod.rs
+++ b/types/src/v21/wallet/mod.rs
@@ -9,7 +9,7 @@ mod into;
 
 use serde::{Deserialize, Serialize};
 
-pub use self::error::SendError;
+pub use self::error::{PsbtBumpFeeError, SendError};
 
 /// Result of JSON-RPC method `importdescriptors`.
 ///
@@ -62,6 +62,28 @@ pub struct ImportDescriptorsResult {
     pub warnings: Option<Vec<String>>,
     /// Error object, if any.
     pub error: Option<serde_json::Value>,
+}
+
+/// Result of JSON-RPC method `psbtbumpfee`.
+///
+/// > Bumps the fee of an opt-in-RBF transaction T, replacing it with a new transaction B.
+/// > Returns a PSBT instead of creating and signing a new transaction.
+/// > See Bitcoin Core RPC documentation for full details.
+///
+/// Arguments:
+/// 1. txid    (string, required) The txid to be bumped
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct PsbtBumpFee {
+    /// The base64-encoded unsigned PSBT of the new transaction.
+    pub psbt: String,
+    /// The fee of the replaced transaction.
+    #[serde(rename = "origfee")]
+    pub original_fee: f64,
+    /// The fee of the new transaction.
+    pub fee: f64,
+    /// Errors encountered during processing (may be empty).
+    pub errors: Vec<String>,
 }
 
 /// Result of JSON-RPC method `send`.

--- a/types/src/v21/wallet/mod.rs
+++ b/types/src/v21/wallet/mod.rs
@@ -121,3 +121,22 @@ pub struct UnloadWallet {
     /// Warning messages, if any, related to unloading the wallet.
     pub warning: String,
 }
+
+/// Result of JSON-RPC method `upgradewallet`.
+///
+/// > Upgrade the wallet. Upgrades to the latest version if no version number is specified.
+/// > New keys may be generated and a new wallet backup will need to be made.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct UpgradeWallet {
+    /// Name of wallet this operation was performed on
+    pub wallet_name: String,
+    /// Version of wallet before this operation
+    pub previous_version: u32,
+    /// Version of wallet after this operation
+    pub current_version: u32,
+    /// Description of result, if no error
+    pub result: Option<String>,
+    /// Error message (if there is one)
+    pub error: Option<String>,
+}

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -213,7 +213,7 @@
 //! | lockunspent                        | version         |                                        |
 //! | removeprunedfunds                  | returns nothing |                                        |
 //! | rescanblockchain                   | version + model | UNTESTED                               |
-//! | send                               | version + model | TODO                                   |
+//! | send                               | version + model |                                        |
 //! | sendmany                           | version + model | UNTESTED                               |
 //! | sendtoaddress                      | version + model |                                        |
 //! | sethdseed                          | returns nothing |                                        |
@@ -308,7 +308,7 @@ pub use crate::{
     v21::{
         Bip9SoftforkInfo, GenerateBlock, GenerateBlockError, GetBlockchainInfo, GetIndexInfo,
         GetIndexInfoName, GetMempoolEntry, GetNetworkInfo, ImportDescriptors,
-        ImportDescriptorsResult, Softfork, SoftforkType, UnloadWallet,
+        ImportDescriptorsResult, Send, SendError, Softfork, SoftforkType, UnloadWallet,
     },
     ScriptPubkey,
 };

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -201,7 +201,7 @@
 //! | listdescriptors                    | version + model | TODO                                   |
 //! | listlabels                         | version + model | UNTESTED                               |
 //! | listlockunspent                    | version + model | UNTESTED                               |
-//! | psbtbumpfee                        | version + model | TODO                                   |
+//! | psbtbumpfee                        | version + model |                                        |
 //! | listreceivedbyaddress              | version + model | UNTESTED                               |
 //! | listreceivedbylabel                | version + model |                                        |
 //! | listsinceblock                     | version + model | UNTESTED                               |
@@ -308,7 +308,8 @@ pub use crate::{
     v21::{
         Bip9SoftforkInfo, GenerateBlock, GenerateBlockError, GetBlockchainInfo, GetIndexInfo,
         GetIndexInfoName, GetMempoolEntry, GetNetworkInfo, ImportDescriptors,
-        ImportDescriptorsResult, Send, SendError, Softfork, SoftforkType, UnloadWallet,
+        ImportDescriptorsResult, PsbtBumpFee, PsbtBumpFeeError, Send, SendError, Softfork,
+        SoftforkType, UnloadWallet,
     },
     ScriptPubkey,
 };

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -157,7 +157,7 @@
 //! | deriveaddresses                    | version + model |                                        |
 //! | estimatesmartfee                   | version + model |                                        |
 //! | getdescriptorinfo                  | version         |                                        |
-//! | getindexinfo                       | version         | TODO                                   |
+//! | getindexinfo                       | version         |                                        |
 //! | signmessagewithprivkey             | version + model |                                        |
 //! | validateaddress                    | version + model |                                        |
 //! | verifymessage                      | version         |                                        |
@@ -306,8 +306,8 @@ pub use crate::{
     },
     v20::{CreateMultisig, GenerateToDescriptor, GetTransaction, GetTransactionDetail},
     v21::{
-        Bip9SoftforkInfo, GenerateBlock, GenerateBlockError, GetBlockchainInfo, GetMempoolEntry,
-        GetNetworkInfo, Softfork, SoftforkType, UnloadWallet,
+        Bip9SoftforkInfo, GenerateBlock, GenerateBlockError, GetBlockchainInfo, GetIndexInfo,
+        GetIndexInfoName, GetMempoolEntry, GetNetworkInfo, Softfork, SoftforkType, UnloadWallet,
     },
     ScriptPubkey,
 };

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -73,7 +73,7 @@
 //!
 //! | JSON-RPC Method Name               | Returns         | Notes                                  |
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
-//! | generateblock                      | version + model | TODO                                   |
+//! | generateblock                      | version + model |                                        |
 //! | generatetoaddress                  | version + model |                                        |
 //! | generatetodescriptor               | version + model |                                        |
 //!
@@ -306,8 +306,8 @@ pub use crate::{
     },
     v20::{CreateMultisig, GenerateToDescriptor, GetTransaction, GetTransactionDetail},
     v21::{
-        Bip9SoftforkInfo, GetBlockchainInfo, GetMempoolEntry, GetNetworkInfo, Softfork,
-        SoftforkType, UnloadWallet,
+        Bip9SoftforkInfo, GenerateBlock, GenerateBlockError, GetBlockchainInfo, GetMempoolEntry,
+        GetNetworkInfo, Softfork, SoftforkType, UnloadWallet,
     },
     ScriptPubkey,
 };

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -223,7 +223,7 @@
 //! | signmessage                        | version + model |                                        |
 //! | signrawtransactionwithwallet       | version + model |                                        |
 //! | unloadwallet                       | returns nothing |                                        |
-//! | upgradewallet                      | version         | TODO                                   |
+//! | upgradewallet                      | version         |                                        |
 //! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
 //! | walletdisplayaddress               | version + model | TODO                                   |
 //! | walletlock                         | returns nothing |                                        |
@@ -309,7 +309,7 @@ pub use crate::{
         Bip9SoftforkInfo, GenerateBlock, GenerateBlockError, GetBlockchainInfo, GetIndexInfo,
         GetIndexInfoName, GetMempoolEntry, GetNetworkInfo, ImportDescriptors,
         ImportDescriptorsResult, PsbtBumpFee, PsbtBumpFeeError, Send, SendError, Softfork,
-        SoftforkType, UnloadWallet,
+        SoftforkType, UnloadWallet, UpgradeWallet,
     },
     ScriptPubkey,
 };

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -190,7 +190,7 @@
 //! | getunconfirmedbalance              | version + model | UNTESTED                               |
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
-//! | importdescriptors                  | version         | TODO                                   |
+//! | importdescriptors                  | version         |                                        |
 //! | importmulti                        | version         |                                        |
 //! | importprivkey                      | returns nothing |                                        |
 //! | importprunedfunds                  | returns nothing |                                        |
@@ -307,7 +307,8 @@ pub use crate::{
     v20::{CreateMultisig, GenerateToDescriptor, GetTransaction, GetTransactionDetail},
     v21::{
         Bip9SoftforkInfo, GenerateBlock, GenerateBlockError, GetBlockchainInfo, GetIndexInfo,
-        GetIndexInfoName, GetMempoolEntry, GetNetworkInfo, Softfork, SoftforkType, UnloadWallet,
+        GetIndexInfoName, GetMempoolEntry, GetNetworkInfo, ImportDescriptors,
+        ImportDescriptorsResult, Softfork, SoftforkType, UnloadWallet,
     },
     ScriptPubkey,
 };

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -181,7 +181,7 @@
 //! | getunconfirmedbalance              | version + model | UNTESTED                               |
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
-//! | importdescriptors                  | version         | TODO                                   |
+//! | importdescriptors                  | version         |                                        |
 //! | importmulti                        | version         |                                        |
 //! | importprivkey                      | returns nothing |                                        |
 //! | importprunedfunds                  | returns nothing |                                        |
@@ -307,7 +307,7 @@ pub use crate::{
     v20::{GenerateToDescriptor, GetTransactionDetail},
     v21::{
         GenerateBlock, GenerateBlockError, GetIndexInfo, GetIndexInfoName, GetNetworkInfo,
-        UnloadWallet,
+        ImportDescriptors, ImportDescriptorsResult, UnloadWallet,
     },
     v22::{Banned, GetMempoolInfo, ListBanned, ScriptPubkey},
 };

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -148,7 +148,7 @@
 //! | deriveaddresses                    | version + model |                                        |
 //! | estimatesmartfee                   | version + model |                                        |
 //! | getdescriptorinfo                  | version         |                                        |
-//! | getindexinfo                       | version         | TODO                                   |
+//! | getindexinfo                       | version         |                                        |
 //! | signmessagewithprivkey             | version + model |                                        |
 //! | validateaddress                    | version + model |                                        |
 //! | verifymessage                      | version         |                                        |
@@ -305,6 +305,9 @@ pub use crate::{
         Softfork, SoftforkType,
     },
     v20::{GenerateToDescriptor, GetTransactionDetail},
-    v21::{GenerateBlock, GenerateBlockError, GetNetworkInfo, UnloadWallet},
+    v21::{
+        GenerateBlock, GenerateBlockError, GetIndexInfo, GetIndexInfoName, GetNetworkInfo,
+        UnloadWallet,
+    },
     v22::{Banned, GetMempoolInfo, ListBanned, ScriptPubkey},
 };

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -206,7 +206,7 @@
 //! | removeprunedfunds                  | returns nothing |                                        |
 //! | rescanblockchain                   | version + model | UNTESTED                               |
 //! | restorewallet                      | version + model | TODO                                   |
-//! | send                               | version + model | TODO                                   |
+//! | send                               | version + model |                                        |
 //! | sendmany                           | version + model | UNTESTED                               |
 //! | sendtoaddress                      | version + model |                                        |
 //! | sethdseed                          | returns nothing |                                        |
@@ -307,7 +307,7 @@ pub use crate::{
     v20::{GenerateToDescriptor, GetTransactionDetail},
     v21::{
         GenerateBlock, GenerateBlockError, GetIndexInfo, GetIndexInfoName, GetNetworkInfo,
-        ImportDescriptors, ImportDescriptorsResult, UnloadWallet,
+        ImportDescriptors, ImportDescriptorsResult, Send, SendError, UnloadWallet,
     },
     v22::{Banned, GetMempoolInfo, ListBanned, ScriptPubkey},
 };

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -216,7 +216,7 @@
 //! | signmessage                        | version + model |                                        |
 //! | signrawtransactionwithwallet       | version + model |                                        |
 //! | unloadwallet                       | returns nothing |                                        |
-//! | upgradewallet                      | version         | TODO                                   |
+//! | upgradewallet                      | version         |                                        |
 //! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
 //! | walletdisplayaddress               | version + model | TODO                                   |
 //! | walletlock                         | returns nothing |                                        |
@@ -308,7 +308,7 @@ pub use crate::{
     v21::{
         GenerateBlock, GenerateBlockError, GetIndexInfo, GetIndexInfoName, GetNetworkInfo,
         ImportDescriptors, ImportDescriptorsResult, PsbtBumpFee, PsbtBumpFeeError, Send, SendError,
-        UnloadWallet,
+        UnloadWallet, UpgradeWallet,
     },
     v22::{Banned, GetMempoolInfo, ListBanned, ScriptPubkey},
 };

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -193,7 +193,7 @@
 //! | listlabels                         | version + model | UNTESTED                               |
 //! | listlockunspent                    | version + model | UNTESTED                               |
 //! | newkeypool                         | version + model | TODO                                   |
-//! | psbtbumpfee                        | version + model | TODO                                   |
+//! | psbtbumpfee                        | version + model |                                        |
 //! | listreceivedbyaddress              | version + model | UNTESTED                               |
 //! | listreceivedbylabel                | version + model |                                        |
 //! | listsinceblock                     | version + model | UNTESTED                               |
@@ -307,7 +307,8 @@ pub use crate::{
     v20::{GenerateToDescriptor, GetTransactionDetail},
     v21::{
         GenerateBlock, GenerateBlockError, GetIndexInfo, GetIndexInfoName, GetNetworkInfo,
-        ImportDescriptors, ImportDescriptorsResult, Send, SendError, UnloadWallet,
+        ImportDescriptors, ImportDescriptorsResult, PsbtBumpFee, PsbtBumpFeeError, Send, SendError,
+        UnloadWallet,
     },
     v22::{Banned, GetMempoolInfo, ListBanned, ScriptPubkey},
 };

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -305,6 +305,6 @@ pub use crate::{
         Softfork, SoftforkType,
     },
     v20::{GenerateToDescriptor, GetTransactionDetail},
-    v21::{GetNetworkInfo, UnloadWallet},
+    v21::{GenerateBlock, GenerateBlockError, GetNetworkInfo, UnloadWallet},
     v22::{Banned, GetMempoolInfo, ListBanned, ScriptPubkey},
 };

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -195,7 +195,7 @@
 //! | listlockunspent                    | version + model | UNTESTED                               |
 //! | migratewallet                      | version + model | TODO                                   |
 //! | newkeypool                         | version + model | TODO                                   |
-//! | psbtbumpfee                        | version + model | TODO                                   |
+//! | psbtbumpfee                        | version + model |                                        |
 //! | listreceivedbyaddress              | version + model | UNTESTED                               |
 //! | listreceivedbylabel                | version + model |                                        |
 //! | listsinceblock                     | version + model | UNTESTED                               |
@@ -308,7 +308,8 @@ pub use crate::{
     v20::GenerateToDescriptor,
     v21::{
         GenerateBlock, GenerateBlockError, GetIndexInfo, GetIndexInfoName, GetNetworkInfo,
-        ImportDescriptors, ImportDescriptorsResult, Send, SendError, UnloadWallet,
+        ImportDescriptors, ImportDescriptorsResult, PsbtBumpFee, PsbtBumpFeeError, Send, SendError,
+        UnloadWallet,
     },
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -149,7 +149,7 @@
 //! | deriveaddresses                    | version + model |                                        |
 //! | estimatesmartfee                   | version + model |                                        |
 //! | getdescriptorinfo                  | version         |                                        |
-//! | getindexinfo                       | version         | TODO                                   |
+//! | getindexinfo                       | version         |                                        |
 //! | signmessagewithprivkey             | version + model |                                        |
 //! | validateaddress                    | version + model |                                        |
 //! | verifymessage                      | version         |                                        |
@@ -306,7 +306,10 @@ pub use crate::{
         Softfork, SoftforkType,
     },
     v20::GenerateToDescriptor,
-    v21::{GenerateBlock, GenerateBlockError, GetNetworkInfo, UnloadWallet},
+    v21::{
+        GenerateBlock, GenerateBlockError, GetIndexInfo, GetIndexInfoName, GetNetworkInfo,
+        UnloadWallet,
+    },
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{
         CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, Logging, SaveMempool,

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -182,7 +182,7 @@
 //! | getunconfirmedbalance              | version + model | UNTESTED                               |
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
-//! | importdescriptors                  | version         | TODO                                   |
+//! | importdescriptors                  | version         |                                        |
 //! | importmulti                        | version         |                                        |
 //! | importprivkey                      | returns nothing |                                        |
 //! | importprunedfunds                  | returns nothing |                                        |
@@ -308,7 +308,7 @@ pub use crate::{
     v20::GenerateToDescriptor,
     v21::{
         GenerateBlock, GenerateBlockError, GetIndexInfo, GetIndexInfoName, GetNetworkInfo,
-        UnloadWallet,
+        ImportDescriptors, ImportDescriptorsResult, UnloadWallet,
     },
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -220,7 +220,7 @@
 //! | signrawtransactionwithwallet       | version + model |                                        |
 //! | simulaterawtransaction             | version + model | TODO                                   |
 //! | unloadwallet                       | returns nothing |                                        |
-//! | upgradewallet                      | version         | TODO                                   |
+//! | upgradewallet                      | version         |                                        |
 //! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
 //! | walletdisplayaddress               | version + model | TODO                                   |
 //! | walletlock                         | returns nothing |                                        |
@@ -309,7 +309,7 @@ pub use crate::{
     v21::{
         GenerateBlock, GenerateBlockError, GetIndexInfo, GetIndexInfoName, GetNetworkInfo,
         ImportDescriptors, ImportDescriptorsResult, PsbtBumpFee, PsbtBumpFeeError, Send, SendError,
-        UnloadWallet,
+        UnloadWallet, UpgradeWallet,
     },
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -306,7 +306,7 @@ pub use crate::{
         Softfork, SoftforkType,
     },
     v20::GenerateToDescriptor,
-    v21::{GetNetworkInfo, UnloadWallet},
+    v21::{GenerateBlock, GenerateBlockError, GetNetworkInfo, UnloadWallet},
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{
         CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, Logging, SaveMempool,

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -208,7 +208,7 @@
 //! | removeprunedfunds                  | returns nothing |                                        |
 //! | rescanblockchain                   | version + model | UNTESTED                               |
 //! | restorewallet                      | version + model | TODO                                   |
-//! | send                               | version + model | TODO                                   |
+//! | send                               | version + model |                                        |
 //! | sendall                            | version + model | TODO                                   |
 //! | sendmany                           | version + model | UNTESTED                               |
 //! | sendtoaddress                      | version + model |                                        |
@@ -308,7 +308,7 @@ pub use crate::{
     v20::GenerateToDescriptor,
     v21::{
         GenerateBlock, GenerateBlockError, GetIndexInfo, GetIndexInfoName, GetNetworkInfo,
-        ImportDescriptors, ImportDescriptorsResult, UnloadWallet,
+        ImportDescriptors, ImportDescriptorsResult, Send, SendError, UnloadWallet,
     },
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{

--- a/types/src/v25/generating/error.rs
+++ b/types/src/v25/generating/error.rs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: CC0-1.0
+
+use core::fmt;
+
+use bitcoin::consensus::encode;
+use bitcoin::hex;
+
+use crate::error::write_err;
+
+/// Error when converting a `GenerateBlock` type into the model type.
+#[derive(Debug)]
+pub enum GenerateBlockError {
+    /// Conversion of the `hash` field failed.
+    Hash(hex::HexToArrayError),
+    /// Conversion of the `hex` field failed.
+    Hex(encode::FromHexError),
+}
+
+impl fmt::Display for GenerateBlockError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use GenerateBlockError::*;
+
+        match *self {
+            Hash(ref e) => write_err!(f, "conversion of the `hash` field failed"; e),
+            Hex(ref e) => write_err!(f, "conversion of the `hex` field failed"; e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for GenerateBlockError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use GenerateBlockError::*;
+
+        match *self {
+            Hash(ref e) => Some(e),
+            Hex(ref e) => Some(e),
+        }
+    }
+}

--- a/types/src/v25/generating/into.rs
+++ b/types/src/v25/generating/into.rs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! The JSON-RPC API for Bitcoin Core `v0.21` - generating.
+//!
+//! Types for methods found under the `== Generating ==` section of the API docs.
+
+use bitcoin::consensus::encode;
+use bitcoin::BlockHash;
+
+use super::{GenerateBlock, GenerateBlockError};
+use crate::model;
+
+impl GenerateBlock {
+    /// Converts version specific type to a version nonspecific, more strongly typed type.
+    pub fn into_model(self) -> Result<model::GenerateBlock, GenerateBlockError> {
+        use GenerateBlockError as E;
+
+        let hash = self.hash.parse::<BlockHash>().map_err(E::Hash)?;
+        let hex =
+            self.hex.as_ref().map(|h| encode::deserialize_hex(h)).transpose().map_err(E::Hex)?;
+        Ok(model::GenerateBlock { hash, hex })
+    }
+}

--- a/types/src/v25/generating/mod.rs
+++ b/types/src/v25/generating/mod.rs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! The JSON-RPC API for Bitcoin Core `v0.21` - generating.
+//!
+//! Types for methods found under the `== Generating ==` section of the API docs.
+
+mod error;
+mod into;
+
+use serde::{Deserialize, Serialize};
+
+pub use self::error::GenerateBlockError;
+
+/// Result of JSON-RPC method `generateblock`.
+///
+/// > Mine a block with a set of ordered transactions immediately to a specified address or descriptor (before the RPC call returns)
+/// >
+/// > Arguments:
+/// > 1. output               (string, required) The address or descriptor to send the newly generated bitcoin to.
+/// > 2. transactions         (json array, required) An array of hex strings which are either txids or raw transactions.
+/// >                        Txids must reference transactions currently in the mempool.
+/// >                        All transactions must be valid and in valid order, otherwise the block will be rejected.
+/// >      [
+/// >        "rawtx/txid",    (string)
+/// >        ...
+/// >      ]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct GenerateBlock {
+    /// Hash of generated block
+    pub hash: String,
+    /// Hex of generated block, only present when submit=false.
+    pub hex: Option<String>,
+}

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -242,12 +242,14 @@
 
 mod blockchain;
 mod control;
+mod generating;
 mod wallet;
 
 #[doc(inline)]
 pub use self::{
     blockchain::GetBlockStats,
     control::Logging,
+    generating::{GenerateBlock, GenerateBlockError},
     wallet::{CreateWallet, LoadWallet, UnloadWallet},
 };
 #[doc(inline)]

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -196,7 +196,7 @@
 //! | listlockunspent                    | version + model | UNTESTED                               |
 //! | migratewallet                      | version + model | TODO                                   |
 //! | newkeypool                         | version + model | TODO                                   |
-//! | psbtbumpfee                        | version + model | TODO                                   |
+//! | psbtbumpfee                        | version + model |                                        |
 //! | listreceivedbyaddress              | version + model | UNTESTED                               |
 //! | listreceivedbylabel                | version + model |                                        |
 //! | listsinceblock                     | version + model | UNTESTED                               |
@@ -303,7 +303,7 @@ pub use crate::{
     v20::GenerateToDescriptor,
     v21::{
         GetIndexInfo, GetIndexInfoName, GetNetworkInfo, ImportDescriptors, ImportDescriptorsResult,
-        Send, SendError,
+        PsbtBumpFee, PsbtBumpFeeError, Send, SendError,
     },
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, SaveMempool},

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -209,7 +209,7 @@
 //! | removeprunedfunds                  | returns nothing |                                        |
 //! | rescanblockchain                   | version + model | UNTESTED                               |
 //! | restorewallet                      | version + model | TODO                                   |
-//! | send                               | version + model | TODO                                   |
+//! | send                               | version + model |                                        |
 //! | sendall                            | version + model | TODO                                   |
 //! | sendmany                           | version + model | UNTESTED                               |
 //! | sendtoaddress                      | version + model |                                        |
@@ -303,6 +303,7 @@ pub use crate::{
     v20::GenerateToDescriptor,
     v21::{
         GetIndexInfo, GetIndexInfoName, GetNetworkInfo, ImportDescriptors, ImportDescriptorsResult,
+        Send, SendError,
     },
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, SaveMempool},

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -221,7 +221,7 @@
 //! | signrawtransactionwithwallet       | version + model |                                        |
 //! | simulaterawtransaction             | version + model | TODO                                   |
 //! | unloadwallet                       | returns nothing |                                        |
-//! | upgradewallet                      | version         | TODO                                   |
+//! | upgradewallet                      | version         |                                        |
 //! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
 //! | walletdisplayaddress               | version + model | TODO                                   |
 //! | walletlock                         | returns nothing |                                        |
@@ -303,7 +303,7 @@ pub use crate::{
     v20::GenerateToDescriptor,
     v21::{
         GetIndexInfo, GetIndexInfoName, GetNetworkInfo, ImportDescriptors, ImportDescriptorsResult,
-        PsbtBumpFee, PsbtBumpFeeError, Send, SendError,
+        PsbtBumpFee, PsbtBumpFeeError, Send, SendError, UpgradeWallet,
     },
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, SaveMempool},

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -150,7 +150,7 @@
 //! | deriveaddresses                    | version + model |                                        |
 //! | estimatesmartfee                   | version + model |                                        |
 //! | getdescriptorinfo                  | version         |                                        |
-//! | getindexinfo                       | version         | TODO                                   |
+//! | getindexinfo                       | version         |                                        |
 //! | signmessagewithprivkey             | version + model |                                        |
 //! | validateaddress                    | version + model |                                        |
 //! | verifymessage                      | version         |                                        |
@@ -301,7 +301,7 @@ pub use crate::{
         Softfork, SoftforkType,
     },
     v20::GenerateToDescriptor,
-    v21::GetNetworkInfo,
+    v21::{GetIndexInfo, GetIndexInfoName, GetNetworkInfo},
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, SaveMempool},
     v24::{

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -183,7 +183,7 @@
 //! | getunconfirmedbalance              | version + model | UNTESTED                               |
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
-//! | importdescriptors                  | version         | TODO                                   |
+//! | importdescriptors                  | version         |                                        |
 //! | importmulti                        | version         |                                        |
 //! | importprivkey                      | returns nothing |                                        |
 //! | importprunedfunds                  | returns nothing |                                        |
@@ -301,7 +301,9 @@ pub use crate::{
         Softfork, SoftforkType,
     },
     v20::GenerateToDescriptor,
-    v21::{GetIndexInfo, GetIndexInfoName, GetNetworkInfo},
+    v21::{
+        GetIndexInfo, GetIndexInfoName, GetNetworkInfo, ImportDescriptors, ImportDescriptorsResult,
+    },
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, SaveMempool},
     v24::{

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -158,7 +158,7 @@
 //! | deriveaddresses                    | version + model |                                        |
 //! | estimatesmartfee                   | version + model |                                        |
 //! | getdescriptorinfo                  | version         |                                        |
-//! | getindexinfo                       | version         | TODO                                   |
+//! | getindexinfo                       | version         |                                        |
 //! | signmessagewithprivkey             | version + model |                                        |
 //! | validateaddress                    | version + model |                                        |
 //! | verifymessage                      | version         |                                        |
@@ -319,7 +319,7 @@ pub use crate::{
         SetWalletFlag, Softfork, SoftforkType,
     },
     v20::GenerateToDescriptor,
-    v21::GetNetworkInfo,
+    v21::{GetIndexInfo, GetIndexInfoName, GetNetworkInfo},
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, SaveMempool},
     v24::{

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -217,7 +217,7 @@
 //! | removeprunedfunds                  | returns nothing |                                        |
 //! | rescanblockchain                   | version + model | UNTESTED                               |
 //! | restorewallet                      | version + model | TODO                                   |
-//! | send                               | version + model | TODO                                   |
+//! | send                               | version + model |                                        |
 //! | sendall                            | version + model | TODO                                   |
 //! | sendmany                           | version + model | UNTESTED                               |
 //! | sendtoaddress                      | version + model |                                        |
@@ -321,6 +321,7 @@ pub use crate::{
     v20::GenerateToDescriptor,
     v21::{
         GetIndexInfo, GetIndexInfoName, GetNetworkInfo, ImportDescriptors, ImportDescriptorsResult,
+        Send, SendError,
     },
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, SaveMempool},

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -204,7 +204,7 @@
 //! | listlockunspent                    | version + model | UNTESTED                               |
 //! | migratewallet                      | version + model | TODO                                   |
 //! | newkeypool                         | version + model | TODO                                   |
-//! | psbtbumpfee                        | version + model | TODO                                   |
+//! | psbtbumpfee                        | version + model |                                        |
 //! | listreceivedbyaddress              | version + model | UNTESTED                               |
 //! | listreceivedbylabel                | version + model |                                        |
 //! | listsinceblock                     | version + model | UNTESTED                               |
@@ -321,7 +321,7 @@ pub use crate::{
     v20::GenerateToDescriptor,
     v21::{
         GetIndexInfo, GetIndexInfoName, GetNetworkInfo, ImportDescriptors, ImportDescriptorsResult,
-        Send, SendError,
+        PsbtBumpFee, PsbtBumpFeeError, Send, SendError,
     },
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, SaveMempool},

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -327,5 +327,5 @@ pub use crate::{
         GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,
         TaprootBip32Deriv, TaprootLeaf, TaprootScript, TaprootScriptPathSig,
     },
-    v25::GetBlockStats,
+    v25::{GenerateBlock, GenerateBlockError, GetBlockStats},
 };

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -191,7 +191,7 @@
 //! | getunconfirmedbalance              | version + model | UNTESTED                               |
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
-//! | importdescriptors                  | version         | TODO                                   |
+//! | importdescriptors                  | version         |                                        |
 //! | importmulti                        | version         |                                        |
 //! | importprivkey                      | returns nothing |                                        |
 //! | importprunedfunds                  | returns nothing |                                        |
@@ -319,7 +319,9 @@ pub use crate::{
         SetWalletFlag, Softfork, SoftforkType,
     },
     v20::GenerateToDescriptor,
-    v21::{GetIndexInfo, GetIndexInfoName, GetNetworkInfo},
+    v21::{
+        GetIndexInfo, GetIndexInfoName, GetNetworkInfo, ImportDescriptors, ImportDescriptorsResult,
+    },
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, SaveMempool},
     v24::{

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -229,7 +229,7 @@
 //! | signrawtransactionwithwallet       | version + model |                                        |
 //! | simulaterawtransaction             | version + model | TODO                                   |
 //! | unloadwallet                       | returns nothing |                                        |
-//! | upgradewallet                      | version         | TODO                                   |
+//! | upgradewallet                      | version         |                                        |
 //! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
 //! | walletdisplayaddress               | version + model | TODO                                   |
 //! | walletlock                         | returns nothing |                                        |
@@ -321,7 +321,7 @@ pub use crate::{
     v20::GenerateToDescriptor,
     v21::{
         GetIndexInfo, GetIndexInfoName, GetNetworkInfo, ImportDescriptors, ImportDescriptorsResult,
-        PsbtBumpFee, PsbtBumpFeeError, Send, SendError,
+        PsbtBumpFee, PsbtBumpFeeError, Send, SendError, UpgradeWallet,
     },
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, SaveMempool},

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -158,7 +158,7 @@
 //! | deriveaddresses                    | version + model |                                        |
 //! | estimatesmartfee                   | version + model |                                        |
 //! | getdescriptorinfo                  | version         |                                        |
-//! | getindexinfo                       | version         | TODO                                   |
+//! | getindexinfo                       | version         |                                        |
 //! | signmessagewithprivkey             | version + model |                                        |
 //! | validateaddress                    | version + model |                                        |
 //! | verifymessage                      | version         |                                        |
@@ -296,7 +296,7 @@ pub use crate::{
         SetWalletFlag, Softfork, SoftforkType,
     },
     v20::GenerateToDescriptor,
-    v21::GetNetworkInfo,
+    v21::{GetIndexInfo, GetIndexInfoName, GetNetworkInfo},
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, SaveMempool},
     v24::{

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -204,7 +204,7 @@
 //! | listlockunspent                    | version + model | UNTESTED                               |
 //! | migratewallet                      | version + model | TODO                                   |
 //! | newkeypool                         | version + model | TODO                                   |
-//! | psbtbumpfee                        | version + model | TODO                                   |
+//! | psbtbumpfee                        | version + model |                                        |
 //! | listreceivedbyaddress              | version + model | UNTESTED                               |
 //! | listreceivedbylabel                | version + model |                                        |
 //! | listsinceblock                     | version + model | UNTESTED                               |
@@ -298,7 +298,7 @@ pub use crate::{
     v20::GenerateToDescriptor,
     v21::{
         GetIndexInfo, GetIndexInfoName, GetNetworkInfo, ImportDescriptors, ImportDescriptorsResult,
-        Send, SendError,
+        PsbtBumpFee, PsbtBumpFeeError, Send, SendError,
     },
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, SaveMempool},

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -191,7 +191,7 @@
 //! | getunconfirmedbalance              | version + model | UNTESTED                               |
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
-//! | importdescriptors                  | version         | TODO                                   |
+//! | importdescriptors                  | version         |                                        |
 //! | importmulti                        | version         |                                        |
 //! | importprivkey                      | returns nothing |                                        |
 //! | importprunedfunds                  | returns nothing |                                        |
@@ -296,7 +296,9 @@ pub use crate::{
         SetWalletFlag, Softfork, SoftforkType,
     },
     v20::GenerateToDescriptor,
-    v21::{GetIndexInfo, GetIndexInfoName, GetNetworkInfo},
+    v21::{
+        GetIndexInfo, GetIndexInfoName, GetNetworkInfo, ImportDescriptors, ImportDescriptorsResult,
+    },
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, SaveMempool},
     v24::{

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -229,7 +229,7 @@
 //! | signrawtransactionwithwallet       | version + model |                                        |
 //! | simulaterawtransaction             | version + model | TODO                                   |
 //! | unloadwallet                       | returns nothing |                                        |
-//! | upgradewallet                      | version         | TODO                                   |
+//! | upgradewallet                      | version         |                                        |
 //! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
 //! | walletdisplayaddress               | version + model | TODO                                   |
 //! | walletlock                         | returns nothing |                                        |
@@ -298,7 +298,7 @@ pub use crate::{
     v20::GenerateToDescriptor,
     v21::{
         GetIndexInfo, GetIndexInfoName, GetNetworkInfo, ImportDescriptors, ImportDescriptorsResult,
-        PsbtBumpFee, PsbtBumpFeeError, Send, SendError,
+        PsbtBumpFee, PsbtBumpFeeError, Send, SendError, UpgradeWallet,
     },
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, SaveMempool},

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -217,7 +217,7 @@
 //! | removeprunedfunds                  | returns nothing |                                        |
 //! | rescanblockchain                   | version + model | UNTESTED                               |
 //! | restorewallet                      | version + model | TODO                                   |
-//! | send                               | version + model | TODO                                   |
+//! | send                               | version + model |                                        |
 //! | sendall                            | version + model | TODO                                   |
 //! | sendmany                           | version + model | UNTESTED                               |
 //! | sendtoaddress                      | version + model |                                        |
@@ -298,6 +298,7 @@ pub use crate::{
     v20::GenerateToDescriptor,
     v21::{
         GetIndexInfo, GetIndexInfoName, GetNetworkInfo, ImportDescriptors, ImportDescriptorsResult,
+        Send, SendError,
     },
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, SaveMempool},

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -304,7 +304,7 @@ pub use crate::{
         GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,
         TaprootBip32Deriv, TaprootLeaf, TaprootScript, TaprootScriptPathSig,
     },
-    v25::GetBlockStats,
+    v25::{GenerateBlock, GenerateBlockError, GetBlockStats},
     v26::{
         CreateWallet, DescriptorProcessPsbt, DescriptorProcessPsbtError, GetBalances,
         GetBalancesError, GetPeerInfo, GetPrioritisedTransactions, GetTransaction,

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -219,7 +219,7 @@
 //! | removeprunedfunds                  | returns nothing |                                        |
 //! | rescanblockchain                   | version + model | UNTESTED                               |
 //! | restorewallet                      | version + model | TODO                                   |
-//! | send                               | version + model | TODO                                   |
+//! | send                               | version + model |                                        |
 //! | sendall                            | version + model | TODO                                   |
 //! | sendmany                           | version + model | UNTESTED                               |
 //! | sendtoaddress                      | version + model |                                        |
@@ -317,7 +317,9 @@ pub use crate::{
         SetWalletFlag, Softfork, SoftforkType,
     },
     v20::GenerateToDescriptor,
-    v21::{GetIndexInfo, GetIndexInfoName, ImportDescriptors, ImportDescriptorsResult},
+    v21::{
+        GetIndexInfo, GetIndexInfoName, ImportDescriptors, ImportDescriptorsResult, Send, SendError,
+    },
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, SaveMempool},
     v24::{

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -324,7 +324,7 @@ pub use crate::{
         GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,
         TaprootBip32Deriv, TaprootLeaf, TaprootScript, TaprootScriptPathSig,
     },
-    v25::GetBlockStats,
+    v25::{GenerateBlock, GenerateBlockError, GetBlockStats},
     v26::{
         CreateWallet, DescriptorProcessPsbt, DescriptorProcessPsbtError, GetBalances,
         GetBalancesError, GetPeerInfo, GetPrioritisedTransactions, GetTransactionError,

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -158,7 +158,7 @@
 //! | deriveaddresses                    | version + model |                                        |
 //! | estimatesmartfee                   | version + model |                                        |
 //! | getdescriptorinfo                  | version         |                                        |
-//! | getindexinfo                       | version         | TODO                                   |
+//! | getindexinfo                       | version         |                                        |
 //! | signmessagewithprivkey             | version + model |                                        |
 //! | validateaddress                    | version + model |                                        |
 //! | verifymessage                      | version         |                                        |
@@ -317,6 +317,7 @@ pub use crate::{
         SetWalletFlag, Softfork, SoftforkType,
     },
     v20::GenerateToDescriptor,
+    v21::{GetIndexInfo, GetIndexInfoName},
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, SaveMempool},
     v24::{

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -206,7 +206,7 @@
 //! | listlockunspent                    | version + model | UNTESTED                               |
 //! | migratewallet                      | version + model | TODO                                   |
 //! | newkeypool                         | version + model | TODO                                   |
-//! | psbtbumpfee                        | version + model | TODO                                   |
+//! | psbtbumpfee                        | version + model |                                        |
 //! | listreceivedbyaddress              | version + model | UNTESTED                               |
 //! | listreceivedbylabel                | version + model |                                        |
 //! | listsinceblock                     | version + model | UNTESTED                               |
@@ -318,7 +318,8 @@ pub use crate::{
     },
     v20::GenerateToDescriptor,
     v21::{
-        GetIndexInfo, GetIndexInfoName, ImportDescriptors, ImportDescriptorsResult, Send, SendError,
+        GetIndexInfo, GetIndexInfoName, ImportDescriptors, ImportDescriptorsResult, PsbtBumpFee,
+        PsbtBumpFeeError, Send, SendError,
     },
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, SaveMempool},

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -193,7 +193,7 @@
 //! | getunconfirmedbalance              | version + model | UNTESTED                               |
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
-//! | importdescriptors                  | version         | TODO                                   |
+//! | importdescriptors                  | version         |                                        |
 //! | importmulti                        | version         |                                        |
 //! | importprivkey                      | returns nothing |                                        |
 //! | importprunedfunds                  | returns nothing |                                        |
@@ -317,7 +317,7 @@ pub use crate::{
         SetWalletFlag, Softfork, SoftforkType,
     },
     v20::GenerateToDescriptor,
-    v21::{GetIndexInfo, GetIndexInfoName},
+    v21::{GetIndexInfo, GetIndexInfoName, ImportDescriptors, ImportDescriptorsResult},
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, SaveMempool},
     v24::{

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -231,7 +231,7 @@
 //! | signrawtransactionwithwallet       | version + model |                                        |
 //! | simulaterawtransaction             | version + model | TODO                                   |
 //! | unloadwallet                       | returns nothing |                                        |
-//! | upgradewallet                      | version         | TODO                                   |
+//! | upgradewallet                      | version         |                                        |
 //! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
 //! | walletdisplayaddress               | version + model | TODO                                   |
 //! | walletlock                         | returns nothing |                                        |
@@ -319,7 +319,7 @@ pub use crate::{
     v20::GenerateToDescriptor,
     v21::{
         GetIndexInfo, GetIndexInfoName, ImportDescriptors, ImportDescriptorsResult, PsbtBumpFee,
-        PsbtBumpFeeError, Send, SendError,
+        PsbtBumpFeeError, Send, SendError, UpgradeWallet,
     },
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, SaveMempool},

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -207,7 +207,7 @@
 //! | listlockunspent                    | version + model | UNTESTED                               |
 //! | migratewallet                      | version + model | TODO                                   |
 //! | newkeypool                         | version + model | TODO                                   |
-//! | psbtbumpfee                        | version + model | TODO                                   |
+//! | psbtbumpfee                        | version + model |                                        |
 //! | listreceivedbyaddress              | version + model | UNTESTED                               |
 //! | listreceivedbylabel                | version + model |                                        |
 //! | listsinceblock                     | version + model | UNTESTED                               |
@@ -316,7 +316,8 @@ pub use crate::{
     },
     v20::GenerateToDescriptor,
     v21::{
-        GetIndexInfo, GetIndexInfoName, ImportDescriptors, ImportDescriptorsResult, Send, SendError,
+        GetIndexInfo, GetIndexInfoName, ImportDescriptors, ImportDescriptorsResult, PsbtBumpFee,
+        PsbtBumpFeeError, Send, SendError,
     },
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, SaveMempool},

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -232,7 +232,7 @@
 //! | signrawtransactionwithwallet       | version + model |                                        |
 //! | simulaterawtransaction             | version + model | TODO                                   |
 //! | unloadwallet                       | returns nothing |                                        |
-//! | upgradewallet                      | version         | TODO                                   |
+//! | upgradewallet                      | version         |                                        |
 //! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
 //! | walletdisplayaddress               | version + model | TODO                                   |
 //! | walletlock                         | returns nothing |                                        |
@@ -317,7 +317,7 @@ pub use crate::{
     v20::GenerateToDescriptor,
     v21::{
         GetIndexInfo, GetIndexInfoName, ImportDescriptors, ImportDescriptorsResult, PsbtBumpFee,
-        PsbtBumpFeeError, Send, SendError,
+        PsbtBumpFeeError, Send, SendError, UpgradeWallet,
     },
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, SaveMempool},

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -194,7 +194,7 @@
 //! | getunconfirmedbalance              | version + model | UNTESTED                               |
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
-//! | importdescriptors                  | version         | TODO                                   |
+//! | importdescriptors                  | version         |                                        |
 //! | importmulti                        | version         |                                        |
 //! | importprivkey                      | returns nothing |                                        |
 //! | importprunedfunds                  | returns nothing |                                        |
@@ -315,7 +315,7 @@ pub use crate::{
         Softfork, SoftforkType,
     },
     v20::GenerateToDescriptor,
-    v21::{GetIndexInfo, GetIndexInfoName},
+    v21::{GetIndexInfo, GetIndexInfoName, ImportDescriptors, ImportDescriptorsResult},
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, SaveMempool},
     v24::{

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -322,7 +322,7 @@ pub use crate::{
         GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,
         TaprootBip32Deriv, TaprootLeaf, TaprootScript, TaprootScriptPathSig,
     },
-    v25::GetBlockStats,
+    v25::{GenerateBlock, GenerateBlockError, GetBlockStats},
     v26::{
         CreateWallet, DescriptorProcessPsbt, DescriptorProcessPsbtError, GetBalances,
         GetBalancesError, GetPrioritisedTransactions, GetTransactionError, GetTxOutSetInfo,

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -159,7 +159,7 @@
 //! | deriveaddresses                    | version + model | TODO                                   |
 //! | estimatesmartfee                   | version + model |                                        |
 //! | getdescriptorinfo                  | version         |                                        |
-//! | getindexinfo                       | version         | TODO                                   |
+//! | getindexinfo                       | version         |                                        |
 //! | signmessagewithprivkey             | version + model |                                        |
 //! | validateaddress                    | version + model |                                        |
 //! | verifymessage                      | version         |                                        |
@@ -315,6 +315,7 @@ pub use crate::{
         Softfork, SoftforkType,
     },
     v20::GenerateToDescriptor,
+    v21::{GetIndexInfo, GetIndexInfoName},
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, SaveMempool},
     v24::{

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -220,7 +220,7 @@
 //! | removeprunedfunds                  | returns nothing |                                        |
 //! | rescanblockchain                   | version + model | UNTESTED                               |
 //! | restorewallet                      | version + model | TODO                                   |
-//! | send                               | version + model | TODO                                   |
+//! | send                               | version + model |                                        |
 //! | sendall                            | version + model | TODO                                   |
 //! | sendmany                           | version + model | UNTESTED                               |
 //! | sendtoaddress                      | version + model |                                        |
@@ -315,7 +315,9 @@ pub use crate::{
         Softfork, SoftforkType,
     },
     v20::GenerateToDescriptor,
-    v21::{GetIndexInfo, GetIndexInfoName, ImportDescriptors, ImportDescriptorsResult},
+    v21::{
+        GetIndexInfo, GetIndexInfoName, ImportDescriptors, ImportDescriptorsResult, Send, SendError,
+    },
     v22::{Banned, ListBanned, ScriptPubkey},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, SaveMempool},
     v24::{


### PR DESCRIPTION
Go through all the `TODO` in the v21 types table. Add all the missing RPCs including models when required and tests.

Add a new macro `create_wallet_with_descriptors` that creates a descriptor wallet for use with v21 and v22 where the default is a legacy wallet. This is required for the `importdescriptors` test.

Move the `wallet` module to a subdirectory since there are multiple new RPCs in v21.