### PR TITLE
Address all TODO in v23

### DIFF
--- a/client/src/client_sync/v23/blockchain.rs
+++ b/client/src/client_sync/v23/blockchain.rs
@@ -25,6 +25,18 @@ macro_rules! impl_client_v23__get_block_from_peer {
     };
 }
 
+/// Implements Bitcoin Core JSON-RPC API method `getdeploymentinfo`.
+#[macro_export]
+macro_rules! impl_client_v23__get_deployment_info {
+    () => {
+        impl Client {
+            pub fn get_deployment_info(&self, blockhash: &BlockHash) -> Result<GetDeploymentInfo> {
+                self.call("getdeploymentinfo", &[into_json(blockhash)?])
+            }
+        }
+    };
+}
+
 /// Implements Bitcoin Core JSON-RPC API method `savemempool`
 #[macro_export]
 macro_rules! impl_client_v23__save_mempool {

--- a/client/src/client_sync/v23/blockchain.rs
+++ b/client/src/client_sync/v23/blockchain.rs
@@ -9,6 +9,22 @@
 //!
 //! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
 
+/// Implements Bitcoin Core JSON-RPC API method `getblockfrompeer`
+#[macro_export]
+macro_rules! impl_client_v23__get_block_from_peer {
+    () => {
+        impl Client {
+            pub fn get_block_from_peer(&self, blockhash: BlockHash, peer_id: u32) -> Result<()> {
+                match self.call("getblockfrompeer", &[into_json(blockhash)?, into_json(peer_id)?]) {
+                    Ok(serde_json::Value::Object(ref map)) if map.is_empty() => Ok(()),
+                    Ok(res) => Err(Error::Returned(res.to_string())),
+                    Err(err) => Err(err.into()),
+                }
+            }
+        }
+    };
+}
+
 /// Implements Bitcoin Core JSON-RPC API method `savemempool`
 #[macro_export]
 macro_rules! impl_client_v23__save_mempool {

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -172,6 +172,7 @@ crate::impl_client_v17__lock_unspent!();
 crate::impl_client_v21__psbt_bump_fee!();
 crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
+crate::impl_client_v23__restore_wallet!();
 crate::impl_client_v21__send!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -169,6 +169,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v23__new_keypool!();
 crate::impl_client_v21__psbt_bump_fee!();
 crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -35,6 +35,7 @@ crate::impl_client_v17__get_block!();
 crate::impl_client_v17__get_blockchain_info!();
 crate::impl_client_v17__get_block_count!();
 crate::impl_client_v19__get_block_filter!();
+crate::impl_client_v23__get_block_from_peer!();
 crate::impl_client_v17__get_block_hash!();
 crate::impl_client_v17__get_block_header!();
 crate::impl_client_v17__get_block_stats!();

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -41,6 +41,7 @@ crate::impl_client_v17__get_block_header!();
 crate::impl_client_v17__get_block_stats!();
 crate::impl_client_v17__get_chain_tips!();
 crate::impl_client_v17__get_chain_tx_stats!();
+crate::impl_client_v23__get_deployment_info!();
 crate::impl_client_v17__get_difficulty!();
 crate::impl_client_v17__get_mempool_ancestors!();
 crate::impl_client_v17__get_mempool_descendants!();

--- a/client/src/client_sync/v23/wallet.rs
+++ b/client/src/client_sync/v23/wallet.rs
@@ -57,6 +57,28 @@ macro_rules! impl_client_v23__create_wallet {
     };
 }
 
+/// Implements Bitcoin Core JSON-RPC API method `newkeypool`.
+#[macro_export]
+macro_rules! impl_client_v23__new_keypool {
+    () => {
+        impl Client {
+            /// Calls `newkeypool` for the loaded wallet.
+            ///
+            /// > newkeypool
+            /// >
+            /// > Entirely clears and refills the keypool.
+            /// > Requires wallet passphrase to be set if wallet is encrypted.
+            pub fn new_keypool(&self) -> Result<()> {
+                match self.call("newkeypool", &[]) {
+                    Ok(serde_json::Value::Null) => Ok(()),
+                    Ok(res) => Err(Error::Returned(res.to_string())),
+                    Err(err) => Err(err.into()),
+                }
+            }
+        }
+    };
+}
+
 /// Implements Bitcoin Core JSON-RPC API method `restorewallet`.
 #[macro_export]
 macro_rules! impl_client_v23__restore_wallet {

--- a/client/src/client_sync/v23/wallet.rs
+++ b/client/src/client_sync/v23/wallet.rs
@@ -56,3 +56,22 @@ macro_rules! impl_client_v23__create_wallet {
         }
     };
 }
+
+/// Implements Bitcoin Core JSON-RPC API method `restorewallet`.
+#[macro_export]
+macro_rules! impl_client_v23__restore_wallet {
+    () => {
+        impl Client {
+            /// Calls `restorewallet` with required and optional arguments.
+            ///
+            /// > restorewallet "wallet_name" "backup_file" ( load_on_startup )
+            pub fn restore_wallet(
+                &self,
+                wallet_name: &str,
+                backup_file: &Path,
+            ) -> Result<RestoreWallet> {
+                self.call("restorewallet", &[wallet_name.into(), into_json(backup_file)?])
+            }
+        }
+    };
+}

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -32,6 +32,7 @@ crate::impl_client_v17__get_block!();
 crate::impl_client_v17__get_blockchain_info!();
 crate::impl_client_v17__get_block_count!();
 crate::impl_client_v19__get_block_filter!();
+crate::impl_client_v23__get_block_from_peer!();
 crate::impl_client_v17__get_block_hash!();
 crate::impl_client_v17__get_block_header!();
 crate::impl_client_v17__get_block_stats!();

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -38,6 +38,7 @@ crate::impl_client_v17__get_block_header!();
 crate::impl_client_v17__get_block_stats!();
 crate::impl_client_v17__get_chain_tips!();
 crate::impl_client_v17__get_chain_tx_stats!();
+crate::impl_client_v23__get_deployment_info!();
 crate::impl_client_v17__get_difficulty!();
 crate::impl_client_v17__get_mempool_ancestors!();
 crate::impl_client_v17__get_mempool_descendants!();

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -169,6 +169,7 @@ crate::impl_client_v17__lock_unspent!();
 crate::impl_client_v21__psbt_bump_fee!();
 crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
