### PR TITLE
Address all TODO in v22

### DIFF
--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -155,6 +155,7 @@ crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__import_wallet!();
 crate::impl_client_v17__key_pool_refill!();
 crate::impl_client_v17__list_address_groupings!();
+crate::impl_client_v22__list_descriptors!();
 crate::impl_client_v18__list_received_by_label!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v17__list_lock_unspent!();

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -4,6 +4,7 @@
 //!
 //! We ignore option arguments unless they effect the shape of the returned JSON data.
 
+mod signer;
 mod wallet;
 
 use std::collections::BTreeMap;
@@ -109,6 +110,9 @@ crate::impl_client_v17__sign_raw_transaction!();
 crate::impl_client_v17__sign_raw_transaction_with_key!();
 crate::impl_client_v17__test_mempool_accept!();
 crate::impl_client_v18__utxo_update_psbt!();
+
+// == Signer ==
+crate::impl_client_v22__enumerate_signers!();
 
 // == Util ==
 crate::impl_client_v17__create_multisig!();

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -181,6 +181,7 @@ crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v21__upgrade_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
+crate::impl_client_v22__wallet_display_address!();
 crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_passphrase!();
 crate::impl_client_v17__wallet_passphrase_change!();

--- a/client/src/client_sync/v22/signer.rs
+++ b/client/src/client_sync/v22/signer.rs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Macros for implementing JSON-RPC methods on a client.
+//!
+//! Specifically this is methods found under the `== Signer ==` section of the
+//! API docs of Bitcoin Core `v22`.
+//!
+//! All macros require `Client` to be in scope.
+//!
+//! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
+
+/// Implements Bitcoin Core JSON-RPC API method `enumeratesigners`
+#[macro_export]
+macro_rules! impl_client_v22__enumerate_signers {
+    () => {
+        impl Client {
+            pub fn enumerate_signers(&self) -> Result<EnumerateSigners> {
+                self.call("enumeratesigners", &[])
+            }
+        }
+    };
+}

--- a/client/src/client_sync/v22/wallet.rs
+++ b/client/src/client_sync/v22/wallet.rs
@@ -32,3 +32,15 @@ macro_rules! impl_client_v22__load_wallet {
         }
     };
 }
+
+/// Implements Bitcoin Core JSON-RPC API method `walletdisplayaddress`
+#[macro_export]
+macro_rules! impl_client_v22__wallet_display_address {
+    () => {
+        impl Client {
+            pub fn wallet_display_address(&self, address: &str) -> Result<WalletDisplayAddress> {
+                self.call("walletdisplayaddress", &[address.into()])
+            }
+        }
+    };
+}

--- a/client/src/client_sync/v22/wallet.rs
+++ b/client/src/client_sync/v22/wallet.rs
@@ -9,6 +9,18 @@
 //!
 //! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
 
