### PR TITLE
Add full stops to rustdocs in client

### DIFF
--- a/client/src/client_sync/error.rs
+++ b/client/src/client_sync/error.rs
@@ -20,7 +20,7 @@ pub enum Error {
     Returned(String),
     /// The server version did not match what was expected.
     ServerVersion(UnexpectedServerVersionError),
-    /// Missing user/password
+    /// Missing user/password.
     MissingUserPassword,
 }
 

--- a/client/src/client_sync/v17/blockchain.rs
+++ b/client/src/client_sync/v17/blockchain.rs
@@ -9,7 +9,7 @@
 //!
 //! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
 
-/// Implements Bitcoin Core JSON-RPC API method `getblockchaininfo`
+/// Implements Bitcoin Core JSON-RPC API method `getblockchaininfo`.
 #[macro_export]
 macro_rules! impl_client_v17__get_blockchain_info {
     () => {
@@ -21,7 +21,7 @@ macro_rules! impl_client_v17__get_blockchain_info {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `getbestblockhash`
+/// Implements Bitcoin Core JSON-RPC API method `getbestblockhash`.
 #[macro_export]
 macro_rules! impl_client_v17__get_best_block_hash {
     () => {
@@ -39,7 +39,7 @@ macro_rules! impl_client_v17__get_best_block_hash {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `getblock`
+/// Implements Bitcoin Core JSON-RPC API method `getblock`.
 #[macro_export]
 macro_rules! impl_client_v17__get_block {
     () => {
@@ -63,7 +63,7 @@ macro_rules! impl_client_v17__get_block {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `getblockcount`
+/// Implements Bitcoin Core JSON-RPC API method `getblockcount`.
 #[macro_export]
 macro_rules! impl_client_v17__get_block_count {
     () => {
@@ -75,7 +75,7 @@ macro_rules! impl_client_v17__get_block_count {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `getblockhash`
+/// Implements Bitcoin Core JSON-RPC API method `getblockhash`.
 #[macro_export]
 macro_rules! impl_client_v17__get_block_hash {
     () => {
@@ -87,7 +87,7 @@ macro_rules! impl_client_v17__get_block_hash {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `getblockheader`
+/// Implements Bitcoin Core JSON-RPC API method `getblockheader`.
 #[macro_export]
 macro_rules! impl_client_v17__get_block_header {
     () => {
@@ -107,7 +107,7 @@ macro_rules! impl_client_v17__get_block_header {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `getblockstats`
+/// Implements Bitcoin Core JSON-RPC API method `getblockstats`.
 #[macro_export]
 macro_rules! impl_client_v17__get_block_stats {
     () => {
@@ -123,7 +123,7 @@ macro_rules! impl_client_v17__get_block_stats {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `getchaintips`
+/// Implements Bitcoin Core JSON-RPC API method `getchaintips`.
 #[macro_export]
 macro_rules! impl_client_v17__get_chain_tips {
     () => {
@@ -133,7 +133,7 @@ macro_rules! impl_client_v17__get_chain_tips {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `getchaintxstats`
+/// Implements Bitcoin Core JSON-RPC API method `getchaintxstats`.
 #[macro_export]
 macro_rules! impl_client_v17__get_chain_tx_stats {
     () => {
@@ -145,7 +145,7 @@ macro_rules! impl_client_v17__get_chain_tx_stats {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `getdifficulty`
+/// Implements Bitcoin Core JSON-RPC API method `getdifficulty`.
 #[macro_export]
 macro_rules! impl_client_v17__get_difficulty {
     () => {
@@ -157,7 +157,7 @@ macro_rules! impl_client_v17__get_difficulty {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `getmempoolancestors`
+/// Implements Bitcoin Core JSON-RPC API method `getmempoolancestors`.
 #[macro_export]
 macro_rules! impl_client_v17__get_mempool_ancestors {
     () => {
@@ -177,7 +177,7 @@ macro_rules! impl_client_v17__get_mempool_ancestors {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `getmempooldescendants`
+/// Implements Bitcoin Core JSON-RPC API method `getmempooldescendants`.
 #[macro_export]
 macro_rules! impl_client_v17__get_mempool_descendants {
     () => {
@@ -197,7 +197,7 @@ macro_rules! impl_client_v17__get_mempool_descendants {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `getmempoolentry`
+/// Implements Bitcoin Core JSON-RPC API method `getmempoolentry`.
 #[macro_export]
 macro_rules! impl_client_v17__get_mempool_entry {
     () => {
@@ -209,7 +209,7 @@ macro_rules! impl_client_v17__get_mempool_entry {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `getmempoolinfo`
+/// Implements Bitcoin Core JSON-RPC API method `getmempoolinfo`.
 #[macro_export]
 macro_rules! impl_client_v17__get_mempool_info {
     () => {
@@ -221,7 +221,7 @@ macro_rules! impl_client_v17__get_mempool_info {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `getrawmempool`
+/// Implements Bitcoin Core JSON-RPC API method `getrawmempool`.
 #[macro_export]
 macro_rules! impl_client_v17__get_raw_mempool {
     () => {
@@ -237,7 +237,7 @@ macro_rules! impl_client_v17__get_raw_mempool {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `gettxout`
+/// Implements Bitcoin Core JSON-RPC API method `gettxout`.
 #[macro_export]
 macro_rules! impl_client_v17__get_tx_out {
     () => {
@@ -249,7 +249,7 @@ macro_rules! impl_client_v17__get_tx_out {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `gettxoutproof`
+/// Implements Bitcoin Core JSON-RPC API method `gettxoutproof`.
 #[macro_export]
 macro_rules! impl_client_v17__get_tx_out_proof {
     () => {
@@ -261,7 +261,7 @@ macro_rules! impl_client_v17__get_tx_out_proof {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `gettxoutsetinfo`
+/// Implements Bitcoin Core JSON-RPC API method `gettxoutsetinfo`.
 #[macro_export]
 macro_rules! impl_client_v17__get_tx_out_set_info {
     () => {
@@ -273,7 +273,7 @@ macro_rules! impl_client_v17__get_tx_out_set_info {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `preciousblock`
+/// Implements Bitcoin Core JSON-RPC API method `preciousblock`.
 #[macro_export]
 macro_rules! impl_client_v17__precious_block {
     () => {
@@ -289,7 +289,7 @@ macro_rules! impl_client_v17__precious_block {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `pruneblockchain`
+/// Implements Bitcoin Core JSON-RPC API method `pruneblockchain`.
 #[macro_export]
 macro_rules! impl_client_v17__prune_blockchain {
     () => {
@@ -302,7 +302,7 @@ macro_rules! impl_client_v17__prune_blockchain {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `savemempool`
+/// Implements Bitcoin Core JSON-RPC API method `savemempool`.
 #[macro_export]
 macro_rules! impl_client_v17__save_mempool {
     () => {
@@ -318,7 +318,7 @@ macro_rules! impl_client_v17__save_mempool {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `verifychain`
+/// Implements Bitcoin Core JSON-RPC API method `verifychain`.
 #[macro_export]
 macro_rules! impl_client_v17__verify_chain {
     () => {
@@ -328,7 +328,7 @@ macro_rules! impl_client_v17__verify_chain {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `verifytxoutproof`
+/// Implements Bitcoin Core JSON-RPC API method `verifytxoutproof`.
 #[macro_export]
 macro_rules! impl_client_v17__verify_tx_out_proof {
     () => {

--- a/client/src/client_sync/v17/generating.rs
+++ b/client/src/client_sync/v17/generating.rs
@@ -9,7 +9,7 @@
 //!
 //! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
 
-/// Implements Bitcoin Core JSON-RPC API method `generatetoaddress`
+/// Implements Bitcoin Core JSON-RPC API method `generatetoaddress`.
 #[macro_export]
 macro_rules! impl_client_v17__generate_to_address {
     () => {
@@ -25,7 +25,7 @@ macro_rules! impl_client_v17__generate_to_address {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `generate`
+/// Implements Bitcoin Core JSON-RPC API method `generate`.
 #[macro_export]
 macro_rules! impl_client_v17__generate {
     () => {
@@ -37,7 +37,7 @@ macro_rules! impl_client_v17__generate {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `invalidateblock`
+/// Implements Bitcoin Core JSON-RPC API method `invalidateblock`.
 // This method does not appear in the output of `bitcoin-cli help`.
 #[macro_export]
 macro_rules! impl_client_v17__invalidate_block {

--- a/client/src/client_sync/v17/mining.rs
+++ b/client/src/client_sync/v17/mining.rs
@@ -9,7 +9,7 @@
 //!
 //! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
 
-/// Implements Bitcoin Core JSON-RPC API method `getblocktemplate`
+/// Implements Bitcoin Core JSON-RPC API method `getblocktemplate`.
 #[macro_export]
 macro_rules! impl_client_v17__get_block_template {
     () => {
@@ -24,7 +24,7 @@ macro_rules! impl_client_v17__get_block_template {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `getmininginfo`
+/// Implements Bitcoin Core JSON-RPC API method `getmininginfo`.
 #[macro_export]
 macro_rules! impl_client_v17__get_mining_info {
     () => {
@@ -36,7 +36,7 @@ macro_rules! impl_client_v17__get_mining_info {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `getnetworkhashps`
+/// Implements Bitcoin Core JSON-RPC API method `getnetworkhashps`.
 #[macro_export]
 macro_rules! impl_client_v17__get_network_hashes_per_second {
     () => {
@@ -46,7 +46,7 @@ macro_rules! impl_client_v17__get_network_hashes_per_second {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `prioritisetransaction`
+/// Implements Bitcoin Core JSON-RPC API method `prioritisetransaction`.
 #[macro_export]
 macro_rules! impl_client_v17__prioritise_transaction {
     () => {
@@ -63,7 +63,7 @@ macro_rules! impl_client_v17__prioritise_transaction {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `submitblock`
+/// Implements Bitcoin Core JSON-RPC API method `submitblock`.
 #[macro_export]
 macro_rules! impl_client_v17__submit_block {
     () => {

--- a/client/src/client_sync/v17/mod.rs
+++ b/client/src/client_sync/v17/mod.rs
@@ -241,7 +241,7 @@ pub struct WalletCreateFundedPsbtInput {
     vout: u32,
 }
 
-/// Args for the `addnode` method
+/// Args for the `addnode` method.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum AddNodeCommand {
@@ -250,7 +250,7 @@ pub enum AddNodeCommand {
     OneTry,
 }
 
-/// Args for the `setban` method
+/// Args for the `setban` method.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum SetBanCommand {
@@ -258,10 +258,10 @@ pub enum SetBanCommand {
     Remove,
 }
 
-/// Args for the `importmulti` method
+/// Args for the `importmulti` method.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ImportMultiRequest {
-    /// Descriptor to import. If using descriptor, donot also provide address/scriptPubKey, scripts, or pubkeys.
+    /// Descriptor to import. If using descriptor, do not also provide address/scriptPubKey, scripts, or pubkeys.
     #[serde(rename = "desc", skip_serializing_if = "Option::is_none")]
     pub descriptor: Option<String>, // from core v18 onwards.
     /// Type of scriptPubKey (string for script, json for address). Should not be provided if using descriptor.
@@ -281,7 +281,7 @@ pub enum ImportMultiScriptPubKey {
     Address { address: String },
 }
 
-/// `timestamp` can be a number (UNIX epoch time) or the string `"now"`
+/// `timestamp` can be a number (UNIX epoch time) or the string `"now"`.
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum ImportMultiTimestamp {

--- a/client/src/client_sync/v17/network.rs
+++ b/client/src/client_sync/v17/network.rs
@@ -9,7 +9,7 @@
 //!
 //! See, or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
 
-/// Implements Bitcoin Core JSON-RPC API method `addnode`
+/// Implements Bitcoin Core JSON-RPC API method `addnode`.
 #[macro_export]
 macro_rules! impl_client_v17__add_node {
     () => {
@@ -25,7 +25,7 @@ macro_rules! impl_client_v17__add_node {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `clearbanned`
+/// Implements Bitcoin Core JSON-RPC API method `clearbanned`.
 #[macro_export]
 macro_rules! impl_client_v17__clear_banned {
     () => {
@@ -41,7 +41,7 @@ macro_rules! impl_client_v17__clear_banned {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `disconnectnode`
+/// Implements Bitcoin Core JSON-RPC API method `disconnectnode`.
 #[macro_export]
 macro_rules! impl_client_v17__disconnect_node {
     () => {
@@ -57,7 +57,7 @@ macro_rules! impl_client_v17__disconnect_node {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `getaddednodeinfo`
+/// Implements Bitcoin Core JSON-RPC API method `getaddednodeinfo`.
 #[macro_export]
 macro_rules! impl_client_v17__get_added_node_info {
     () => {
@@ -69,7 +69,7 @@ macro_rules! impl_client_v17__get_added_node_info {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `getconnectioncount`
+/// Implements Bitcoin Core JSON-RPC API method `getconnectioncount`.
 #[macro_export]
 macro_rules! impl_client_v17__get_connection_count {
     () => {
@@ -81,7 +81,7 @@ macro_rules! impl_client_v17__get_connection_count {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `getnettotals`
+/// Implements Bitcoin Core JSON-RPC API method `getnettotals`.
 #[macro_export]
 macro_rules! impl_client_v17__get_net_totals {
     () => {
@@ -91,7 +91,7 @@ macro_rules! impl_client_v17__get_net_totals {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `getnetworkinfo`
+/// Implements Bitcoin Core JSON-RPC API method `getnetworkinfo`.
 #[macro_export]
 macro_rules! impl_client_v17__get_network_info {
     () => {
@@ -109,7 +109,7 @@ macro_rules! impl_client_v17__get_network_info {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `getpeerinfo`
+/// Implements Bitcoin Core JSON-RPC API method `getpeerinfo`.
 #[macro_export]
 macro_rules! impl_client_v17__get_peer_info {
     () => {
@@ -119,7 +119,7 @@ macro_rules! impl_client_v17__get_peer_info {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `listbanned`
+/// Implements Bitcoin Core JSON-RPC API method `listbanned`.
 #[macro_export]
 macro_rules! impl_client_v17__list_banned {
     () => {
@@ -129,7 +129,7 @@ macro_rules! impl_client_v17__list_banned {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `ping`
+/// Implements Bitcoin Core JSON-RPC API method `ping`.
 #[macro_export]
 macro_rules! impl_client_v17__ping {
     () => {
@@ -145,7 +145,7 @@ macro_rules! impl_client_v17__ping {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `setban`
+/// Implements Bitcoin Core JSON-RPC API method `setban`.
 #[macro_export]
 macro_rules! impl_client_v17__set_ban {
     () => {
@@ -161,7 +161,7 @@ macro_rules! impl_client_v17__set_ban {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `setnetworkactive`
+/// Implements Bitcoin Core JSON-RPC API method `setnetworkactive`.
 #[macro_export]
 macro_rules! impl_client_v17__set_network_active {
     () => {

--- a/client/src/client_sync/v17/raw_transactions.rs
+++ b/client/src/client_sync/v17/raw_transactions.rs
@@ -9,7 +9,7 @@
 //!
 //! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
 
-/// Implements Bitcoin Core JSON-RPC API method `combinepsbt`
+/// Implements Bitcoin Core JSON-RPC API method `combinepsbt`.
 #[macro_export]
 macro_rules! impl_client_v17__combine_psbt {
     () => {
@@ -22,7 +22,7 @@ macro_rules! impl_client_v17__combine_psbt {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `combinerawtransaction`
+/// Implements Bitcoin Core JSON-RPC API method `combinerawtransaction`.
 #[macro_export]
 macro_rules! impl_client_v17__combine_raw_transaction {
     () => {
@@ -41,7 +41,7 @@ macro_rules! impl_client_v17__combine_raw_transaction {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `converttopsbt`
+/// Implements Bitcoin Core JSON-RPC API method `converttopsbt`.
 #[macro_export]
 macro_rules! impl_client_v17__convert_to_psbt {
     () => {
@@ -54,7 +54,7 @@ macro_rules! impl_client_v17__convert_to_psbt {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `createpsbt`
+/// Implements Bitcoin Core JSON-RPC API method `createpsbt`.
 #[macro_export]
 macro_rules! impl_client_v17__create_psbt {
     () => {
@@ -66,7 +66,7 @@ macro_rules! impl_client_v17__create_psbt {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `createrawtransaction`
+/// Implements Bitcoin Core JSON-RPC API method `createrawtransaction`.
 #[macro_export]
 macro_rules! impl_client_v17__create_raw_transaction {
     () => {
@@ -82,7 +82,7 @@ macro_rules! impl_client_v17__create_raw_transaction {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `decodepsbt`
+/// Implements Bitcoin Core JSON-RPC API method `decodepsbt`.
 #[macro_export]
 macro_rules! impl_client_v17__decode_psbt {
     () => {
@@ -94,7 +94,7 @@ macro_rules! impl_client_v17__decode_psbt {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `finalizepsbt`
+/// Implements Bitcoin Core JSON-RPC API method `finalizepsbt`.
 #[macro_export]
 macro_rules! impl_client_v17__finalize_psbt {
     () => {
@@ -107,7 +107,7 @@ macro_rules! impl_client_v17__finalize_psbt {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `decoderawtransaction`
+/// Implements Bitcoin Core JSON-RPC API method `decoderawtransaction`.
 #[macro_export]
 macro_rules! impl_client_v17__decode_raw_transaction {
     () => {
@@ -123,7 +123,7 @@ macro_rules! impl_client_v17__decode_raw_transaction {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `decodescript`
+/// Implements Bitcoin Core JSON-RPC API method `decodescript`.
 #[macro_export]
 macro_rules! impl_client_v17__decode_script {
     () => {
@@ -136,7 +136,7 @@ macro_rules! impl_client_v17__decode_script {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `fundrawtransaction`
+/// Implements Bitcoin Core JSON-RPC API method `fundrawtransaction`.
 #[macro_export]
 macro_rules! impl_client_v17__fund_raw_transaction {
     () => {
@@ -152,7 +152,7 @@ macro_rules! impl_client_v17__fund_raw_transaction {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `getrawtransaction`
+/// Implements Bitcoin Core JSON-RPC API method `getrawtransaction`.
 #[macro_export]
 macro_rules! impl_client_v17__get_raw_transaction {
     () => {
@@ -171,7 +171,7 @@ macro_rules! impl_client_v17__get_raw_transaction {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `sendrawtransaction`
+/// Implements Bitcoin Core JSON-RPC API method `sendrawtransaction`.
 #[macro_export]
 macro_rules! impl_client_v17__send_raw_transaction {
     () => {
@@ -187,7 +187,7 @@ macro_rules! impl_client_v17__send_raw_transaction {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `signrawtransaction`
+/// Implements Bitcoin Core JSON-RPC API method `signrawtransaction`.
 #[macro_export]
 macro_rules! impl_client_v17__sign_raw_transaction {
     () => {
@@ -203,7 +203,7 @@ macro_rules! impl_client_v17__sign_raw_transaction {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `signrawtransactionwithkey`
+/// Implements Bitcoin Core JSON-RPC API method `signrawtransactionwithkey`.
 #[macro_export]
 macro_rules! impl_client_v17__sign_raw_transaction_with_key {
     () => {
@@ -221,7 +221,7 @@ macro_rules! impl_client_v17__sign_raw_transaction_with_key {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `testmempoolaccept`
+/// Implements Bitcoin Core JSON-RPC API method `testmempoolaccept`.
 #[macro_export]
 macro_rules! impl_client_v17__test_mempool_accept {
     () => {

--- a/client/src/client_sync/v17/util.rs
+++ b/client/src/client_sync/v17/util.rs
@@ -9,7 +9,7 @@
 //!
 //! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
 
-/// Implements Bitcoin Core JSON-RPC API method `createmultisig`
+/// Implements Bitcoin Core JSON-RPC API method `createmultisig`.
 #[macro_export]
 macro_rules! impl_client_v17__create_multisig {
     () => {
@@ -25,7 +25,7 @@ macro_rules! impl_client_v17__create_multisig {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `estimatesmartfee`
+/// Implements Bitcoin Core JSON-RPC API method `estimatesmartfee`.
 #[macro_export]
 macro_rules! impl_client_v17__estimate_smart_fee {
     () => {
@@ -37,7 +37,7 @@ macro_rules! impl_client_v17__estimate_smart_fee {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `signmessagewithprivkey`
+/// Implements Bitcoin Core JSON-RPC API method `signmessagewithprivkey`.
 #[macro_export]
 macro_rules! impl_client_v17__sign_message_with_priv_key {
     () => {
@@ -53,7 +53,7 @@ macro_rules! impl_client_v17__sign_message_with_priv_key {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `validateaddress`
+/// Implements Bitcoin Core JSON-RPC API method `validateaddress`.
 #[macro_export]
 macro_rules! impl_client_v17__validate_address {
     () => {
@@ -68,7 +68,7 @@ macro_rules! impl_client_v17__validate_address {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `verifymessage`
+/// Implements Bitcoin Core JSON-RPC API method `verifymessage`.
 #[macro_export]
 macro_rules! impl_client_v17__verify_message {
     () => {

--- a/client/src/client_sync/v17/wallet.rs
+++ b/client/src/client_sync/v17/wallet.rs
@@ -298,7 +298,7 @@ macro_rules! impl_client_v17__import_address {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `importmulti`
+/// Implements Bitcoin Core JSON-RPC API method `importmulti`.
 #[macro_export]
 macro_rules! impl_client_v17__import_multi {
     () => {
@@ -608,7 +608,7 @@ macro_rules! impl_client_v17__set_hd_seed {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `settxfee`
+/// Implements Bitcoin Core JSON-RPC API method `settxfee`.
 #[macro_export]
 macro_rules! impl_client_v17__set_tx_fee {
     () => {
@@ -666,7 +666,7 @@ macro_rules! impl_client_v17__unload_wallet {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `walletpassphrase`
+/// Implements Bitcoin Core JSON-RPC API method `walletpassphrase`.
 #[macro_export]
 macro_rules! impl_client_v17__wallet_passphrase {
     () => {
@@ -714,7 +714,7 @@ macro_rules! impl_client_v17__wallet_lock {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `walletpassphrasechange`
+/// Implements Bitcoin Core JSON-RPC API method `walletpassphrasechange`.
 #[macro_export]
 macro_rules! impl_client_v17__wallet_passphrase_change {
     () => {

--- a/client/src/client_sync/v18/network.rs
+++ b/client/src/client_sync/v18/network.rs
@@ -9,7 +9,7 @@
 //!
 //! See, or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
 
-/// Implements Bitcoin Core JSON-RPC API method `getnodeaddresses`
+/// Implements Bitcoin Core JSON-RPC API method `getnodeaddresses`.
 #[macro_export]
 macro_rules! impl_client_v18__get_node_addresses {
     () => {

--- a/client/src/client_sync/v18/raw_transactions.rs
+++ b/client/src/client_sync/v18/raw_transactions.rs
@@ -9,7 +9,7 @@
 //!
 //! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
 
-/// Implements Bitcoin Core JSON-RPC API method `analyzepsbt`
+/// Implements Bitcoin Core JSON-RPC API method `analyzepsbt`.
 #[macro_export]
 macro_rules! impl_client_v18__analyze_psbt {
     () => {
@@ -22,7 +22,7 @@ macro_rules! impl_client_v18__analyze_psbt {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `joinpsbts`
+/// Implements Bitcoin Core JSON-RPC API method `joinpsbts`.
 #[macro_export]
 macro_rules! impl_client_v18__join_psbts {
     () => {
@@ -35,7 +35,7 @@ macro_rules! impl_client_v18__join_psbts {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `uxtoupdatepsbt`
+/// Implements Bitcoin Core JSON-RPC API method `uxtoupdatepsbt`.
 #[macro_export]
 macro_rules! impl_client_v18__utxo_update_psbt {
     () => {

--- a/client/src/client_sync/v18/util.rs
+++ b/client/src/client_sync/v18/util.rs
@@ -9,7 +9,7 @@
 //!
 //! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
 
-/// Implements Bitcoin Core JSON-RPC API method `deriveaddresses`
+/// Implements Bitcoin Core JSON-RPC API method `deriveaddresses`.
 #[macro_export]
 macro_rules! impl_client_v18__derive_addresses {
     () => {
@@ -21,7 +21,7 @@ macro_rules! impl_client_v18__derive_addresses {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `getdescriptorinfo`
+/// Implements Bitcoin Core JSON-RPC API method `getdescriptorinfo`.
 #[macro_export]
 macro_rules! impl_client_v18__get_descriptor_info {
     () => {

--- a/client/src/client_sync/v19/blockchain.rs
+++ b/client/src/client_sync/v19/blockchain.rs
@@ -9,7 +9,7 @@
 //!
 //! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
 
-/// Implements Bitcoin Core JSON-RPC API method `getblockfilter`
+/// Implements Bitcoin Core JSON-RPC API method `getblockfilter`.
 #[macro_export]
 macro_rules! impl_client_v19__get_block_filter {
     () => {

--- a/client/src/client_sync/v19/wallet.rs
+++ b/client/src/client_sync/v19/wallet.rs
@@ -9,7 +9,7 @@
 //!
 //! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
 
-/// Implements Bitcoin Core JSON-RPC API method `getbalances`
+/// Implements Bitcoin Core JSON-RPC API method `getbalances`.
 #[macro_export]
 macro_rules! impl_client_v19__get_balances {
     () => {
@@ -19,7 +19,7 @@ macro_rules! impl_client_v19__get_balances {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `setwalletflag`
+/// Implements Bitcoin Core JSON-RPC API method `setwalletflag`.
 #[macro_export]
 macro_rules! impl_client_v19__set_wallet_flag {
     () => {

--- a/client/src/client_sync/v20/generating.rs
+++ b/client/src/client_sync/v20/generating.rs
@@ -9,7 +9,7 @@
 //!
 //! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
 
-/// Implements Bitcoin Core JSON-RPC API method `generatetodescriptor`
+/// Implements Bitcoin Core JSON-RPC API method `generatetodescriptor`.
 #[macro_export]
 macro_rules! impl_client_v20__generate_to_descriptor {
     () => {

--- a/client/src/client_sync/v21/generating.rs
+++ b/client/src/client_sync/v21/generating.rs
@@ -9,7 +9,7 @@
 //!
 //! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
 
-/// Implements Bitcoin Core JSON-RPC API method `generateblock`
+/// Implements Bitcoin Core JSON-RPC API method `generateblock`.
 #[macro_export]
 macro_rules! impl_client_v21__generate_block {
     () => {

--- a/client/src/client_sync/v21/wallet.rs
+++ b/client/src/client_sync/v21/wallet.rs
@@ -9,7 +9,7 @@
 //!
 //! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
 
-/// Implements Bitcoin Core JSON-RPC API method `createwallet` with descriptors=true (descriptor wallet)
+/// Implements Bitcoin Core JSON-RPC API method `createwallet` with descriptors=true (descriptor wallet).
 #[macro_export]
 macro_rules! impl_client_v21__create_wallet_with_descriptors {
     () => {
@@ -30,7 +30,7 @@ macro_rules! impl_client_v21__create_wallet_with_descriptors {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `importdescriptors`
+/// Implements Bitcoin Core JSON-RPC API method `importdescriptors`.
 #[macro_export]
 macro_rules! impl_client_v21__import_descriptors {
     () => {
@@ -69,7 +69,7 @@ macro_rules! impl_client_v21__send {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `unloadwallet`
+/// Implements Bitcoin Core JSON-RPC API method `unloadwallet`.
 #[macro_export]
 macro_rules! impl_client_v21__unload_wallet {
     () => {

--- a/client/src/client_sync/v22/wallet.rs
+++ b/client/src/client_sync/v22/wallet.rs
@@ -9,7 +9,7 @@
 //!
 //! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
 
-/// Implements Bitcoin Core JSON-RPC API method `listdescriptors`
+/// Implements Bitcoin Core JSON-RPC API method `listdescriptors`.
 #[macro_export]
 macro_rules! impl_client_v22__list_descriptors {
     () => {
@@ -21,7 +21,7 @@ macro_rules! impl_client_v22__list_descriptors {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `loadwallet`
+/// Implements Bitcoin Core JSON-RPC API method `loadwallet`.
 #[macro_export]
 macro_rules! impl_client_v22__load_wallet {
     () => {
@@ -33,7 +33,7 @@ macro_rules! impl_client_v22__load_wallet {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `walletdisplayaddress`
+/// Implements Bitcoin Core JSON-RPC API method `walletdisplayaddress`.
 #[macro_export]
 macro_rules! impl_client_v22__wallet_display_address {
     () => {

--- a/client/src/client_sync/v23/blockchain.rs
+++ b/client/src/client_sync/v23/blockchain.rs
@@ -9,7 +9,7 @@
 //!
 //! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
 
-/// Implements Bitcoin Core JSON-RPC API method `getblockfrompeer`
+/// Implements Bitcoin Core JSON-RPC API method `getblockfrompeer`.
 #[macro_export]
 macro_rules! impl_client_v23__get_block_from_peer {
     () => {
@@ -37,7 +37,7 @@ macro_rules! impl_client_v23__get_deployment_info {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `savemempool`
+/// Implements Bitcoin Core JSON-RPC API method `savemempool`.
 #[macro_export]
 macro_rules! impl_client_v23__save_mempool {
     () => {

--- a/client/src/client_sync/v25/generating.rs
+++ b/client/src/client_sync/v25/generating.rs
@@ -9,7 +9,7 @@
 //!
 //! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
 
-/// Implements Bitcoin Core JSON-RPC API method `generateblock`
+/// Implements Bitcoin Core JSON-RPC API method `generateblock`.
 #[macro_export]
 macro_rules! impl_client_v25__generate_block {
     () => {

--- a/client/src/client_sync/v26/blockchain.rs
+++ b/client/src/client_sync/v26/blockchain.rs
@@ -9,7 +9,7 @@
 //!
 //! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
 
-/// Implements Bitcoin Core JSON-RPC API method `gettxoutsetinfo`
+/// Implements Bitcoin Core JSON-RPC API method `gettxoutsetinfo`.
 #[macro_export]
 macro_rules! impl_client_v26__get_tx_out_set_info {
     () => {

--- a/client/src/client_sync/v26/mining.rs
+++ b/client/src/client_sync/v26/mining.rs
@@ -9,7 +9,7 @@
 //!
 //! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
 
-/// Implements Bitcoin Core JSON-RPC API method `getprioritisedtransactions`
+/// Implements Bitcoin Core JSON-RPC API method `getprioritisedtransactions`.
 #[macro_export]
 macro_rules! impl_client_v26__get_prioritised_transactions {
     () => {

--- a/client/src/client_sync/v26/raw_transactions.rs
+++ b/client/src/client_sync/v26/raw_transactions.rs
@@ -9,7 +9,7 @@
 //!
 //! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
 
-/// Implements Bitcoin Core JSON-RPC API method `submitpackage`
+/// Implements Bitcoin Core JSON-RPC API method `submitpackage`.
 #[macro_export]
 macro_rules! impl_client_v26__submit_package {
     () => {

--- a/client/src/client_sync/v28/raw_transactions.rs
+++ b/client/src/client_sync/v28/raw_transactions.rs
@@ -9,7 +9,7 @@
 //!
 //! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
 
-/// Implements Bitcoin Core JSON-RPC API method `submitpackage`
+/// Implements Bitcoin Core JSON-RPC API method `submitpackage`.
 #[macro_export]
 macro_rules! impl_client_v28__submit_package {
     () => {

--- a/client/src/client_sync/v29/blockchain.rs
+++ b/client/src/client_sync/v29/blockchain.rs
@@ -9,7 +9,7 @@
 //!
 //! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
 
-/// Implements Bitcoin Core JSON-RPC API method `getdescriptoractivity`
+/// Implements Bitcoin Core JSON-RPC API method `getdescriptoractivity`.
 #[macro_export]
 macro_rules! impl_client_v29__get_descriptor_activity {
     () => {


### PR DESCRIPTION
Use AI to go through every file in client and add missing full stops to the rust docs.

There is one typo it also fixed without asking that I noticed.

Part of the fix for issue #296 