### PR TITLE
Add full stops to rustdocs in types

### DIFF
--- a/types/src/v17/network/mod.rs
+++ b/types/src/v17/network/mod.rs
@@ -273,7 +273,7 @@ pub struct PeerInfo {
 #[serde(deny_unknown_fields)]
 pub struct ListBanned(pub Vec<Banned>);
 
-/// An item from the list returned by the JSON-RPC method `listbanned`
+/// An item from the list returned by the JSON-RPC method `listbanned`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Banned {

--- a/types/src/v17/wallet/mod.rs
+++ b/types/src/v17/wallet/mod.rs
@@ -24,7 +24,7 @@ pub use self::error::*;
 // - ListSinceBlockTransaction
 // - ListTransactionsItem
 
-/// Returned as part of `getaddressesbylabel` and `getaddressinfo`
+/// Returned as part of `getaddressesbylabel` and `getaddressinfo`.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum AddressPurpose {

--- a/types/src/v20/network.rs
+++ b/types/src/v20/network.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 #[serde(deny_unknown_fields)]
 pub struct ListBanned(pub Vec<Banned>);
 
-/// An item from the list returned by the JSON-RPC method `listbanned`
+/// An item from the list returned by the JSON-RPC method `listbanned`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Banned {

--- a/types/src/v22/network.rs
+++ b/types/src/v22/network.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 #[serde(deny_unknown_fields)]
 pub struct ListBanned(pub Vec<Banned>);
 
-/// An item from the list returned by the JSON-RPC method `listbanned`
+/// An item from the list returned by the JSON-RPC method `listbanned`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Banned {

--- a/types/src/v28/raw_transactions/mod.rs
+++ b/types/src/v28/raw_transactions/mod.rs
@@ -62,7 +62,7 @@ pub struct SubmitPackageTxResult {
     pub vsize: Option<i64>,
     /// Transaction fees.
     pub fees: Option<SubmitPackageTxResultFees>,
-    /// The transaction error string, if it was rejected by the mempool
+    /// The transaction error string, if it was rejected by the mempool.
     pub error: Option<String>,
 }
 

--- a/types/src/v28/wallet/mod.rs
+++ b/types/src/v28/wallet/mod.rs
@@ -71,7 +71,7 @@ pub struct GetTransaction {
     /// If a comment is associated with the transaction, only present if not empty. v20 to v24 only.
     pub comment: Option<String>,
     /// Whether this transaction could be replaced due to BIP125 (replace-by-fee);
-    /// may be unknown for unconfirmed transactions not in the mempool
+    /// may be unknown for unconfirmed transactions not in the mempool.
     #[serde(rename = "bip125-replaceable")]
     pub bip125_replaceable: Bip125Replaceable,
     /// Only if 'category' is 'received'. List of parent descriptors for the output script of this

--- a/types/src/v29/blockchain/mod.rs
+++ b/types/src/v29/blockchain/mod.rs
@@ -38,7 +38,7 @@ pub struct GetBlockVerboseOne {
     /// The block version formatted in hexadecimal.
     #[serde(rename = "versionHex")]
     pub version_hex: String,
-    /// The merkle root
+    /// The merkle root.
     #[serde(rename = "merkleroot")]
     pub merkle_root: String,
     /// The transaction ids.
@@ -118,7 +118,7 @@ pub struct GetBlockchainInfo {
     pub automatic_pruning: Option<bool>,
     /// The target size used by pruning (only present if automatic pruning is enabled).
     pub prune_target_size: Option<i64>,
-    /// The block challenge (aka. block script)
+    /// The block challenge (aka. block script).
     pub signet_challenge: Option<String>,
     /// Any network and blockchain warnings.
     pub warnings: Vec<String>,
@@ -165,7 +165,7 @@ pub struct GetBlockHeaderVerbose {
     pub nonce: i64,
     /// The bits.
     pub bits: String,
-    /// The difficulty target (hex-encoded). From v29+
+    /// The difficulty target (hex-encoded). From v29+.
     pub target: String,
     /// The difficulty.
     pub difficulty: f64,
@@ -238,19 +238,19 @@ pub struct SpendActivity {
 #[serde(deny_unknown_fields)]
 pub struct ReceiveActivity {
     // Note: 'type' field is used for deserialization tag, not included here explicitly.
-    /// The total amount in BTC of the new output
+    /// The total amount in BTC of the new output.
     pub amount: f64,
-    /// The block that this receive is in
+    /// The block that this receive is in.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[serde(rename = "blockhash")]
     pub block_hash: Option<String>,
-    /// The height of the receive
+    /// The height of the receive.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub height: Option<i64>,
-    /// The txid of the receiving transaction
+    /// The txid of the receiving transaction.
     pub txid: String,
-    /// The vout of the receiving output
+    /// The vout of the receiving output.
     pub vout: u32,
-    /// The ScriptPubKey
+    /// The ScriptPubKey.
     pub output_spk: ScriptPubkey,
 }


### PR DESCRIPTION
Use AI to go through every file in types and add missing full stops to the rust docs.

Only change this crates rustdocs, not anything preceded with `/// >` that comes from core help for the RPCs.

Part of the fix for issue #296 