+/// Implements Bitcoin Core JSON-RPC API method `listdescriptors`
+#[macro_export]
+macro_rules! impl_client_v22__list_descriptors {
+    () => {
+        impl Client {
+            pub fn list_descriptors(&self) -> Result<ListDescriptors> {
+                self.call("listdescriptors", &[])
+            }
+        }
+    };
+}
+
 /// Implements Bitcoin Core JSON-RPC API method `loadwallet`
 #[macro_export]
 macro_rules! impl_client_v22__load_wallet {

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -156,6 +156,7 @@ crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__import_wallet!();
 crate::impl_client_v17__key_pool_refill!();
 crate::impl_client_v17__list_address_groupings!();
+crate::impl_client_v22__list_descriptors!();
 crate::impl_client_v18__list_received_by_label!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v17__list_lock_unspent!();

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -182,6 +182,7 @@ crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v21__upgrade_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
+crate::impl_client_v22__wallet_display_address!();
 crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_passphrase!();
 crate::impl_client_v17__wallet_passphrase_change!();

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -112,6 +112,9 @@ crate::impl_client_v17__sign_raw_transaction_with_key!();
 crate::impl_client_v17__test_mempool_accept!();
 crate::impl_client_v18__utxo_update_psbt!();
 
+// == Signer ==
+crate::impl_client_v22__enumerate_signers!();
+
 // == Util ==
 crate::impl_client_v17__create_multisig!();
 crate::impl_client_v18__derive_addresses!();

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -109,6 +109,9 @@ crate::impl_client_v17__sign_raw_transaction_with_key!();
 crate::impl_client_v17__test_mempool_accept!();
 crate::impl_client_v18__utxo_update_psbt!();
 
+// == Signer ==
+crate::impl_client_v22__enumerate_signers!();
+
 // == Util ==
 crate::impl_client_v17__create_multisig!();
 crate::impl_client_v18__derive_addresses!();

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -153,6 +153,7 @@ crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__import_wallet!();
 crate::impl_client_v17__key_pool_refill!();
 crate::impl_client_v17__list_address_groupings!();
+crate::impl_client_v22__list_descriptors!();
 crate::impl_client_v18__list_received_by_label!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v17__list_lock_unspent!();

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -179,6 +179,7 @@ crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v21__upgrade_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
+crate::impl_client_v22__wallet_display_address!();
 crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_passphrase!();
 crate::impl_client_v17__wallet_passphrase_change!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -155,6 +155,7 @@ crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__import_wallet!();
 crate::impl_client_v17__key_pool_refill!();
 crate::impl_client_v17__list_address_groupings!();
+crate::impl_client_v22__list_descriptors!();
 crate::impl_client_v18__list_received_by_label!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v17__list_lock_unspent!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -111,6 +111,9 @@ crate::impl_client_v17__sign_raw_transaction_with_key!();
 crate::impl_client_v17__test_mempool_accept!();
 crate::impl_client_v18__utxo_update_psbt!();
 
+// == Signer ==
+crate::impl_client_v22__enumerate_signers!();
+
 // == Util ==
 crate::impl_client_v17__create_multisig!();
 crate::impl_client_v18__derive_addresses!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -181,6 +181,7 @@ crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v21__upgrade_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
+crate::impl_client_v22__wallet_display_address!();
 crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_passphrase!();
 crate::impl_client_v17__wallet_passphrase_change!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -159,6 +159,7 @@ crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__import_wallet!();
 crate::impl_client_v17__key_pool_refill!();
 crate::impl_client_v17__list_address_groupings!();
+crate::impl_client_v22__list_descriptors!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v18__list_received_by_label!();
 crate::impl_client_v17__list_lock_unspent!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -115,6 +115,9 @@ crate::impl_client_v26__submit_package!();
 crate::impl_client_v17__test_mempool_accept!();
 crate::impl_client_v18__utxo_update_psbt!();
 
+// == Signer ==
+crate::impl_client_v22__enumerate_signers!();
+
 // == Util ==
 crate::impl_client_v17__create_multisig!();
 crate::impl_client_v18__derive_addresses!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -185,6 +185,7 @@ crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v21__upgrade_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
+crate::impl_client_v22__wallet_display_address!();
 crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_passphrase!();
 crate::impl_client_v17__wallet_passphrase_change!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -155,6 +155,7 @@ crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__import_wallet!();
 crate::impl_client_v17__key_pool_refill!();
 crate::impl_client_v17__list_address_groupings!();
+crate::impl_client_v22__list_descriptors!();
 crate::impl_client_v18__list_received_by_label!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v17__list_lock_unspent!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -111,6 +111,9 @@ crate::impl_client_v26__submit_package!();
 crate::impl_client_v17__test_mempool_accept!();
 crate::impl_client_v18__utxo_update_psbt!();
 
+// == Signer ==
+crate::impl_client_v22__enumerate_signers!();
+
 // == Util ==
 crate::impl_client_v17__create_multisig!();
 crate::impl_client_v18__derive_addresses!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -181,6 +181,7 @@ crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v21__upgrade_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
+crate::impl_client_v22__wallet_display_address!();
 crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_passphrase!();
 crate::impl_client_v17__wallet_passphrase_change!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -157,6 +157,7 @@ crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__import_wallet!();
 crate::impl_client_v17__key_pool_refill!();
 crate::impl_client_v17__list_address_groupings!();
+crate::impl_client_v22__list_descriptors!();
 crate::impl_client_v18__list_received_by_label!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v17__list_lock_unspent!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -183,6 +183,7 @@ crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v21__upgrade_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
+crate::impl_client_v22__wallet_display_address!();
 crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_passphrase!();
 crate::impl_client_v17__wallet_passphrase_change!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -113,6 +113,9 @@ crate::impl_client_v28__submit_package!();
 crate::impl_client_v17__test_mempool_accept!();
 crate::impl_client_v18__utxo_update_psbt!();
 
+// == Signer ==
+crate::impl_client_v22__enumerate_signers!();
+
 // == Util ==
 crate::impl_client_v17__create_multisig!();
 crate::impl_client_v18__derive_addresses!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -157,6 +157,7 @@ crate::impl_client_v17__import_pubkey!();
 crate::impl_client_v17__import_wallet!();
 crate::impl_client_v17__key_pool_refill!();
 crate::impl_client_v17__list_address_groupings!();
+crate::impl_client_v22__list_descriptors!();
 crate::impl_client_v18__list_received_by_label!();
 crate::impl_client_v17__list_labels!();
 crate::impl_client_v17__list_lock_unspent!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -183,6 +183,7 @@ crate::impl_client_v17__sign_raw_transaction_with_wallet!();
 crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v21__upgrade_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();
+crate::impl_client_v22__wallet_display_address!();
 crate::impl_client_v17__wallet_lock!();
 crate::impl_client_v17__wallet_passphrase!();
 crate::impl_client_v17__wallet_passphrase_change!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -113,6 +113,9 @@ crate::impl_client_v28__submit_package!();
 crate::impl_client_v17__test_mempool_accept!();
 crate::impl_client_v18__utxo_update_psbt!();
 
+// == Signer ==
+crate::impl_client_v22__enumerate_signers!();
+
 // == Util ==
 crate::impl_client_v17__create_multisig!();
 crate::impl_client_v18__derive_addresses!();

--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -496,6 +496,25 @@ fn wallet__import_pubkey() {
 }
 
 #[test]
+#[cfg(not(feature = "v21_and_below"))]
+fn wallet__list_descriptors() {
+    let node = Node::with_wallet(Wallet::None, &[]);
+    let wallet_name = "desc_wallet";
+
+    #[cfg(feature = "v22_and_below")]
+    node.client.create_wallet_with_descriptors(wallet_name).expect("create descriptor wallet");
+
+    // v23 onwards uses descriptor wallets by default.
+    #[cfg(not(feature = "v22_and_below"))]
+    node.client.create_wallet(wallet_name).expect("create wallet");
+
+    let json: ListDescriptors = node.client.list_descriptors().expect("listdescriptors");
+
+    let has_descriptor = json.descriptors.iter().any(|desc_info| desc_info.descriptor.starts_with("wpkh(") || desc_info.descriptor.starts_with("pkh("));
+    assert!(has_descriptor, "No standard descriptors found in listdescriptors result");
+}
+
+#[test]
 fn wallet__list_unspent__modelled() {
     let node = match () {
         #[cfg(feature = "v17")]

--- a/types/src/model/mod.rs
+++ b/types/src/model/mod.rs
@@ -60,6 +60,7 @@ pub use self::{
         ListReceivedByLabel, ListReceivedByLabelItem, ListSinceBlock, ListSinceBlockTransaction,
         ListTransactions, ListTransactionsItem, ListUnspent, ListUnspentItem, ListWallets,
         LoadWallet, PsbtBumpFee, RescanBlockchain, ScriptType, Send, SendMany, SendToAddress,
-        SignMessage, TransactionCategory, UnloadWallet, WalletCreateFundedPsbt, WalletProcessPsbt,
+        SignMessage, TransactionCategory, UnloadWallet, WalletCreateFundedPsbt,
+        WalletDisplayAddress, WalletProcessPsbt,
     },
 };

--- a/types/src/model/wallet.rs
+++ b/types/src/model/wallet.rs
@@ -790,6 +790,14 @@ pub struct WalletCreateFundedPsbt {
     pub change_pos: u32,
 }
 
+/// Models the result of JSON-RPC method `walletdisplayaddress`.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WalletDisplayAddress {
+    /// The address as confirmed by the signer
+    pub address: Address<NetworkUnchecked>,
+}
+
 /// Models the result of JSON-RPC method `walletprocesspsbt`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -198,7 +198,7 @@
 //! | importwallet                       | returns nothing |                                        |
 //! | keypoolrefill                      | returns nothing |                                        |
 //! | listaddressgroupings               | version + model | UNTESTED                               |
-//! | listdescriptors                    | version + model | TODO                                   |
+//! | listdescriptors                    | version         |                                        |
 //! | listlabels                         | version + model | UNTESTED                               |
 //! | listlockunspent                    | version + model | UNTESTED                               |
 //! | psbtbumpfee                        | version + model |                                        |
@@ -248,6 +248,7 @@ mod control;
 mod network;
 mod raw_transactions;
 mod signer;
+mod wallet;
 
 #[doc(inline)]
 pub use self::{
@@ -256,6 +257,7 @@ pub use self::{
     network::{Banned, GetPeerInfo, ListBanned},
     raw_transactions::{DecodeScript, DecodeScriptError},
     signer::EnumerateSigners,
+    wallet::ListDescriptors,
 };
 #[doc(inline)]
 pub use crate::{

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -225,7 +225,7 @@
 //! | unloadwallet                       | returns nothing |                                        |
 //! | upgradewallet                      | version         |                                        |
 //! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
-//! | walletdisplayaddress               | version + model | TODO                                   |
+//! | walletdisplayaddress               | version + model | UNTESTED                               |
 //! | walletlock                         | returns nothing |                                        |
 //! | walletpassphrase                   | returns nothing |                                        |
 //! | walletpassphrasechange             | returns nothing |                                        |
@@ -257,7 +257,7 @@ pub use self::{
     network::{Banned, GetPeerInfo, ListBanned},
     raw_transactions::{DecodeScript, DecodeScriptError},
     signer::EnumerateSigners,
-    wallet::ListDescriptors,
+    wallet::{ListDescriptors, WalletDisplayAddress},
 };
 #[doc(inline)]
 pub use crate::{

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -144,7 +144,7 @@
 //!
 //! | JSON-RPC Method Name               | Returns         | Notes                                  |
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
-//! | enumeratesigners                   | version + model | TODO                                   |
+//! | enumeratesigners                   | version         | UNTESTED                               |
 //!
 //! </details>
 //!
@@ -247,6 +247,7 @@ mod blockchain;
 mod control;
 mod network;
 mod raw_transactions;
+mod signer;
 
 #[doc(inline)]
 pub use self::{
@@ -254,6 +255,7 @@ pub use self::{
     control::Logging,
     network::{Banned, GetPeerInfo, ListBanned},
     raw_transactions::{DecodeScript, DecodeScriptError},
+    signer::EnumerateSigners,
 };
 #[doc(inline)]
 pub use crate::{

--- a/types/src/v22/signer.rs
+++ b/types/src/v22/signer.rs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! The JSON-RPC API for Bitcoin Core `v22` - signer.
+//!
+//! Types for methods found under the `== Signer ==` section of the API docs.
+
+use serde::{Deserialize, Serialize};
+
+/// Result of JSON-RPC method `enumeratesigners`.
+///
+/// > Returns a list of external signers from -signer.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct EnumerateSigners(pub Vec<Signers>);
+
+/// An item from the list returned by the JSON-RPC method `enumeratesigners`
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Signers {
+    /// Master key fingerprint.
+    pub hex: String,
+    /// Device name.
+    #[serde(rename = "str")]
+    pub device_name: String,
+}

--- a/types/src/v22/wallet/into.rs
+++ b/types/src/v22/wallet/into.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: CC0-1.0
+
+use bitcoin::{address, Address};
+
+use super::WalletDisplayAddress;
+use crate::model;
+
+impl WalletDisplayAddress {
+    pub fn into_model(self) -> Result<model::WalletDisplayAddress, address::ParseError> {
+        let address = self.address.parse::<Address<_>>()?;
+        Ok(model::WalletDisplayAddress { address })
+    }
+}

--- a/types/src/v22/wallet/mod.rs
+++ b/types/src/v22/wallet/mod.rs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! The JSON-RPC API for Bitcoin Core `v22` - wallet.
+//!
+//! Types for methods found under the `== Wallet ==` section of the API docs.
+
+use serde::{Deserialize, Serialize};
+
+/// Result of JSON-RPC method `listdescriptors`.
+///
+/// > List descriptors imported into a descriptor-enabled wallet.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ListDescriptors {
+    /// Name of wallet this operation was performed on.
+    pub wallet_name: String,
+    /// Array of descriptor objects.
+    pub descriptors: Vec<DescriptorInfo>,
+}
+
+/// A descriptor object from `listdescriptors`.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DescriptorInfo {
+    /// Descriptor string representation.
+    #[serde(rename = "desc")]
+    pub descriptor: String,
+    /// The creation time of the descriptor.
+    pub timestamp: u64,
+    /// Activeness flag.
+    pub active: bool,
+    /// Whether this is an internal or external descriptor; defined only for active descriptors.
+    pub internal: Option<bool>,
+    /// Defined only for ranged descriptors.
+    pub range: Option<[u64; 2]>,
+    /// The next index to generate addresses from; defined only for ranged descriptors.
+    pub next: Option<u64>,
+}

--- a/types/src/v22/wallet/mod.rs
+++ b/types/src/v22/wallet/mod.rs
@@ -4,6 +4,8 @@
 //!
 //! Types for methods found under the `== Wallet ==` section of the API docs.
 
+mod into;
+
 use serde::{Deserialize, Serialize};
 
 /// Result of JSON-RPC method `listdescriptors`.
@@ -35,4 +37,14 @@ pub struct DescriptorInfo {
     pub range: Option<[u64; 2]>,
     /// The next index to generate addresses from; defined only for ranged descriptors.
     pub next: Option<u64>,
+}
+
+/// Result of JSON-RPC method `walletdisplayaddress`.
+///
+/// > Display address on an external signer for verification.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct WalletDisplayAddress {
+    /// The address as confirmed by the signer
+    pub address: String,
 }

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -218,7 +218,7 @@
 //! | unloadwallet                       | returns nothing |                                        |
 //! | upgradewallet                      | version         |                                        |
 //! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
-//! | walletdisplayaddress               | version + model | TODO                                   |
+//! | walletdisplayaddress               | version + model | UNTESTED                               |
 //! | walletlock                         | returns nothing |                                        |
 //! | walletpassphrase                   | returns nothing |                                        |
 //! | walletpassphrasechange             | returns nothing |                                        |
@@ -310,5 +310,8 @@ pub use crate::{
         ImportDescriptors, ImportDescriptorsResult, PsbtBumpFee, PsbtBumpFeeError, Send, SendError,
         UnloadWallet, UpgradeWallet,
     },
-    v22::{Banned, EnumerateSigners, GetMempoolInfo, ListBanned, ListDescriptors, ScriptPubkey},
+    v22::{
+        Banned, EnumerateSigners, GetMempoolInfo, ListBanned, ListDescriptors, ScriptPubkey,
+        WalletDisplayAddress,
+    },
 };

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -189,7 +189,7 @@
 //! | importwallet                       | returns nothing |                                        |
 //! | keypoolrefill                      | returns nothing |                                        |
 //! | listaddressgroupings               | version + model | UNTESTED                               |
-//! | listdescriptors                    | version + model | TODO                                   |
+//! | listdescriptors                    | version         |                                        |
 //! | listlabels                         | version + model | UNTESTED                               |
 //! | listlockunspent                    | version + model | UNTESTED                               |
 //! | newkeypool                         | version + model | TODO                                   |
@@ -310,5 +310,5 @@ pub use crate::{
         ImportDescriptors, ImportDescriptorsResult, PsbtBumpFee, PsbtBumpFeeError, Send, SendError,
         UnloadWallet, UpgradeWallet,
     },
-    v22::{Banned, EnumerateSigners, GetMempoolInfo, ListBanned, ScriptPubkey},
+    v22::{Banned, EnumerateSigners, GetMempoolInfo, ListBanned, ListDescriptors, ScriptPubkey},
 };

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -135,7 +135,7 @@
 //!
 //! | JSON-RPC Method Name               | Returns         | Notes                                  |
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
-//! | enumeratesigners                   | version + model | TODO                                   |
+//! | enumeratesigners                   | version         | UNTESTED                               |
 //!
 //! </details>
 //!
@@ -310,5 +310,5 @@ pub use crate::{
         ImportDescriptors, ImportDescriptorsResult, PsbtBumpFee, PsbtBumpFeeError, Send, SendError,
         UnloadWallet, UpgradeWallet,
     },
-    v22::{Banned, GetMempoolInfo, ListBanned, ScriptPubkey},
+    v22::{Banned, EnumerateSigners, GetMempoolInfo, ListBanned, ScriptPubkey},
 };

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -136,7 +136,7 @@
 //!
 //! | JSON-RPC Method Name               | Returns         | Notes                                  |
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
-//! | enumeratesigners                   | version + model | TODO                                   |
+//! | enumeratesigners                   | version         | UNTESTED                               |
 //!
 //! </details>
 //!