+crate::impl_client_v23__restore_wallet!();
 crate::impl_client_v21__send!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -166,6 +166,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v23__new_keypool!();
 crate::impl_client_v21__psbt_bump_fee!();
 crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -34,6 +34,7 @@ crate::impl_client_v17__get_block!();
 crate::impl_client_v17__get_blockchain_info!();
 crate::impl_client_v17__get_block_count!();
 crate::impl_client_v19__get_block_filter!();
+crate::impl_client_v23__get_block_from_peer!();
 crate::impl_client_v17__get_block_hash!();
 crate::impl_client_v17__get_block_header!();
 crate::impl_client_v17__get_block_stats!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -168,6 +168,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v23__new_keypool!();
 crate::impl_client_v21__psbt_bump_fee!();
 crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -40,6 +40,7 @@ crate::impl_client_v17__get_block_header!();
 crate::impl_client_v17__get_block_stats!();
 crate::impl_client_v17__get_chain_tips!();
 crate::impl_client_v17__get_chain_tx_stats!();
+crate::impl_client_v23__get_deployment_info!();
 crate::impl_client_v17__get_difficulty!();
 crate::impl_client_v17__get_mempool_ancestors!();
 crate::impl_client_v17__get_mempool_descendants!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -171,6 +171,7 @@ crate::impl_client_v17__lock_unspent!();
 crate::impl_client_v21__psbt_bump_fee!();
 crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
+crate::impl_client_v23__restore_wallet!();
 crate::impl_client_v21__send!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -42,6 +42,7 @@ crate::impl_client_v17__get_block_header!();
 crate::impl_client_v17__get_block_stats!();
 crate::impl_client_v17__get_chain_tips!();
 crate::impl_client_v17__get_chain_tx_stats!();
+crate::impl_client_v23__get_deployment_info!();
 crate::impl_client_v17__get_difficulty!();
 crate::impl_client_v17__get_mempool_ancestors!();
 crate::impl_client_v17__get_mempool_descendants!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -36,6 +36,7 @@ crate::impl_client_v17__get_block!();
 crate::impl_client_v17__get_blockchain_info!();
 crate::impl_client_v17__get_block_count!();
 crate::impl_client_v19__get_block_filter!();
+crate::impl_client_v23__get_block_from_peer!();
 crate::impl_client_v17__get_block_hash!();
 crate::impl_client_v17__get_block_header!();
 crate::impl_client_v17__get_block_stats!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -175,6 +175,7 @@ crate::impl_client_v17__lock_unspent!();
 crate::impl_client_v21__psbt_bump_fee!();
 crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
+crate::impl_client_v23__restore_wallet!();
 crate::impl_client_v21__send!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -172,6 +172,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v23__new_keypool!();
 crate::impl_client_v21__psbt_bump_fee!();
 crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -32,6 +32,7 @@ crate::impl_client_v17__get_block!();
 crate::impl_client_v17__get_blockchain_info!();
 crate::impl_client_v17__get_block_count!();
 crate::impl_client_v19__get_block_filter!();
+crate::impl_client_v23__get_block_from_peer!();
 crate::impl_client_v17__get_block_hash!();
 crate::impl_client_v17__get_block_header!();
 crate::impl_client_v17__get_block_stats!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -38,6 +38,7 @@ crate::impl_client_v17__get_block_header!();
 crate::impl_client_v17__get_block_stats!();
 crate::impl_client_v17__get_chain_tips!();
 crate::impl_client_v17__get_chain_tx_stats!();
+crate::impl_client_v23__get_deployment_info!();
 crate::impl_client_v17__get_difficulty!();
 crate::impl_client_v17__get_mempool_ancestors!();
 crate::impl_client_v17__get_mempool_descendants!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -168,6 +168,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v23__new_keypool!();
 crate::impl_client_v21__psbt_bump_fee!();
 crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -171,6 +171,7 @@ crate::impl_client_v17__lock_unspent!();
 crate::impl_client_v21__psbt_bump_fee!();
 crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
+crate::impl_client_v23__restore_wallet!();
 crate::impl_client_v21__send!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -34,6 +34,7 @@ crate::impl_client_v17__get_block!();
 crate::impl_client_v17__get_blockchain_info!();
 crate::impl_client_v17__get_block_count!();
 crate::impl_client_v19__get_block_filter!();
+crate::impl_client_v23__get_block_from_peer!();
 crate::impl_client_v17__get_block_hash!();
 crate::impl_client_v17__get_block_header!();
 crate::impl_client_v17__get_block_stats!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -40,6 +40,7 @@ crate::impl_client_v17__get_block_header!();
 crate::impl_client_v17__get_block_stats!();
 crate::impl_client_v17__get_chain_tips!();
 crate::impl_client_v17__get_chain_tx_stats!();
+crate::impl_client_v23__get_deployment_info!();
 crate::impl_client_v17__get_difficulty!();
 crate::impl_client_v17__get_mempool_ancestors!();
 crate::impl_client_v17__get_mempool_descendants!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -170,6 +170,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v23__new_keypool!();
 crate::impl_client_v21__psbt_bump_fee!();
 crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -173,6 +173,7 @@ crate::impl_client_v17__lock_unspent!();
 crate::impl_client_v21__psbt_bump_fee!();
 crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
+crate::impl_client_v23__restore_wallet!();
 crate::impl_client_v21__send!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -39,6 +39,7 @@ crate::impl_client_v17__get_block_header!();
 crate::impl_client_v17__get_block_stats!();
 crate::impl_client_v17__get_chain_tips!();
 crate::impl_client_v17__get_chain_tx_stats!();
+crate::impl_client_v23__get_deployment_info!();
 crate::impl_client_v29__get_descriptor_activity!();
 crate::impl_client_v17__get_difficulty!();
 crate::impl_client_v17__get_mempool_ancestors!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -33,6 +33,7 @@ crate::impl_client_v17__get_block!();
 crate::impl_client_v17__get_blockchain_info!();
 crate::impl_client_v17__get_block_count!();
 crate::impl_client_v19__get_block_filter!();
+crate::impl_client_v23__get_block_from_peer!();
 crate::impl_client_v17__get_block_hash!();
 crate::impl_client_v17__get_block_header!();
 crate::impl_client_v17__get_block_stats!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -170,6 +170,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v23__new_keypool!();
 crate::impl_client_v21__psbt_bump_fee!();
 crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -173,6 +173,7 @@ crate::impl_client_v17__lock_unspent!();
 crate::impl_client_v21__psbt_bump_fee!();
 crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
+crate::impl_client_v23__restore_wallet!();
 crate::impl_client_v21__send!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();

