### PR TITLE
Add full stops to rustdocs in jsonrpc

### DIFF
--- a/jsonrpc/src/client.rs
+++ b/jsonrpc/src/client.rs
@@ -3,7 +3,7 @@
 //! # Client support
 //!
 //! Support for connecting to JSONRPC servers over HTTP, sending requests,
-//! and parsing responses
+//! and parsing responses.
 
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -44,7 +44,7 @@ impl Client {
 
     /// Builds a request.
     ///
-    /// To construct the arguments, one can use one of the shorthand methods
+    /// To construct the arguments, one can use one of the shorthand methods.
     /// [`crate::arg`] or [`crate::try_arg`].
     pub fn build_request<'a>(&self, method: &'a str, params: Option<&'a RawValue>) -> Request<'a> {
         let nonce = self.nonce.fetch_add(1, atomic::Ordering::Relaxed);

--- a/jsonrpc/src/error.rs
+++ b/jsonrpc/src/error.rs
@@ -14,23 +14,23 @@ use crate::Response;
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum Error {
-    /// A transport error
+    /// A transport error.
     Transport(Box<dyn error::Error + Send + Sync>),
-    /// Json error
+    /// Json error.
     Json(serde_json::Error),
-    /// Error response
+    /// Error response.
     Rpc(RpcError),
-    /// Response to a request did not have the expected nonce
+    /// Response to a request did not have the expected nonce.
     NonceMismatch,
-    /// Response to a request had a jsonrpc field other than "2.0"
+    /// Response to a request had a jsonrpc field other than "2.0".
     VersionMismatch,
-    /// Batches can't be empty
+    /// Batches can't be empty.
     EmptyBatch,
-    /// Too many responses returned in batch
+    /// Too many responses returned in batch.
     WrongBatchResponseSize,
-    /// Batch response contained a duplicate ID
+    /// Batch response contained a duplicate ID.
     BatchDuplicateResponseId(serde_json::Value),
-    /// Batch response contained an ID that didn't correspond to any request ID
+    /// Batch response contained an ID that didn't correspond to any request ID.
     WrongBatchResponseId(serde_json::Value),
 }
 
@@ -79,7 +79,7 @@ impl error::Error for Error {
 }
 
 /// Standard error responses, as described at at
-/// <http://www.jsonrpc.org/specification#error_object>
+/// <http://www.jsonrpc.org/specification#error_object>.
 ///
 /// # Documentation Copyright
 /// Copyright (C) 2007-2010 by the JSON-RPC Working Group

--- a/jsonrpc/src/http/minreq_http.rs
+++ b/jsonrpc/src/http/minreq_http.rs
@@ -28,7 +28,7 @@ const DEFAULT_TIMEOUT_SECONDS: u64 = 1;
 pub struct MinreqHttpTransport {
     /// URL of the RPC server.
     url: String,
-    /// timeout only supports second granularity.
+    /// Timeout only supports second granularity.
     timeout: Duration,
     /// The value of the `Authorization` HTTP header, i.e., a base64 encoding of 'user:password'.
     basic_auth: Option<String>,

--- a/jsonrpc/src/http/simple_http.rs
+++ b/jsonrpc/src/http/simple_http.rs
@@ -470,7 +470,7 @@ pub enum Error {
     },
     /// The HTTP response started with a HTTP/1.1 line which was not ASCII.
     HttpResponseNonAsciiHello(Vec<u8>),
-    /// The HTTP response did not start with HTTP/1.1
+    /// The HTTP response did not start with HTTP/1.1.
     HttpResponseBadHello {
         /// Actual HTTP-whatever string.
         actual: String,
@@ -488,7 +488,7 @@ pub enum Error {
         /// Our hard maximum on number of bytes we'll try to read.
         max: u64,
     },
-    /// The server is replying with chunked encoding which is not supported
+    /// The server is replying with chunked encoding which is not supported.
     HttpResponseChunked,
     /// Unexpected HTTP error code (non-200).
     HttpErrorCode(u16),
@@ -727,7 +727,7 @@ mod tests {
     }
 
     /// Test that the client will detect that a socket is closed and open a fresh one before sending
-    /// the request
+    /// the request.
     #[cfg(all(not(feature = "proxy"), not(jsonrpc_fuzz)))]
     #[test]
     fn request_to_closed_socket() {


### PR DESCRIPTION
Use AI to go through every file in jsonrpc and add missing full stops to the rust docs.

Part of the fix for issue #296 