@@ -311,7 +311,7 @@ pub use crate::{
         ImportDescriptors, ImportDescriptorsResult, PsbtBumpFee, PsbtBumpFeeError, Send, SendError,
         UnloadWallet, UpgradeWallet,
     },
-    v22::{Banned, ListBanned, ScriptPubkey},
+    v22::{Banned, EnumerateSigners, ListBanned, ScriptPubkey},
     v23::{
         CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, Logging, SaveMempool,
     },

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -190,7 +190,7 @@
 //! | importwallet                       | returns nothing |                                        |
 //! | keypoolrefill                      | returns nothing |                                        |
 //! | listaddressgroupings               | version + model | UNTESTED                               |
-//! | listdescriptors                    | version + model | TODO                                   |
+//! | listdescriptors                    | version         |                                        |
 //! | listlabels                         | version + model | UNTESTED                               |
 //! | listlockunspent                    | version + model | UNTESTED                               |
 //! | migratewallet                      | version + model | TODO                                   |
@@ -311,7 +311,7 @@ pub use crate::{
         ImportDescriptors, ImportDescriptorsResult, PsbtBumpFee, PsbtBumpFeeError, Send, SendError,
         UnloadWallet, UpgradeWallet,
     },
-    v22::{Banned, EnumerateSigners, ListBanned, ScriptPubkey},
+    v22::{Banned, EnumerateSigners, ListBanned, ListDescriptors, ScriptPubkey},
     v23::{
         CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, Logging, SaveMempool,
     },

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -222,7 +222,7 @@
 //! | unloadwallet                       | returns nothing |                                        |
 //! | upgradewallet                      | version         |                                        |
 //! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