--- a/integration_test/tests/blockchain.rs
+++ b/integration_test/tests/blockchain.rs
@@ -179,6 +179,17 @@ fn blockchain__get_chain_tx_stats__modelled() {
 }
 
 #[test]
+#[cfg(not(feature = "v22_and_below"))]
+fn blockchain__get_deployment_info__modelled() {
+    let node = Node::with_wallet(Wallet::None, &[]);
+    let block_hash = node.client.best_block_hash().expect("best_block_hash failed");
+
+    let json: GetDeploymentInfo = node.client.get_deployment_info(&block_hash).expect("getdeploymentinfo");
+    let model: Result<mtype::GetDeploymentInfo, GetDeploymentInfoError> = json.into_model();
+    model.unwrap();
+}
+
+#[test]
 #[cfg(not(feature = "v28_and_below"))]
 fn blockchain__get_descriptor_activity__modelled() {
     let node = Node::with_wallet(Wallet::None, &["-coinstatsindex=1", "-txindex=1"]);

--- a/integration_test/tests/blockchain.rs
+++ b/integration_test/tests/blockchain.rs
@@ -66,6 +66,37 @@ fn blockchain__get_block_filter__modelled() {
 }
 
 #[test]
+#[cfg(not(feature = "v22_and_below"))]
+fn blockchain__get_block_from_peer() {
+    use bitcoin::hashes::Hash;
+    let (node1, _node2, _node3) = integration_test::three_node_network();
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("Time went backwards")
+        .as_secs() as u32;
+
+    // Create a dummy header and submit it
+    let mut header = bitcoin::block::Header {
+        version: bitcoin::block::Version::from_consensus(0x20000000),
+        prev_blockhash: node1.client.best_block_hash().expect("best_block_hash failed"),
+        merkle_root: bitcoin::TxMerkleNode::all_zeros(),
+        time: now,
+        bits: bitcoin::CompactTarget::from_consensus(0x207fffff),
+        nonce: 0,
+    };
+    let target = header.target();
+    while header.validate_pow(target).is_err() {
+        header.nonce += 1;
+    }
+    node1.client.submit_header(&header).expect("submit_header failed");
+
+    let hash = header.block_hash();
+    let peer_id = node1.client.get_peer_info().expect("getpeerinfo").0[0].id;
+    let _: () = node1.client.get_block_from_peer(hash, peer_id).expect("getblockfrompeer");
+}
+
+#[test]
 fn blockchain__get_block_hash__modelled() {
     let node = Node::with_wallet(Wallet::None, &[]);
 

--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -573,6 +573,14 @@ fn wallet__lock_unspent() {
     assert!(json.0);
 }
 
+#[cfg(not(feature = "v22_and_below"))]
+#[test]
+fn wallet__new_keypool() {
+    let node = Node::with_wallet(Wallet::None, &["-deprecatedrpc=create_bdb"]);
+    node.client.create_legacy_wallet("legacy_wallet").expect("createlegacywallet");
+    let _: () = node.client.new_keypool().expect("newkeypool");
+}
+
 #[cfg(not(feature = "v20_and_below"))]
 #[test]
 fn wallet__psbt_bump_fee__modelled() {

--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -66,12 +66,25 @@ fn wallet__add_multisig_address__modelled() {
 
 #[test]
 fn wallet__backup_wallet() {
+    backup_and_restore_wallet()
+}
+
+fn backup_and_restore_wallet() {
     let node = Node::with_wallet(Wallet::Default, &[]);
     let file_path = integration_test::random_tmp_file();
 
     let _: () = node.client.backup_wallet(&file_path).expect("backupwallet");
     assert!(file_path.exists(), "Backup file should exist at destination");
     assert!(file_path.is_file(), "Backup destination should be a file");
+
+    // Restore wallet only available for v23 and above.
+    #[cfg(not(feature = "v22_and_below"))]
+    {
+        let wallet_name = "test_wallet";
+        let node2 = Node::with_wallet(Wallet::None, &[]);
+        let restored_wallet: RestoreWallet = node2.client.restore_wallet(wallet_name, &file_path).expect("restorewallet");
+        assert_eq!(restored_wallet.name, wallet_name);
+    }
 
     fs::remove_file(&file_path).expect("removefile");
 }
@@ -594,6 +607,11 @@ fn wallet__remove_pruned_funds() {
 
     let _: () = node.client.remove_pruned_funds(txid).expect("removeprunedfunds");
 }
+
+// This is tested in `backup_and_restore_wallet()`, called by wallet__backup_wallet()
+#[cfg(not(feature = "v22_and_below"))]
+#[test]
+fn wallet__restore_wallet() {}
 
 // This is tested in raw_transactions.rs `create_sign_send()`.
 #[test]

--- a/types/src/model/blockchain.rs
+++ b/types/src/model/blockchain.rs
@@ -384,6 +384,72 @@ pub struct GetChainTxStats {
     pub tx_rate: Option<u32>,
 }
 
+/// Models the result of JSON-RPC method `getdeploymentinfo`.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct GetDeploymentInfo {
+    /// Requested block hash (or tip).
+    pub hash: BlockHash,
+    /// Requested block height (or tip).
+    pub height: u32,
+    /// Deployments info, keyed by deployment name.
+    pub deployments: std::collections::BTreeMap<String, DeploymentInfo>,
+}
+
+/// Deployment info. Returned as part of `getdeploymentinfo`.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DeploymentInfo {
+    /// One of "buried", "bip9".
+    pub deployment_type: String,
+    /// Height of the first block which the rules are or will be enforced (only for "buried" type, or "bip9" type with "active" status).
+    pub height: Option<u32>,
+    /// True if the rules are enforced for the mempool and the next block.
+    pub active: bool,
+    /// Status of bip9 softforks (only for "bip9" type).
+    pub bip9: Option<Bip9Info>,
+}
+
+/// Status of bip9 softforks. Returned as part of `getdeploymentinfo`.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Bip9Info {
+    /// The bit (0-28) in the block version field used to signal this softfork (only for "started" and "locked_in" status).
+    pub bit: Option<u8>,
+    /// The minimum median time past of a block at which the bit gains its meaning.
+    pub start_time: i64,
+    /// The median time past of a block at which the deployment is considered failed if not yet locked in.
+    pub timeout: i64,
+    /// Minimum height of blocks for which the rules may be enforced.
+    pub min_activation_height: u32,
+    /// Status of deployment at specified block (one of "defined", "started", "locked_in", "active", "failed").
+    pub status: String,
+    /// Height of the first block to which the status applies.
+    pub since: u32,
+    /// Status of deployment at the next block.
+    pub status_next: String,
+    /// Numeric statistics about signalling for a softfork (only for "started" and "locked_in" status).
+    pub statistics: Option<Bip9Statistics>,
+    /// Indicates blocks that signalled with a # and blocks that did not with a -.
+    pub signalling: Option<String>,
+}
+
+/// Numeric statistics about signalling for a softfork. Returned as part of `getdeploymentinfo`.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Bip9Statistics {
+    /// The length in blocks of the signalling period.
+    pub period: u32,
+    /// The number of blocks with the version bit set required to activate the feature (only for "started" status).
+    pub threshold: Option<u32>,
+    /// The number of blocks elapsed since the beginning of the current period.
+    pub elapsed: u32,
+    /// The number of blocks with the version bit set in the current period.
+    pub count: u32,
+    /// Returns false if there are not enough blocks left in this period to pass activation threshold (only for "started" status).
+    pub possible: Option<bool>,
+}
+
 /// Models the result of JSON-RPC method `getdifficulty`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]