-//! | walletdisplayaddress               | version + model | TODO                                   |
+//! | walletdisplayaddress               | version + model | UNTESTED                               |
 //! | walletlock                         | returns nothing |                                        |
 //! | walletpassphrase                   | returns nothing |                                        |
 //! | walletpassphrasechange             | returns nothing |                                        |
@@ -311,7 +311,9 @@ pub use crate::{
         ImportDescriptors, ImportDescriptorsResult, PsbtBumpFee, PsbtBumpFeeError, Send, SendError,
         UnloadWallet, UpgradeWallet,
     },
-    v22::{Banned, EnumerateSigners, ListBanned, ListDescriptors, ScriptPubkey},
+    v22::{
+        Banned, EnumerateSigners, ListBanned, ListDescriptors, ScriptPubkey, WalletDisplayAddress,
+    },
     v23::{
         CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, Logging, SaveMempool,
     },

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -223,7 +223,7 @@
 //! | unloadwallet                       | returns nothing |                                        |
 //! | upgradewallet                      | version         |                                        |
 //! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
-//! | walletdisplayaddress               | version + model | TODO                                   |
+//! | walletdisplayaddress               | version + model | UNTESTED                               |
 //! | walletlock                         | returns nothing |                                        |
 //! | walletpassphrase                   | returns nothing |                                        |
 //! | walletpassphrasechange             | returns nothing |                                        |
@@ -305,7 +305,7 @@ pub use crate::{
         GetIndexInfo, GetIndexInfoName, GetNetworkInfo, ImportDescriptors, ImportDescriptorsResult,
         PsbtBumpFee, PsbtBumpFeeError, Send, SendError, UpgradeWallet,
     },
-    v22::{Banned, EnumerateSigners, ListBanned, ScriptPubkey},
+    v22::{Banned, EnumerateSigners, ListBanned, ScriptPubkey, WalletDisplayAddress},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, SaveMempool},
     v24::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetPeerInfo, GetTransaction,

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -191,7 +191,7 @@
 //! | importwallet                       | returns nothing |                                        |
 //! | keypoolrefill                      | returns nothing |                                        |
 //! | listaddressgroupings               | version + model | UNTESTED                               |
-//! | listdescriptors                    | version + model | TODO                                   |
+//! | listdescriptors                    | version         |                                        |
 //! | listlabels                         | version + model | UNTESTED                               |
 //! | listlockunspent                    | version + model | UNTESTED                               |
 //! | migratewallet                      | version + model | TODO                                   |
@@ -250,7 +250,7 @@ pub use self::{
     blockchain::GetBlockStats,
     control::Logging,
     generating::{GenerateBlock, GenerateBlockError},
-    wallet::{CreateWallet, LoadWallet, UnloadWallet},
+    wallet::{CreateWallet, ListDescriptors, LoadWallet, UnloadWallet},
 };
 #[doc(inline)]
 pub use crate::{

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -137,7 +137,7 @@
 //!
 //! | JSON-RPC Method Name               | Returns         | Notes                                  |
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
-//! | enumeratesigners                   | version + model | TODO                                   |
+//! | enumeratesigners                   | version         | UNTESTED                               |
 //!
 //! </details>
 //!
@@ -305,7 +305,7 @@ pub use crate::{
         GetIndexInfo, GetIndexInfoName, GetNetworkInfo, ImportDescriptors, ImportDescriptorsResult,
         PsbtBumpFee, PsbtBumpFeeError, Send, SendError, UpgradeWallet,
     },
-    v22::{Banned, ListBanned, ScriptPubkey},
+    v22::{Banned, EnumerateSigners, ListBanned, ScriptPubkey},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, SaveMempool},
     v24::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetPeerInfo, GetTransaction,

--- a/types/src/v25/wallet.rs
+++ b/types/src/v25/wallet.rs
@@ -77,7 +77,7 @@ pub struct DescriptorInfo {
     pub internal: Option<bool>,
     /// Defined only for ranged descriptors.
     pub range: Option<[u64; 2]>,
-    /// The next index to generate addresses from; defined only for ranged descriptors.
+    /// Same as `next_index` field. Kept for compatibility reason.
     pub next: Option<u64>,
     /// The next index to generate addresses from; defined only for ranged descriptors.
     pub next_index: Option<u64>,

--- a/types/src/v25/wallet.rs
+++ b/types/src/v25/wallet.rs
@@ -50,6 +50,38 @@ impl CreateWallet {
     /// Returns the created wallet name.
     pub fn name(self) -> String { self.into_model().name }
 }
+/// Result of JSON-RPC method `listdescriptors`.
+///
+/// > List descriptors imported into a descriptor-enabled wallet.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ListDescriptors {
+    /// Name of wallet this operation was performed on.
+    pub wallet_name: String,
+    /// Array of descriptor objects.
+    pub descriptors: Vec<DescriptorInfo>,
+}
+
+/// A descriptor object from `listdescriptors`.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DescriptorInfo {
+    /// Descriptor string representation.
+    #[serde(rename = "desc")]
+    pub descriptor: String,
+    /// The creation time of the descriptor.
+    pub timestamp: u64,
+    /// Activeness flag.
+    pub active: bool,
+    /// Whether this is an internal or external descriptor; defined only for active descriptors.
+    pub internal: Option<bool>,
+    /// Defined only for ranged descriptors.
+    pub range: Option<[u64; 2]>,
+    /// The next index to generate addresses from; defined only for ranged descriptors.
+    pub next: Option<u64>,
+    /// The next index to generate addresses from; defined only for ranged descriptors.
+    pub next_index: Option<u64>,
+}
 
 /// Result of the JSON-RPC method `loadwallet`.
 ///

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -231,7 +231,7 @@
 //! | unloadwallet                       | returns nothing |                                        |
 //! | upgradewallet                      | version         |                                        |
 //! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
-//! | walletdisplayaddress               | version + model | TODO                                   |
+//! | walletdisplayaddress               | version + model | UNTESTED                               |
 //! | walletlock                         | returns nothing |                                        |
 //! | walletpassphrase                   | returns nothing |                                        |
 //! | walletpassphrasechange             | returns nothing |                                        |
@@ -323,7 +323,7 @@ pub use crate::{
         GetIndexInfo, GetIndexInfoName, GetNetworkInfo, ImportDescriptors, ImportDescriptorsResult,
         PsbtBumpFee, PsbtBumpFeeError, Send, SendError, UpgradeWallet,
     },
-    v22::{Banned, EnumerateSigners, ListBanned, ScriptPubkey},
+    v22::{Banned, EnumerateSigners, ListBanned, ScriptPubkey, WalletDisplayAddress},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, SaveMempool},
     v24::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -145,7 +145,7 @@
 //!
 //! | JSON-RPC Method Name               | Returns         | Notes                                  |
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
-//! | enumeratesigners                   | version + model | TODO                                   |
+//! | enumeratesigners                   | version         | UNTESTED                               |
 //!
 //! </details>
 //!
@@ -323,7 +323,7 @@ pub use crate::{
         GetIndexInfo, GetIndexInfoName, GetNetworkInfo, ImportDescriptors, ImportDescriptorsResult,
         PsbtBumpFee, PsbtBumpFeeError, Send, SendError, UpgradeWallet,
     },
-    v22::{Banned, ListBanned, ScriptPubkey},
+    v22::{Banned, EnumerateSigners, ListBanned, ScriptPubkey},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, SaveMempool},
     v24::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -199,7 +199,7 @@
 //! | importwallet                       | returns nothing |                                        |
 //! | keypoolrefill                      | returns nothing |                                        |
 //! | listaddressgroupings               | version + model | UNTESTED                               |
-//! | listdescriptors                    | version + model | TODO                                   |
+//! | listdescriptors                    | version         |                                        |
 //! | listlabels                         | version + model | UNTESTED                               |
 //! | listlockunspent                    | version + model | UNTESTED                               |
 //! | migratewallet                      | version + model | TODO                                   |
@@ -330,5 +330,5 @@ pub use crate::{
         GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,
         TaprootBip32Deriv, TaprootLeaf, TaprootScript, TaprootScriptPathSig,
     },
-    v25::{GenerateBlock, GenerateBlockError, GetBlockStats},
+    v25::{GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors},
 };

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -145,7 +145,7 @@
 //!
 //! | JSON-RPC Method Name               | Returns         | Notes                                  |
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
-//! | enumeratesigners                   | version + model | TODO                                   |
+//! | enumeratesigners                   | version         | UNTESTED                               |
 //!
 //! </details>
 //!
@@ -300,7 +300,7 @@ pub use crate::{
         GetIndexInfo, GetIndexInfoName, GetNetworkInfo, ImportDescriptors, ImportDescriptorsResult,
         PsbtBumpFee, PsbtBumpFeeError, Send, SendError, UpgradeWallet,
     },
-    v22::{Banned, ListBanned, ScriptPubkey},
+    v22::{Banned, EnumerateSigners, ListBanned, ScriptPubkey},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, SaveMempool},
     v24::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -199,7 +199,7 @@
 //! | importwallet                       | returns nothing |                                        |
 //! | keypoolrefill                      | returns nothing |                                        |
 //! | listaddressgroupings               | version + model | UNTESTED                               |
-//! | listdescriptors                    | version + model | TODO                                   |
+//! | listdescriptors                    | version         |                                        |
 //! | listlabels                         | version + model | UNTESTED                               |
 //! | listlockunspent                    | version + model | UNTESTED                               |
 //! | migratewallet                      | version + model | TODO                                   |