--- a/types/src/model/mod.rs
+++ b/types/src/model/mod.rs
@@ -29,6 +29,7 @@ pub use self::{
         GetMempoolDescendants, GetMempoolDescendantsVerbose, GetMempoolEntry, GetMempoolInfo,
         GetRawMempool, GetRawMempoolVerbose, GetTxOut, GetTxOutSetInfo, MempoolEntry,
         MempoolEntryFees, ReceiveActivity, Softfork, SoftforkType, SpendActivity, VerifyTxOutProof,
+        GetDeploymentInfo, DeploymentInfo, Bip9Info, Bip9Statistics,
     },
     generating::{Generate, GenerateBlock, GenerateToAddress, GenerateToDescriptor},
     mining::{

--- a/types/src/model/mod.rs
+++ b/types/src/model/mod.rs
@@ -21,15 +21,15 @@ mod zmq;
 #[doc(inline)]
 pub use self::{
     blockchain::{
-        ActivityEntry, Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, ChainTips,
-        ChainTipsStatus, GetBestBlockHash, GetBlockCount, GetBlockFilter, GetBlockHash,
-        GetBlockHeader, GetBlockHeaderVerbose, GetBlockStats, GetBlockVerboseOne,
-        GetBlockVerboseZero, GetBlockchainInfo, GetChainTips, GetChainTxStats,
-        GetDescriptorActivity, GetDifficulty, GetMempoolAncestors, GetMempoolAncestorsVerbose,
-        GetMempoolDescendants, GetMempoolDescendantsVerbose, GetMempoolEntry, GetMempoolInfo,
-        GetRawMempool, GetRawMempoolVerbose, GetTxOut, GetTxOutSetInfo, MempoolEntry,
-        MempoolEntryFees, ReceiveActivity, Softfork, SoftforkType, SpendActivity, VerifyTxOutProof,
-        GetDeploymentInfo, DeploymentInfo, Bip9Info, Bip9Statistics,
+        ActivityEntry, Bip9Info, Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus,
+        Bip9Statistics, ChainTips, ChainTipsStatus, DeploymentInfo, GetBestBlockHash,
+        GetBlockCount, GetBlockFilter, GetBlockHash, GetBlockHeader, GetBlockHeaderVerbose,
+        GetBlockStats, GetBlockVerboseOne, GetBlockVerboseZero, GetBlockchainInfo, GetChainTips,
+        GetChainTxStats, GetDeploymentInfo, GetDescriptorActivity, GetDifficulty,
+        GetMempoolAncestors, GetMempoolAncestorsVerbose, GetMempoolDescendants,
+        GetMempoolDescendantsVerbose, GetMempoolEntry, GetMempoolInfo, GetRawMempool,
+        GetRawMempoolVerbose, GetTxOut, GetTxOutSetInfo, MempoolEntry, MempoolEntryFees,
+        ReceiveActivity, Softfork, SoftforkType, SpendActivity, VerifyTxOutProof,
     },
     generating::{Generate, GenerateBlock, GenerateToAddress, GenerateToDescriptor},
     mining::{

--- a/types/src/v23/blockchain/error.rs
+++ b/types/src/v23/blockchain/error.rs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: CC0-1.0
+
+use core::fmt;
+
+use bitcoin::hex;
+
+use crate::error::write_err;
+use crate::NumericError;
+
+#[derive(Debug)]
+pub enum GetDeploymentInfoError {
+    /// Conversion of the `hash field failed.
+    BlockHash(hex::HexToArrayError),
+    /// Conversion of the `deployments` field failed.
+    Deployment(NumericError),
+}
+
+impl fmt::Display for GetDeploymentInfoError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use GetDeploymentInfoError as E;
+
+        match *self {
+            E::BlockHash(ref e) => write_err!(f, "conversion of the `hash` field failed"; e),
+            E::Deployment(ref e) =>
+                write_err!(f, "conversion of the `deployments` field failed"; e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for GetDeploymentInfoError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use GetDeploymentInfoError as E;
+
+        match *self {
+            E::BlockHash(ref e) => Some(e),
+            E::Deployment(ref e) => Some(e),
+        }
+    }
+}

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -31,7 +31,7 @@
 //! | getblockchaininfo                  | version + model |                                        |
 //! | getblockcount                      | version + model |                                        |
 //! | getblockfilter                     | version         |                                        |
-//! | getblockfrompeer                   | version + model | TODO                                   |
+//! | getblockfrompeer                   | returns nothing |                                        |
 //! | getblockhash                       | version + model |                                        |
 //! | getblockheader                     | version + model | Includes additional 'verbose' type     |
 //! | getblockstats                      | version + model |                                        |

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -37,7 +37,7 @@
 //! | getblockstats                      | version + model |                                        |
 //! | getchaintips                       | version + model |                                        |
 //! | getchaintxstats                    | version + model |                                        |
-//! | getdeploymentinfo                  | version + model | TODO                                   |
+//! | getdeploymentinfo                  | version + model |                                        |
 //! | getdifficulty                      | version + model |                                        |
 //! | getmempoolancestors                | version + model | UNTESTED (incl. verbose type)          |
 //! | getmempooldescendants              | version + model | UNTESTED (incl. verbose type)          |
@@ -245,7 +245,10 @@ mod wallet;
 
 #[doc(inline)]
 pub use self::{
-    blockchain::{GetBlockchainInfo, GetMempoolEntry, SaveMempool},
+    blockchain::{
+        GetBlockchainInfo, GetMempoolEntry, SaveMempool, GetDeploymentInfo,
+        GetDeploymentInfoError, DeploymentInfo, Bip9Info, Bip9Statistics
+    },
     control::Logging,
     network::GetPeerInfo,
     raw_transactions::{

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -192,7 +192,7 @@
 //! | listdescriptors                    | version         |                                        |
 //! | listlabels                         | version + model | UNTESTED                               |
 //! | listlockunspent                    | version + model | UNTESTED                               |
-//! | newkeypool                         | version + model | TODO                                   |
+//! | newkeypool                         | returns nothing |                                        |
 //! | psbtbumpfee                        | version + model |                                        |
 //! | listreceivedbyaddress              | version + model | UNTESTED                               |
 //! | listreceivedbylabel                | version + model |                                        |

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -205,7 +205,7 @@
 //! | lockunspent                        | version         |                                        |
 //! | removeprunedfunds                  | returns nothing |                                        |
 //! | rescanblockchain                   | version + model | UNTESTED                               |
-//! | restorewallet                      | version + model | TODO                                   |
+//! | restorewallet                      | version         |                                        |
 //! | send                               | version + model |                                        |
 //! | sendmany                           | version + model | UNTESTED                               |
 //! | sendtoaddress                      | version + model |                                        |
@@ -253,7 +253,7 @@ pub use self::{
         PsbtInput, PsbtOutput,
     },
     util::CreateMultisig,
-    wallet::{GetTransaction, GetTransactionError},
+    wallet::{GetTransaction, GetTransactionError, RestoreWallet},
 };
 #[doc(inline)]
 pub use crate::{

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -246,8 +246,8 @@ mod wallet;
 #[doc(inline)]
 pub use self::{
     blockchain::{
-        GetBlockchainInfo, GetMempoolEntry, SaveMempool, GetDeploymentInfo,
-        GetDeploymentInfoError, DeploymentInfo, Bip9Info, Bip9Statistics
+        Bip9Info, Bip9Statistics, DeploymentInfo, GetBlockchainInfo, GetDeploymentInfo,
+        GetDeploymentInfoError, GetMempoolEntry, SaveMempool,
     },
     control::Logging,
     network::GetPeerInfo,

--- a/types/src/v23/wallet/mod.rs
+++ b/types/src/v23/wallet/mod.rs
@@ -77,3 +77,21 @@ pub struct GetTransaction {
     /// The decoded transaction (only present when `verbose` is passed). v19 and later only.
     pub decoded: Option<Transaction>,
 }
+
+/// Result of the JSON-RPC method `restorewallet`.
+///
+/// > restorewallet "wallet_name" "backup_file" ( load_on_startup )
+/// >
+/// > Restore and loads a wallet from backup.
+/// >
+/// > Arguments:
+/// > 1. wallet_name        (string, required) The name that will be applied to the restored wallet
+/// > 2. backup_file        (string, required) The backup file that will be used to restore the wallet.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RestoreWallet {
+    /// The wallet name if restored successfully.
+    pub name: String,
+    /// Warning message if wallet was not loaded cleanly.
+    pub warning: Option<String>,
+}

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -207,7 +207,7 @@
 //! | lockunspent                        | version         |                                        |
 //! | removeprunedfunds                  | returns nothing |                                        |
 //! | rescanblockchain                   | version + model | UNTESTED                               |
-//! | restorewallet                      | version + model | TODO                                   |
+//! | restorewallet                      | version         |                                        |
 //! | send                               | version + model |                                        |
 //! | sendall                            | version + model | TODO                                   |
 //! | sendmany                           | version + model | UNTESTED                               |
@@ -315,6 +315,7 @@ pub use crate::{
         Banned, EnumerateSigners, ListBanned, ListDescriptors, ScriptPubkey, WalletDisplayAddress,
     },
     v23::{
-        CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, Logging, SaveMempool,
+        CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, Logging, RestoreWallet,
+        SaveMempool,
     },
 };

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -31,7 +31,7 @@
 //! | getblockchaininfo                  | version + model |                                        |
 //! | getblockcount                      | version + model |                                        |
 //! | getblockfilter                     | version         |                                        |
-//! | getblockfrompeer                   | version + model | TODO                                   |
+//! | getblockfrompeer                   | returns nothing |                                        |
 //! | getblockhash                       | version + model |                                        |
 //! | getblockheader                     | version + model | Includes additional 'verbose' type     |
 //! | getblockstats                      | version + model |                                        |

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -194,7 +194,7 @@
 //! | listlabels                         | version + model | UNTESTED                               |
 //! | listlockunspent                    | version + model | UNTESTED                               |
 //! | migratewallet                      | version + model | TODO                                   |
-//! | newkeypool                         | version + model | TODO                                   |
+//! | newkeypool                         | returns nothing |                                        |
 //! | psbtbumpfee                        | version + model |                                        |
 //! | listreceivedbyaddress              | version + model | UNTESTED                               |
 //! | listreceivedbylabel                | version + model |                                        |

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -315,7 +315,8 @@ pub use crate::{
         Banned, EnumerateSigners, ListBanned, ListDescriptors, ScriptPubkey, WalletDisplayAddress,
     },
     v23::{
-        CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, Logging, RestoreWallet,
-        SaveMempool, GetDeploymentInfo, GetDeploymentInfoError, DeploymentInfo, Bip9Info, Bip9Statistics,
+        Bip9Info, Bip9Statistics, CreateMultisig, DecodeScript, DecodeScriptError, DeploymentInfo,
+        GetBlockchainInfo, GetDeploymentInfo, GetDeploymentInfoError, Logging, RestoreWallet,
+        SaveMempool,
     },
 };

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -37,7 +37,7 @@
 //! | getblockstats                      | version + model |                                        |
 //! | getchaintips                       | version + model |                                        |
 //! | getchaintxstats                    | version + model |                                        |
-//! | getdeploymentinfo                  | version + model | TODO                                   |
+//! | getdeploymentinfo                  | version + model |                                        |
 //! | getdifficulty                      | version + model |                                        |
 //! | getmempoolancestors                | version + model | UNTESTED (incl. verbose type)          |
 //! | getmempooldescendants              | version + model | UNTESTED (incl. verbose type)          |
@@ -316,6 +316,6 @@ pub use crate::{
     },
     v23::{
         CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, Logging, RestoreWallet,
-        SaveMempool,
+        SaveMempool, GetDeploymentInfo, GetDeploymentInfoError, DeploymentInfo, Bip9Info, Bip9Statistics,
     },
 };

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -31,7 +31,7 @@
 //! | getblockchaininfo                  | version + model |                                        |
 //! | getblockcount                      | version + model |                                        |
 //! | getblockfilter                     | version         |                                        |
-//! | getblockfrompeer                   | version + model | TODO                                   |
+//! | getblockfrompeer                   | returns nothing |                                        |
 //! | getblockhash                       | version + model |                                        |
 //! | getblockheader                     | version + model | Includes additional 'verbose' type     |
 //! | getblockstats                      | version + model |                                        |

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -208,7 +208,7 @@
 //! | lockunspent                        | version         |                                        |
 //! | removeprunedfunds                  | returns nothing |                                        |
 //! | rescanblockchain                   | version + model | UNTESTED                               |
-//! | restorewallet                      | version + model | TODO                                   |
+//! | restorewallet                      | version         |                                        |
 //! | send                               | version + model |                                        |
 //! | sendall                            | version + model | TODO                                   |
 //! | sendmany                           | version + model | UNTESTED                               |
@@ -306,7 +306,10 @@ pub use crate::{
         PsbtBumpFee, PsbtBumpFeeError, Send, SendError, UpgradeWallet,
     },
     v22::{Banned, EnumerateSigners, ListBanned, ScriptPubkey, WalletDisplayAddress},
-    v23::{CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, SaveMempool},
+    v23::{
+        CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, RestoreWallet,
+        SaveMempool,
+    },
     v24::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetPeerInfo, GetTransaction,
         GetTransactionDetail, GetTransactionError, GlobalXpub, ListUnspent, ListUnspentItem,

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -37,7 +37,7 @@
 //! | getblockstats                      | version + model |                                        |
 //! | getchaintips                       | version + model |                                        |
 //! | getchaintxstats                    | version + model |                                        |
-//! | getdeploymentinfo                  | version + model | TODO                                   |
+//! | getdeploymentinfo                  | version + model |                                        |
 //! | getdifficulty                      | version + model |                                        |
 //! | getmempoolancestors                | version + model | UNTESTED (incl. verbose type)          |
 //! | getmempooldescendants              | version + model | UNTESTED (incl. verbose type)          |
@@ -308,7 +308,7 @@ pub use crate::{
     v22::{Banned, EnumerateSigners, ListBanned, ScriptPubkey, WalletDisplayAddress},
     v23::{
         CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, RestoreWallet,
-        SaveMempool,
+        SaveMempool, GetDeploymentInfo, GetDeploymentInfoError, DeploymentInfo, Bip9Info, Bip9Statistics,
     },
     v24::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetPeerInfo, GetTransaction,

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -307,8 +307,8 @@ pub use crate::{
     },
     v22::{Banned, EnumerateSigners, ListBanned, ScriptPubkey, WalletDisplayAddress},
     v23::{
-        CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, RestoreWallet,
-        SaveMempool, GetDeploymentInfo, GetDeploymentInfoError, DeploymentInfo, Bip9Info, Bip9Statistics,
+        Bip9Info, Bip9Statistics, CreateMultisig, DecodeScript, DecodeScriptError, DeploymentInfo,
+        GetBlockchainInfo, GetDeploymentInfo, GetDeploymentInfoError, RestoreWallet, SaveMempool,
     },
     v24::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetPeerInfo, GetTransaction,

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -195,7 +195,7 @@
 //! | listlabels                         | version + model | UNTESTED                               |
 //! | listlockunspent                    | version + model | UNTESTED                               |
 //! | migratewallet                      | version + model | TODO                                   |
-//! | newkeypool                         | version + model | TODO                                   |
+//! | newkeypool                         | returns nothing |                                        |
 //! | psbtbumpfee                        | version + model |                                        |
 //! | listreceivedbyaddress              | version + model | UNTESTED                               |
 //! | listreceivedbylabel                | version + model |                                        |

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -39,7 +39,7 @@
 //! | getchainstates                     | version + model | TODO                                   |
 //! | getchaintips                       | version + model |                                        |
 //! | getchaintxstats                    | version + model |                                        |
-//! | getdeploymentinfo                  | version + model | TODO                                   |
+//! | getdeploymentinfo                  | version + model |                                        |
 //! | getdifficulty                      | version + model |                                        |
 //! | getmempoolancestors                | version + model | UNTESTED (incl. verbose type)          |
 //! | getmempooldescendants              | version + model | UNTESTED (incl. verbose type)          |
@@ -326,7 +326,7 @@ pub use crate::{
     v22::{Banned, EnumerateSigners, ListBanned, ScriptPubkey, WalletDisplayAddress},
     v23::{
         CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, RestoreWallet,
-        SaveMempool,
+        SaveMempool, GetDeploymentInfo, GetDeploymentInfoError, DeploymentInfo, Bip9Info, Bip9Statistics,
     },
     v24::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -325,8 +325,8 @@ pub use crate::{
     },
     v22::{Banned, EnumerateSigners, ListBanned, ScriptPubkey, WalletDisplayAddress},
     v23::{
-        CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, RestoreWallet,
-        SaveMempool, GetDeploymentInfo, GetDeploymentInfoError, DeploymentInfo, Bip9Info, Bip9Statistics,
+        Bip9Info, Bip9Statistics, CreateMultisig, DecodeScript, DecodeScriptError, DeploymentInfo,
+        GetBlockchainInfo, GetDeploymentInfo, GetDeploymentInfoError, RestoreWallet, SaveMempool,
     },
     v24::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -32,7 +32,7 @@
 //! | getblockchaininfo                  | version + model |                                        |
 //! | getblockcount                      | version + model |                                        |
 //! | getblockfilter                     | version         |                                        |
-//! | getblockfrompeer                   | version + model | TODO                                   |
+//! | getblockfrompeer                   | returns nothing |                                        |
 //! | getblockhash                       | version + model |                                        |
 //! | getblockheader                     | version + model | Includes additional 'verbose' type     |
 //! | getblockstats                      | version + model |                                        |

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -203,7 +203,7 @@
 //! | listlabels                         | version + model | UNTESTED                               |
 //! | listlockunspent                    | version + model | UNTESTED                               |
 //! | migratewallet                      | version + model | TODO                                   |
-//! | newkeypool                         | version + model | TODO                                   |
+//! | newkeypool                         | returns nothing |                                        |
 //! | psbtbumpfee                        | version + model |                                        |
 //! | listreceivedbyaddress              | version + model | UNTESTED                               |
 //! | listreceivedbylabel                | version + model |                                        |

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -216,7 +216,7 @@
 //! | lockunspent                        | version         |                                        |
 //! | removeprunedfunds                  | returns nothing |                                        |
 //! | rescanblockchain                   | version + model | UNTESTED                               |
-//! | restorewallet                      | version + model | TODO                                   |
+//! | restorewallet                      | version         |                                        |
 //! | send                               | version + model |                                        |
 //! | sendall                            | version + model | TODO                                   |
 //! | sendmany                           | version + model | UNTESTED                               |
@@ -324,7 +324,10 @@ pub use crate::{
         PsbtBumpFee, PsbtBumpFeeError, Send, SendError, UpgradeWallet,
     },
     v22::{Banned, EnumerateSigners, ListBanned, ScriptPubkey, WalletDisplayAddress},
-    v23::{CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, SaveMempool},
+    v23::{
+        CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, RestoreWallet,
+        SaveMempool,
+    },
     v24::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,
         GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -302,8 +302,8 @@ pub use crate::{
     },
     v22::{Banned, EnumerateSigners, ListBanned, ScriptPubkey, WalletDisplayAddress},
     v23::{
-        CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, RestoreWallet,
-        SaveMempool, GetDeploymentInfo, GetDeploymentInfoError, DeploymentInfo, Bip9Info, Bip9Statistics,
+        Bip9Info, Bip9Statistics, CreateMultisig, DecodeScript, DecodeScriptError, DeploymentInfo,
+        GetBlockchainInfo, GetDeploymentInfo, GetDeploymentInfoError, RestoreWallet, SaveMempool,
     },
     v24::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -32,7 +32,7 @@
 //! | getblockchaininfo                  | version + model |                                        |
 //! | getblockcount                      | version + model |                                        |
 //! | getblockfilter                     | version         |                                        |
-//! | getblockfrompeer                   | version + model | TODO                                   |
+//! | getblockfrompeer                   | returns nothing |                                        |
 //! | getblockhash                       | version + model |                                        |
 //! | getblockheader                     | version + model | Includes additional 'verbose' type     |
 //! | getblockstats                      | version + model |                                        |

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -216,7 +216,7 @@
 //! | lockunspent                        | version         |                                        |
 //! | removeprunedfunds                  | returns nothing |                                        |
 //! | rescanblockchain                   | version + model | UNTESTED                               |
-//! | restorewallet                      | version + model | TODO                                   |
+//! | restorewallet                      | version         |                                        |
 //! | send                               | version + model |                                        |
 //! | sendall                            | version + model | TODO                                   |
 //! | sendmany                           | version + model | UNTESTED                               |
@@ -301,7 +301,10 @@ pub use crate::{
         PsbtBumpFee, PsbtBumpFeeError, Send, SendError, UpgradeWallet,
     },
     v22::{Banned, EnumerateSigners, ListBanned, ScriptPubkey, WalletDisplayAddress},
-    v23::{CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, SaveMempool},
+    v23::{
+        CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, RestoreWallet,
+        SaveMempool,
+    },
     v24::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,
         GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -39,7 +39,7 @@
 //! | getchainstates                     | version + model | TODO                                   |
 //! | getchaintips                       | version + model |                                        |
 //! | getchaintxstats                    | version + model |                                        |
-//! | getdeploymentinfo                  | version + model | TODO                                   |
+//! | getdeploymentinfo                  | version + model |                                        |
 //! | getdifficulty                      | version + model |                                        |
 //! | getmempoolancestors                | version + model | UNTESTED (incl. verbose type)          |
 //! | getmempooldescendants              | version + model | UNTESTED (incl. verbose type)          |
@@ -303,7 +303,7 @@ pub use crate::{
     v22::{Banned, EnumerateSigners, ListBanned, ScriptPubkey, WalletDisplayAddress},
     v23::{
         CreateMultisig, DecodeScript, DecodeScriptError, GetBlockchainInfo, RestoreWallet,
-        SaveMempool,
+        SaveMempool, GetDeploymentInfo, GetDeploymentInfoError, DeploymentInfo, Bip9Info, Bip9Statistics,
     },
     v24::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -203,7 +203,7 @@
 //! | listlabels                         | version + model | UNTESTED                               |
 //! | listlockunspent                    | version + model | UNTESTED                               |
 //! | migratewallet                      | version + model | TODO                                   |
-//! | newkeypool                         | version + model | TODO                                   |
+//! | newkeypool                         | returns nothing |                                        |
 //! | psbtbumpfee                        | version + model |                                        |
 //! | listreceivedbyaddress              | version + model | UNTESTED                               |
 //! | listreceivedbylabel                | version + model |                                        |

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -205,7 +205,7 @@
 //! | listlabels                         | version + model | UNTESTED                               |
 //! | listlockunspent                    | version + model | UNTESTED                               |
 //! | migratewallet                      | version + model | TODO                                   |
-//! | newkeypool                         | version + model | TODO                                   |
+//! | newkeypool                         | returns nothing |                                        |
 //! | psbtbumpfee                        | version + model |                                        |
 //! | listreceivedbyaddress              | version + model | UNTESTED                               |
 //! | listreceivedbylabel                | version + model |                                        |

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -322,8 +322,10 @@ pub use crate::{
         PsbtBumpFeeError, Send, SendError, UpgradeWallet,
     },
     v22::{Banned, EnumerateSigners, ListBanned, ScriptPubkey, WalletDisplayAddress},
-    v23::{CreateMultisig, DecodeScript, DecodeScriptError, RestoreWallet, SaveMempool,
-        GetDeploymentInfo, GetDeploymentInfoError, DeploymentInfo, Bip9Info, Bip9Statistics},
+    v23::{
+        Bip9Info, Bip9Statistics, CreateMultisig, DecodeScript, DecodeScriptError, DeploymentInfo,
+        GetDeploymentInfo, GetDeploymentInfoError, RestoreWallet, SaveMempool,
+    },
     v24::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,
         GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -32,7 +32,7 @@
 //! | getblockchaininfo                  | version + model |                                        |
 //! | getblockcount                      | version + model |                                        |
 //! | getblockfilter                     | version         |                                        |
-//! | getblockfrompeer                   | version + model | TODO                                   |
+//! | getblockfrompeer                   | returns nothing |                                        |
 //! | getblockhash                       | version + model |                                        |
 //! | getblockheader                     | version + model | Includes additional 'verbose' type     |
 //! | getblockstats                      | version + model |                                        |

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -39,7 +39,7 @@
 //! | getchainstates                     | version + model | TODO                                   |
 //! | getchaintips                       | version + model |                                        |
 //! | getchaintxstats                    | version + model |                                        |
-//! | getdeploymentinfo                  | version + model | TODO                                   |
+//! | getdeploymentinfo                  | version + model |                                        |
 //! | getdifficulty                      | version + model |                                        |
 //! | getmempoolancestors                | version + model | UNTESTED (incl. verbose type)          |
 //! | getmempooldescendants              | version + model | UNTESTED (incl. verbose type)          |
@@ -322,7 +322,8 @@ pub use crate::{
         PsbtBumpFeeError, Send, SendError, UpgradeWallet,
     },
     v22::{Banned, EnumerateSigners, ListBanned, ScriptPubkey, WalletDisplayAddress},
-    v23::{CreateMultisig, DecodeScript, DecodeScriptError, RestoreWallet, SaveMempool},
+    v23::{CreateMultisig, DecodeScript, DecodeScriptError, RestoreWallet, SaveMempool,
+        GetDeploymentInfo, GetDeploymentInfoError, DeploymentInfo, Bip9Info, Bip9Statistics},
     v24::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,
         GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -218,7 +218,7 @@
 //! | lockunspent                        | version         |                                        |
 //! | removeprunedfunds                  | returns nothing |                                        |
 //! | rescanblockchain                   | version + model | UNTESTED                               |
-//! | restorewallet                      | version + model | TODO                                   |
+//! | restorewallet                      | version         |                                        |
 //! | send                               | version + model |                                        |
 //! | sendall                            | version + model | TODO                                   |
 //! | sendmany                           | version + model | UNTESTED                               |
@@ -322,7 +322,7 @@ pub use crate::{
         PsbtBumpFeeError, Send, SendError, UpgradeWallet,
     },
     v22::{Banned, EnumerateSigners, ListBanned, ScriptPubkey, WalletDisplayAddress},
-    v23::{CreateMultisig, DecodeScript, DecodeScriptError, SaveMempool},
+    v23::{CreateMultisig, DecodeScript, DecodeScriptError, RestoreWallet, SaveMempool},
     v24::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,
         GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -39,7 +39,7 @@
 //! | getchainstates                     | version + model | TODO                                   |
 //! | getchaintips                       | version + model |                                        |
 //! | getchaintxstats                    | version + model |                                        |
-//! | getdeploymentinfo                  | version + model | TODO                                   |
+//! | getdeploymentinfo                  | version + model |                                        |
 //! | getdescriptoractivity              | version + model |                                        |
 //! | getdifficulty                      | version + model |                                        |
 //! | getmempoolancestors                | version + model | UNTESTED (incl. verbose type)          |
@@ -320,7 +320,8 @@ pub use crate::{
         PsbtBumpFeeError, Send, SendError, UpgradeWallet,
     },
     v22::{Banned, EnumerateSigners, ListBanned, ScriptPubkey, WalletDisplayAddress},
-    v23::{CreateMultisig, DecodeScript, DecodeScriptError, RestoreWallet, SaveMempool},
+    v23::{CreateMultisig, DecodeScript, DecodeScriptError, RestoreWallet, SaveMempool,
+        GetDeploymentInfo, GetDeploymentInfoError, DeploymentInfo, Bip9Info, Bip9Statistics},
     v24::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,
         GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -206,7 +206,7 @@
 //! | listlabels                         | version + model | UNTESTED                               |
 //! | listlockunspent                    | version + model | UNTESTED                               |
 //! | migratewallet                      | version + model | TODO                                   |
-//! | newkeypool                         | version + model | TODO                                   |
+//! | newkeypool                         | returns nothing |                                        |
 //! | psbtbumpfee                        | version + model |                                        |
 //! | listreceivedbyaddress              | version + model | UNTESTED                               |
 //! | listreceivedbylabel                | version + model |                                        |

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -32,7 +32,7 @@
 //! | getblockchaininfo                  | version + model |                                        |
 //! | getblockcount                      | version + model |                                        |
 //! | getblockfilter                     | version         |                                        |
-//! | getblockfrompeer                   | version + model | TODO                                   |
+//! | getblockfrompeer                   | returns nothing |                                        |
 //! | getblockhash                       | version + model |                                        |
 //! | getblockheader                     | version + model | Includes additional 'verbose' type     |
 //! | getblockstats                      | version + model |                                        |

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -219,7 +219,7 @@
 //! | lockunspent                        | version         |                                        |
 //! | removeprunedfunds                  | returns nothing |                                        |
 //! | rescanblockchain                   | version + model | UNTESTED                               |
-//! | restorewallet                      | version + model | TODO                                   |
+//! | restorewallet                      | version         |                                        |
 //! | send                               | version + model |                                        |
 //! | sendall                            | version + model | TODO                                   |
 //! | sendmany                           | version + model | UNTESTED                               |
@@ -320,7 +320,7 @@ pub use crate::{
         PsbtBumpFeeError, Send, SendError, UpgradeWallet,
     },
     v22::{Banned, EnumerateSigners, ListBanned, ScriptPubkey, WalletDisplayAddress},
-    v23::{CreateMultisig, DecodeScript, DecodeScriptError, SaveMempool},
+    v23::{CreateMultisig, DecodeScript, DecodeScriptError, RestoreWallet, SaveMempool},
     v24::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,
         GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -320,8 +320,10 @@ pub use crate::{
         PsbtBumpFeeError, Send, SendError, UpgradeWallet,
     },
     v22::{Banned, EnumerateSigners, ListBanned, ScriptPubkey, WalletDisplayAddress},
-    v23::{CreateMultisig, DecodeScript, DecodeScriptError, RestoreWallet, SaveMempool,
-        GetDeploymentInfo, GetDeploymentInfoError, DeploymentInfo, Bip9Info, Bip9Statistics},
+    v23::{
+        Bip9Info, Bip9Statistics, CreateMultisig, DecodeScript, DecodeScriptError, DeploymentInfo,
+        GetDeploymentInfo, GetDeploymentInfoError, RestoreWallet, SaveMempool,
+    },
     v24::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,
         GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,


### PR DESCRIPTION
Go through all the TODO in the v23 types table. Add all the missing RPCs.

- Add getblockfrompeer macro and test
- Add restorewallet struct, macro and test
- Add newkeypool macro and test
- Add getdeploymentinfo struct, model and test
- Run the formatter