@@ -307,7 +307,7 @@ pub use crate::{
         GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,
         TaprootBip32Deriv, TaprootLeaf, TaprootScript, TaprootScriptPathSig,
     },
-    v25::{GenerateBlock, GenerateBlockError, GetBlockStats},
+    v25::{GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors},
     v26::{
         CreateWallet, DescriptorProcessPsbt, DescriptorProcessPsbtError, GetBalances,
         GetBalancesError, GetPeerInfo, GetPrioritisedTransactions, GetTransaction,

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -231,7 +231,7 @@
 //! | unloadwallet                       | returns nothing |                                        |
 //! | upgradewallet                      | version         |                                        |
 //! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
-//! | walletdisplayaddress               | version + model | TODO                                   |
+//! | walletdisplayaddress               | version + model | UNTESTED                               |
 //! | walletlock                         | returns nothing |                                        |
 //! | walletpassphrase                   | returns nothing |                                        |
 //! | walletpassphrasechange             | returns nothing |                                        |
@@ -300,7 +300,7 @@ pub use crate::{
         GetIndexInfo, GetIndexInfoName, GetNetworkInfo, ImportDescriptors, ImportDescriptorsResult,
         PsbtBumpFee, PsbtBumpFeeError, Send, SendError, UpgradeWallet,
     },
-    v22::{Banned, EnumerateSigners, ListBanned, ScriptPubkey},
+    v22::{Banned, EnumerateSigners, ListBanned, ScriptPubkey, WalletDisplayAddress},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, SaveMempool},
     v24::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -201,7 +201,7 @@
 //! | importwallet                       | returns nothing |                                        |
 //! | keypoolrefill                      | returns nothing |                                        |
 //! | listaddressgroupings               | version + model | UNTESTED                               |
-//! | listdescriptors                    | version + model | TODO                                   |
+//! | listdescriptors                    | version         |                                        |
 //! | listlabels                         | version + model | UNTESTED                               |
 //! | listlockunspent                    | version + model | UNTESTED                               |
 //! | migratewallet                      | version + model | TODO                                   |
@@ -328,7 +328,7 @@ pub use crate::{
         GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,
         TaprootBip32Deriv, TaprootLeaf, TaprootScript, TaprootScriptPathSig,
     },
-    v25::{GenerateBlock, GenerateBlockError, GetBlockStats},
+    v25::{GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors},
     v26::{
         CreateWallet, DescriptorProcessPsbt, DescriptorProcessPsbtError, GetBalances,
         GetBalancesError, GetPeerInfo, GetPrioritisedTransactions, GetTransactionError,

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -145,7 +145,7 @@
 //!
 //! | JSON-RPC Method Name               | Returns         | Notes                                  |
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
-//! | enumeratesigners                   | version + model | TODO                                   |
+//! | enumeratesigners                   | version         | UNTESTED                               |
 //!
 //! </details>
 //!
@@ -321,7 +321,7 @@ pub use crate::{
         GetIndexInfo, GetIndexInfoName, ImportDescriptors, ImportDescriptorsResult, PsbtBumpFee,
         PsbtBumpFeeError, Send, SendError, UpgradeWallet,
     },
-    v22::{Banned, ListBanned, ScriptPubkey},
+    v22::{Banned, EnumerateSigners, ListBanned, ScriptPubkey},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, SaveMempool},
     v24::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -233,7 +233,7 @@
 //! | unloadwallet                       | returns nothing |                                        |
 //! | upgradewallet                      | version         |                                        |
 //! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
-//! | walletdisplayaddress               | version + model | TODO                                   |
+//! | walletdisplayaddress               | version + model | UNTESTED                               |
 //! | walletlock                         | returns nothing |                                        |
 //! | walletpassphrase                   | returns nothing |                                        |
 //! | walletpassphrasechange             | returns nothing |                                        |
@@ -321,7 +321,7 @@ pub use crate::{
         GetIndexInfo, GetIndexInfoName, ImportDescriptors, ImportDescriptorsResult, PsbtBumpFee,
         PsbtBumpFeeError, Send, SendError, UpgradeWallet,
     },
-    v22::{Banned, EnumerateSigners, ListBanned, ScriptPubkey},
+    v22::{Banned, EnumerateSigners, ListBanned, ScriptPubkey, WalletDisplayAddress},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, SaveMempool},
     v24::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -202,7 +202,7 @@
 //! | importwallet                       | returns nothing |                                        |
 //! | keypoolrefill                      | returns nothing |                                        |
 //! | listaddressgroupings               | version + model | UNTESTED                               |
-//! | listdescriptors                    | version + model | TODO                                   |
+//! | listdescriptors                    | version         |                                        |
 //! | listlabels                         | version + model | UNTESTED                               |
 //! | listlockunspent                    | version + model | UNTESTED                               |
 //! | migratewallet                      | version + model | TODO                                   |
@@ -326,7 +326,7 @@ pub use crate::{
         GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,
         TaprootBip32Deriv, TaprootLeaf, TaprootScript, TaprootScriptPathSig,
     },
-    v25::{GenerateBlock, GenerateBlockError, GetBlockStats},
+    v25::{GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors},
     v26::{
         CreateWallet, DescriptorProcessPsbt, DescriptorProcessPsbtError, GetBalances,
         GetBalancesError, GetPrioritisedTransactions, GetTransactionError, GetTxOutSetInfo,

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -146,7 +146,7 @@
 //!
 //! | JSON-RPC Method Name               | Returns         | Notes                                  |
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
-//! | enumeratesigners                   | version + model | TODO                                   |
+//! | enumeratesigners                   | version         | UNTESTED                               |
 //!
 //! </details>
 //!
@@ -319,7 +319,7 @@ pub use crate::{
         GetIndexInfo, GetIndexInfoName, ImportDescriptors, ImportDescriptorsResult, PsbtBumpFee,
         PsbtBumpFeeError, Send, SendError, UpgradeWallet,
     },
-    v22::{Banned, ListBanned, ScriptPubkey},
+    v22::{Banned, EnumerateSigners, ListBanned, ScriptPubkey},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, SaveMempool},
     v24::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -234,7 +234,7 @@
 //! | unloadwallet                       | returns nothing |                                        |
 //! | upgradewallet                      | version         |                                        |
 //! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
-//! | walletdisplayaddress               | version + model | TODO                                   |
+//! | walletdisplayaddress               | version + model | UNTESTED                               |
 //! | walletlock                         | returns nothing |                                        |
 //! | walletpassphrase                   | returns nothing |                                        |
 //! | walletpassphrasechange             | returns nothing |                                        |
@@ -319,7 +319,7 @@ pub use crate::{
         GetIndexInfo, GetIndexInfoName, ImportDescriptors, ImportDescriptorsResult, PsbtBumpFee,
         PsbtBumpFeeError, Send, SendError, UpgradeWallet,
     },
-    v22::{Banned, EnumerateSigners, ListBanned, ScriptPubkey},
+    v22::{Banned, EnumerateSigners, ListBanned, ScriptPubkey, WalletDisplayAddress},
     v23::{CreateMultisig, DecodeScript, DecodeScriptError, SaveMempool},
     v24::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,

--- a/verify/src/method/v22.rs
+++ b/verify/src/method/v22.rs
@@ -131,7 +131,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("importwallet", "import_walet"),
     Method::new_nothing("keypoolrefill", "keypool_refill"),
     Method::new_modelled("listaddressgroupings", "ListAddressGroupings", "list_address_groupings"),
-    Method::new_modelled("listdescriptors", "ListDescriptors", "list_descriptors"),
+    Method::new_no_model("listdescriptors", "ListDescriptors", "list_descriptors"),
     Method::new_modelled("listlabels", "ListLabels", "list_labels"),
     Method::new_modelled("listlockunspent", "ListLockUnspent", "list_lock_unspent"),
     Method::new_modelled("psbtbumpfee", "PsbtBumpFee", "psbt_bump_fee"),

--- a/verify/src/method/v22.rs
+++ b/verify/src/method/v22.rs
@@ -87,7 +87,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("testmempoolaccept", "test_mempool_accept"),
     Method::new_modelled("utxoupdatepsbt", "UtxoUpdatePsbt", "utxo_update_psbt"),
     // signer
-    Method::new_modelled("enumeratesigners", "EnumerateSigners", "enumerate_signers"),
+    Method::new_no_model("enumeratesigners", "EnumerateSigners", "enumerate_signers"),
     // util
     Method::new_modelled("createmultisig", "CreateMultisig", "create_multisig"),
     Method::new_modelled("deriveaddresses", "DeriveAddresses", "derive_addresses"),

--- a/verify/src/method/v23.rs
+++ b/verify/src/method/v23.rs
@@ -129,7 +129,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("importwallet", "import_walet"),
     Method::new_nothing("keypoolrefill", "keypool_refill"),
     Method::new_modelled("listaddressgroupings", "ListAddressGroupings", "list_address_groupings"),
-    Method::new_modelled("listdescriptors", "ListDescriptors", "list_descriptors"),
+    Method::new_no_model("listdescriptors", "ListDescriptors", "list_descriptors"),
     Method::new_modelled("listlabels", "ListLabels", "list_labels"),
     Method::new_modelled("listlockunspent", "ListLockUnspent", "list_lock_unspent"),
     Method::new_modelled("newkeypool", "NewKeyPool", "new_key_pool"),

--- a/verify/src/method/v23.rs
+++ b/verify/src/method/v23.rs
@@ -93,6 +93,8 @@ pub const METHODS: &[Method] = &[
     Method::new_string("signmessagewithprivkey", "sign_message_with_priv_key"),
     Method::new_modelled("validateaddress", "ValidateAddress", "validate_address"),
     Method::new_bool("verifymessage", "verify_message"),
+    // signer
+    Method::new_no_model("enumeratesigners", "EnumerateSigners", "enumerate_signers"),
     // wallet
     Method::new_nothing("abandontransaction", "abandon_transaction"),
     Method::new_no_model("abortrescan", "AbortRescan", "abort_rescan"),

--- a/verify/src/method/v24.rs
+++ b/verify/src/method/v24.rs
@@ -94,6 +94,8 @@ pub const METHODS: &[Method] = &[
     Method::new_string("signmessagewithprivkey", "sign_message_with_priv_key"),
     Method::new_modelled("validateaddress", "ValidateAddress", "validate_address"),
     Method::new_bool("verifymessage", "verify_message"),
+    // signer
+    Method::new_no_model("enumeratesigners", "EnumerateSigners", "enumerate_signers"),
     // wallet
     Method::new_nothing("abandontransaction", "abandon_transaction"),
     Method::new_no_model("abortrescan", "AbortRescan", "abort_rescan"),

--- a/verify/src/method/v24.rs
+++ b/verify/src/method/v24.rs
@@ -130,7 +130,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("importwallet", "import_walet"),
     Method::new_nothing("keypoolrefill", "keypool_refill"),
     Method::new_modelled("listaddressgroupings", "ListAddressGroupings", "list_address_groupings"),
-    Method::new_modelled("listdescriptors", "ListDescriptors", "list_descriptors"),
+    Method::new_no_model("listdescriptors", "ListDescriptors", "list_descriptors"),
     Method::new_modelled("listlabels", "ListLabels", "list_labels"),
     Method::new_modelled("listlockunspent", "ListLockUnspent", "list_lock_unspent"),
     Method::new_modelled("migratewallet", "MigrateWallet", "migrate_wallet"),

--- a/verify/src/method/v25.rs
+++ b/verify/src/method/v25.rs
@@ -96,6 +96,8 @@ pub const METHODS: &[Method] = &[
     Method::new_modelled("validateaddress", "ValidateAddress", "validate_address"),
     Method::new_bool("verifymessage", "verify_message"),
     Method::new_nothing("abandontransaction", "abandon_transaction"),
+    // signer
+    Method::new_no_model("enumeratesigners", "EnumerateSigners", "enumerate_signers"),
     // wallet
     Method::new_no_model("abortrescan", "AbortRescan", "abort_rescan"),
     Method::new_modelled("addmultisigaddress", "AddMultisigAddress", "add_multisig_address"),

--- a/verify/src/method/v25.rs
+++ b/verify/src/method/v25.rs
@@ -131,7 +131,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("importwallet", "import_walet"),
     Method::new_nothing("keypoolrefill", "keypool_refill"),
     Method::new_modelled("listaddressgroupings", "ListAddressGroupings", "list_address_groupings"),
-    Method::new_modelled("listdescriptors", "ListDescriptors", "list_descriptors"),
+    Method::new_no_model("listdescriptors", "ListDescriptors", "list_descriptors"),
     Method::new_modelled("listlabels", "ListLabels", "list_labels"),
     Method::new_modelled("listlockunspent", "ListLockUnspent", "list_lock_unspent"),
     Method::new_modelled("migratewallet", "MigrateWallet", "migrate_wallet"),

--- a/verify/src/method/v26.rs
+++ b/verify/src/method/v26.rs
@@ -139,7 +139,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("importwallet", "import_walet"),
     Method::new_nothing("keypoolrefill", "keypool_refill"),
     Method::new_modelled("listaddressgroupings", "ListAddressGroupings", "list_address_groupings"),
-    Method::new_modelled("listdescriptors", "ListDescriptors", "list_descriptors"),
+    Method::new_no_model("listdescriptors", "ListDescriptors", "list_descriptors"),
     Method::new_modelled("listlabels", "ListLabels", "list_labels"),
     Method::new_modelled("listlockunspent", "ListLockUnspent", "list_lock_unspent"),
     Method::new_modelled("migratewallet", "MigrateWallet", "migrate_wallet"),

--- a/verify/src/method/v26.rs
+++ b/verify/src/method/v26.rs
@@ -103,6 +103,8 @@ pub const METHODS: &[Method] = &[
     Method::new_string("signmessagewithprivkey", "sign_message_with_priv_key"),
     Method::new_modelled("validateaddress", "ValidateAddress", "validate_address"),
     Method::new_bool("verifymessage", "verify_message"),
+    // signer
+    Method::new_no_model("enumeratesigners", "EnumerateSigners", "enumerate_signers"),
     // wallet
     Method::new_nothing("abandontransaction", "abandon_transaction"),
     Method::new_no_model("abortrescan", "AbortRescan", "abort_rescan"),

--- a/verify/src/method/v26.rs
+++ b/verify/src/method/v26.rs
@@ -74,6 +74,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("ping", "ping"),
     Method::new_nothing("setban", "set_ban"),
     Method::new_no_model("setnetworkactive", "SetNetworkActive", "set_network_active"),
+    // raw transactions
     Method::new_modelled("analyzepsbt", "AnalyzePsbt", "analyze_psbt"),
     Method::new_nothing("combinepsbt", "combine_psbt"),
     Method::new_nothing("combinerawtransaction", "combine_raw_transaction"),

--- a/verify/src/method/v27.rs
+++ b/verify/src/method/v27.rs
@@ -141,7 +141,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("importwallet", "import_walet"),
     Method::new_nothing("keypoolrefill", "keypool_refill"),
     Method::new_modelled("listaddressgroupings", "ListAddressGroupings", "list_address_groupings"),
-    Method::new_modelled("listdescriptors", "ListDescriptors", "list_descriptors"),
+    Method::new_no_model("listdescriptors", "ListDescriptors", "list_descriptors"),
     Method::new_modelled("listlabels", "ListLabels", "list_labels"),
     Method::new_modelled("listlockunspent", "ListLockUnspent", "list_lock_unspent"),
     Method::new_modelled("migratewallet", "MigrateWallet", "migrate_wallet"),

--- a/verify/src/method/v27.rs
+++ b/verify/src/method/v27.rs
@@ -105,6 +105,8 @@ pub const METHODS: &[Method] = &[
     Method::new_string("signmessagewithprivkey", "sign_message_with_priv_key"),
     Method::new_modelled("validateaddress", "ValidateAddress", "validate_address"),
     Method::new_bool("verifymessage", "verify_message"),
+    // signer
+    Method::new_no_model("enumeratesigners", "EnumerateSigners", "enumerate_signers"),
     // wallet
     Method::new_nothing("abandontransaction", "abandon_transaction"),
     Method::new_no_model("abortrescan", "AbortRescan", "abort_rescan"),

--- a/verify/src/method/v28.rs
+++ b/verify/src/method/v28.rs
@@ -143,7 +143,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("importwallet", "import_walet"),
     Method::new_nothing("keypoolrefill", "keypool_refill"),
     Method::new_modelled("listaddressgroupings", "ListAddressGroupings", "list_address_groupings"),
-    Method::new_modelled("listdescriptors", "ListDescriptors", "list_descriptors"),
+    Method::new_no_model("listdescriptors", "ListDescriptors", "list_descriptors"),
     Method::new_modelled("listlabels", "ListLabels", "list_labels"),
     Method::new_modelled("listlockunspent", "ListLockUnspent", "list_lock_unspent"),
     Method::new_modelled("migratewallet", "MigrateWallet", "migrate_wallet"),

--- a/verify/src/method/v28.rs
+++ b/verify/src/method/v28.rs
@@ -105,6 +105,8 @@ pub const METHODS: &[Method] = &[
     Method::new_string("signmessagewithprivkey", "sign_message_with_priv_key"),
     Method::new_modelled("validateaddress", "ValidateAddress", "validate_address"),
     Method::new_bool("verifymessage", "verify_message"),
+    // signer
+    Method::new_no_model("enumeratesigners", "EnumerateSigners", "enumerate_signers"),
     // wallet
     Method::new_nothing("abandontransaction", "abandon_transaction"),
     Method::new_no_model("abortrescan", "AbortRescan", "abort_rescan"),

--- a/verify/src/method/v29.rs
+++ b/verify/src/method/v29.rs
@@ -144,7 +144,7 @@ pub const METHODS: &[Method] = &[
     Method::new_nothing("importwallet", "import_walet"),
     Method::new_nothing("keypoolrefill", "keypool_refill"),
     Method::new_modelled("listaddressgroupings", "ListAddressGroupings", "list_address_groupings"),
-    Method::new_modelled("listdescriptors", "ListDescriptors", "list_descriptors"),
+    Method::new_no_model("listdescriptors", "ListDescriptors", "list_descriptors"),
     Method::new_modelled("listlabels", "ListLabels", "list_labels"),
     Method::new_modelled("listlockunspent", "ListLockUnspent", "list_lock_unspent"),
     Method::new_modelled("migratewallet", "MigrateWallet", "migrate_wallet"),

--- a/verify/src/method/v29.rs
+++ b/verify/src/method/v29.rs
@@ -106,6 +106,8 @@ pub const METHODS: &[Method] = &[
     Method::new_string("signmessagewithprivkey", "sign_message_with_priv_key"),
     Method::new_modelled("validateaddress", "ValidateAddress", "validate_address"),
     Method::new_bool("verifymessage", "verify_message"),
+    // signer
+    Method::new_no_model("enumeratesigners", "EnumerateSigners", "enumerate_signers"),
     // wallet
     Method::new_nothing("abandontransaction", "abandon_transaction"),
     Method::new_no_model("abortrescan", "AbortRescan", "abort_rescan"),


### PR DESCRIPTION
Go through all the TODO in the v22 types table. Add all the missing RPCs. 

Redefine `listdescriptors` in v25 due to added return field.

`enumeratesigners` and `walletdisplayaddress` RPCs require an external signer and have been left untested because of this. Opened #294.

