### PR TITLE
Make serde renames consistent

### DIFF
--- a/client/src/client_sync/v17/mod.rs
+++ b/client/src/client_sync/v17/mod.rs
@@ -262,8 +262,8 @@ pub enum SetBanCommand {
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ImportMultiRequest {
     /// Descriptor to import. If using descriptor, donot also provide address/scriptPubKey, scripts, or pubkeys.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub desc: Option<String>, // from core v18 onwards.
+    #[serde(rename = "desc", skip_serializing_if = "Option::is_none")]
+    pub descriptor: Option<String>, // from core v18 onwards.
     /// Type of scriptPubKey (string for script, json for address). Should not be provided if using descriptor.
     #[serde(rename = "scriptPubKey", skip_serializing_if = "Option::is_none")]
     pub script_pubkey: Option<ImportMultiScriptPubKey>,

--- a/client/src/client_sync/v21/mod.rs
+++ b/client/src/client_sync/v21/mod.rs
@@ -188,7 +188,8 @@ crate::impl_client_v17__wallet_process_psbt!();
 #[serde(deny_unknown_fields)]
 pub struct ImportDescriptorsRequest {
     /// Descriptor to import.
-    pub desc: String,
+    #[serde(rename = "desc")]
+    pub descriptor: String,
     /// Time from which to start rescanning the blockchain for this descriptor, in UNIX epoch time or "now".
     pub timestamp: serde_json::Value,
 }

--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -323,7 +323,7 @@ fn wallet__import_descriptors() {
     let descriptor = format!("addr({})", address);
 
     let request = ImportDescriptorsRequest {
-        desc: descriptor,
+        descriptor,
         timestamp: serde_json::Value::String("now".to_string()),
     };
 
@@ -413,14 +413,14 @@ fn wallet__import_multi() {
     // NOTE: On v17, use a wallet-generated address (not raw script)
     // to ensure import succeeds, since the wallet already knows the key.
     let req1 = ImportMultiRequest {
-        desc: None,
+        descriptor: None,
         script_pubkey: Some(ImportMultiScriptPubKey::Script(dummy_script_hex.to_string())),
         timestamp: ImportMultiTimestamp::Now,
     };
 
     // Uses an address (valid): success - false, with JSON-RPC error.
     let req2 = ImportMultiRequest {
-        desc: None,
+        descriptor: None,
         script_pubkey: Some(ImportMultiScriptPubKey::Address {
             address: addr.to_string(),
         }),
@@ -431,7 +431,7 @@ fn wallet__import_multi() {
     // on v18 onwards, it will return a watch-only warning.
     // NOTE: Works only for v18 onwards, as v17 doesn't support descriptors.
     let req3 = ImportMultiRequest {
-        desc: Some(dummy_desc.to_string()),
+        descriptor: Some(dummy_desc.to_string()),
         script_pubkey: None,
         timestamp: ImportMultiTimestamp::Time(1_700_000_000),
     };

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -194,7 +194,7 @@ pub struct ScriptPubkey {
     /// Only returned before in versions prior to 22 or for version 22 onwards if
     /// config option `-deprecatedrpc=addresses` is passed.
     #[serde(rename = "reqSigs")]
-    pub req_sigs: Option<i64>,
+    pub required_signatures: Option<i64>,
     /// The type, eg pubkeyhash.
     #[serde(rename = "type")]
     pub type_: String,

--- a/types/src/model/wallet.rs
+++ b/types/src/model/wallet.rs
@@ -362,7 +362,7 @@ pub struct GetTransaction {
 #[serde(deny_unknown_fields)]
 pub struct GetTransactionDetail {
     /// Only returns true if imported addresses were involved in transaction. v20 and later only.
-    pub involves_watchonly: Option<bool>,
+    pub involves_watch_only: Option<bool>,
     /// DEPRECATED. The account name involved in the transaction, can be "" for the default account.
     pub account: Option<String>, // Docs are wrong, this is not documented as optional.
     /// The bitcoin address involved in the transaction.
@@ -787,7 +787,7 @@ pub struct WalletCreateFundedPsbt {
     #[serde(default, with = "bitcoin::amount::serde::as_btc")]
     pub fee: SignedAmount,
     /// The position of the added change output, or -1.
-    pub change_pos: u32,
+    pub change_position: u32,
 }
 
 /// Models the result of JSON-RPC method `walletprocesspsbt`.

--- a/types/src/psbt/mod.rs
+++ b/types/src/psbt/mod.rs
@@ -173,7 +173,7 @@ pub struct PsbtScript {
     pub hex: String,
     /// The type, eg 'pubkeyhash'.
     #[serde(rename = "type")]
-    pub script_type: String,
+    pub type_: String,
 }
 
 impl PsbtScript {

--- a/types/src/v17/raw_transactions/mod.rs
+++ b/types/src/v17/raw_transactions/mod.rs
@@ -253,7 +253,7 @@ pub struct DecodeScriptSegwit {
     pub addresses: Option<Vec<String>>,
     /// Address of P2SH script wrapping this redeem script (not returned if the script is already a P2SH).
     #[serde(rename = "p2sh-segwit")]
-    pub p2sh_segtwit: Option<String>,
+    pub p2sh_segwit: Option<String>,
 }
 
 /// Result of JSON-RPC method `finalizepsbt`.

--- a/types/src/v17/wallet/into.rs
+++ b/types/src/v17/wallet/into.rs
@@ -390,7 +390,7 @@ impl GetTransactionDetail {
         let fee = self.fee.map(|fee| SignedAmount::from_btc(fee).map_err(E::Fee)).transpose()?;
 
         Ok(model::GetTransactionDetail {
-            involves_watchonly: None, // v20 and later only.
+            involves_watch_only: None, // v20 and later only.
             account: self.account,
             address,
             category: self.category.into_model(),
@@ -742,8 +742,8 @@ impl WalletCreateFundedPsbt {
 
         let psbt = self.psbt.parse::<Psbt>().map_err(E::Psbt)?;
         let fee = SignedAmount::from_btc(self.fee).map_err(E::Fee)?;
-        let change_pos = crate::to_u32(self.change_pos, "change_pos")?;
-        Ok(model::WalletCreateFundedPsbt { psbt, fee, change_pos })
+        let change_position = crate::to_u32(self.change_position, "change_position")?;
+        Ok(model::WalletCreateFundedPsbt { psbt, fee, change_position })
     }
 }
 

--- a/types/src/v17/wallet/mod.rs
+++ b/types/src/v17/wallet/mod.rs
@@ -1056,7 +1056,7 @@ pub struct WalletCreateFundedPsbt {
     pub fee: f64,
     /// The position of the added change output, or -1.
     #[serde(rename = "changepos")]
-    pub change_pos: i64,
+    pub change_position: i64,
 }
 
 /// Result of the JSON-RPC method `walletprocesspsbt`.

--- a/types/src/v20/wallet/into.rs
+++ b/types/src/v20/wallet/into.rs
@@ -72,7 +72,7 @@ impl GetTransactionDetail {
         let fee = self.fee.map(|fee| SignedAmount::from_btc(fee).map_err(E::Fee)).transpose()?;
 
         Ok(model::GetTransactionDetail {
-            involves_watchonly: self.involves_watchonly,
+            involves_watch_only: self.involves_watch_only,
             account: self.account,
             address,
             category: self.category.into_model(),

--- a/types/src/v20/wallet/mod.rs
+++ b/types/src/v20/wallet/mod.rs
@@ -77,7 +77,7 @@ pub struct GetTransaction {
 pub struct GetTransactionDetail {
     /// Only returns true if imported addresses were involved in transaction. v20 and later only.
     #[serde(rename = "involvesWatchonly")]
-    pub involves_watchonly: Option<bool>,
+    pub involves_watch_only: Option<bool>,
     /// DEPRECATED. The account name involved in the transaction, can be "" for the default account.
     pub account: Option<String>, // Docs are wrong, this is not documented as optional.
     /// The bitcoin address involved in the transaction.

--- a/types/src/v21/network/mod.rs
+++ b/types/src/v21/network/mod.rs
@@ -152,9 +152,11 @@ pub struct PeerInfo {
     pub inflight: Vec<u64>,
     /// The total number of addresses processed, excluding those dropped due to rate limiting. v21 and
     /// later only.
-    pub addr_processed: usize,
+    #[serde(rename = "addr_processed")]
+    pub addresses_processed: usize,
     /// The total number of addresses dropped due to rate limiting. v21 and later only.
-    pub addr_rate_limited: usize,
+    #[serde(rename = "addr_rate_limited")]
+    pub addresses_rate_limited: usize,
     /// Any special permissions that have been granted to this peer. v0.19 and later only.
     pub permissions: Vec<String>,
     /// The minimum fee rate for transactions this peer accepts. v0.19 and later only.

--- a/types/src/v22/network.rs
+++ b/types/src/v22/network.rs
@@ -126,9 +126,11 @@ pub struct PeerInfo {
     pub inflight: Vec<u64>,
     /// The total number of addresses processed, excluding those dropped due to rate limiting. v21 and
     /// later only.
-    pub addr_processed: usize,
+    #[serde(rename = "addr_processed")]
+    pub addresses_processed: usize,
     /// The total number of addresses dropped due to rate limiting. v21 and later only.
-    pub addr_rate_limited: usize,
+    #[serde(rename = "addr_rate_limited")]
+    pub addresses_rate_limited: usize,
     /// Any special permissions that have been granted to this peer. v0.19 and later only.
     pub permissions: Vec<String>,
     /// The minimum fee rate for transactions this peer accepts. v0.19 and later only.

--- a/types/src/v22/raw_transactions/mod.rs
+++ b/types/src/v22/raw_transactions/mod.rs
@@ -64,5 +64,5 @@ pub struct DecodeScriptSegwit {
     pub addresses: Option<Vec<String>>,
     /// Address of P2SH script wrapping this redeem script (not returned if the script is already a P2SH).
     #[serde(rename = "p2sh-segwit")]
-    pub p2sh_segtwit: Option<String>,
+    pub p2sh_segwit: Option<String>,
 }

--- a/types/src/v23/network.rs
+++ b/types/src/v23/network.rs
@@ -100,12 +100,15 @@ pub struct PeerInfo {
     /// The heights of blocks we're currently asking from this peer.
     pub inflight: Option<Vec<u64>>,
     /// Whether we participate in address relay with this peer. v23 and later only.
-    pub addr_relay_enabled: Option<bool>,
+    #[serde(rename = "addr_relay_enabled")]
+    pub addresses_relay_enabled: Option<bool>,
     /// The total number of addresses processed, excluding those dropped due to rate limiting. v21 and
     /// later only.
-    pub addr_processed: Option<usize>,
+    #[serde(rename = "addr_processed")]
+    pub addresses_processed: Option<usize>,
     /// The total number of addresses dropped due to rate limiting. v21 and later only.
-    pub addr_rate_limited: Option<usize>,
+    #[serde(rename = "addr_rate_limited")]
+    pub addresses_rate_limited: Option<usize>,
     /// Any special permissions that have been granted to this peer. v0.19 and later only.
     pub permissions: Vec<String>,
     /// The minimum fee rate for transactions this peer accepts. v0.19 and later only.

--- a/types/src/v23/raw_transactions/mod.rs
+++ b/types/src/v23/raw_transactions/mod.rs
@@ -186,5 +186,5 @@ pub struct DecodeScriptSegwit {
     pub descriptor: Option<String>,
     /// Address of P2SH script wrapping this redeem script (not returned if the script is already a P2SH).
     #[serde(rename = "p2sh-segwit")]
-    pub p2sh_segtwit: Option<String>,
+    pub p2sh_segwit: Option<String>,
 }

--- a/types/src/v24/network.rs
+++ b/types/src/v24/network.rs
@@ -103,12 +103,15 @@ pub struct PeerInfo {
     /// The heights of blocks we're currently asking from this peer.
     pub inflight: Option<Vec<u64>>,
     /// Whether we participate in address relay with this peer. v23 and later only.
-    pub addr_relay_enabled: Option<bool>,
+    #[serde(rename = "addr_relay_enabled")]
+    pub addresses_relay_enabled: Option<bool>,
     /// The total number of addresses processed, excluding those dropped due to rate limiting. v21 and
     /// later only.
-    pub addr_processed: Option<usize>,
+    #[serde(rename = "addr_processed")]
+    pub addresses_processed: Option<usize>,
     /// The total number of addresses dropped due to rate limiting. v21 and later only.
-    pub addr_rate_limited: Option<usize>,
+    #[serde(rename = "addr_rate_limited")]
+    pub addresses_rate_limited: Option<usize>,
     /// Any special permissions that have been granted to this peer. v0.19 and later only.
     pub permissions: Vec<String>,
     /// The minimum fee rate for transactions this peer accepts. v0.19 and later only.

--- a/types/src/v24/raw_transactions/into.rs
+++ b/types/src/v24/raw_transactions/into.rs
@@ -397,8 +397,8 @@ impl TaprootScript {
 
         let script = ScriptBuf::from_hex(&self.script).map_err(E::Script)?;
 
-        let leaf_ver = self.leaf_ver as u8; // FIXME: Is this cast ok?
-        let version = LeafVersion::from_consensus(leaf_ver).map_err(E::LeafVer)?;
+        let leaf_version = self.leaf_version as u8; // FIXME: Is this cast ok?
+        let version = LeafVersion::from_consensus(leaf_version).map_err(E::LeafVer)?;
 
         let control_block = control_block(&self.control_blocks).map_err(E::ControlBlocks)?;
 
@@ -452,8 +452,8 @@ fn build_taproot_tree(leaves: Vec<TaprootLeaf>) -> Result<TapTree, TaprootLeafEr
         // Cast ok because depth can never exceed 128.
         let depth = leaf.depth as u8;
 
-        let leaf_ver = leaf.leaf_ver as u8; // FIXME: Is this cast ok?
-        let version = LeafVersion::from_consensus(leaf_ver).map_err(E::LeafVer)?;
+        let leaf_version = leaf.leaf_version as u8; // FIXME: Is this cast ok?
+        let version = LeafVersion::from_consensus(leaf_version).map_err(E::LeafVer)?;
 
         let script = ScriptBuf::from_hex(&leaf.script).map_err(E::Script)?;
 

--- a/types/src/v24/raw_transactions/mod.rs
+++ b/types/src/v24/raw_transactions/mod.rs
@@ -164,7 +164,8 @@ pub struct TaprootScript {
     /// A leaf script.
     pub script: String,
     /// The version number for the leaf script.
-    pub leaf_ver: u32,
+    #[serde(rename = "leaf_ver")]
+    pub leaf_version: u32,
     /// The control blocks for this script.
     pub control_blocks: Vec<String>,
 }
@@ -190,7 +191,8 @@ pub struct TaprootLeaf {
     /// The depth of this element in the tree.
     pub depth: u32,
     /// The version of this leaf.
-    pub leaf_ver: u32,
+    #[serde(rename = "leaf_ver")]
+    pub leaf_version: u32,
     /// The hex-encoded script itself.
     pub script: String,
 }

--- a/types/src/v24/wallet/into.rs
+++ b/types/src/v24/wallet/into.rs
@@ -82,7 +82,7 @@ impl GetTransactionDetail {
         let fee = self.fee.map(|fee| SignedAmount::from_btc(fee).map_err(E::Fee)).transpose()?;
 
         Ok(model::GetTransactionDetail {
-            involves_watchonly: self.involves_watchonly,
+            involves_watch_only: self.involves_watch_only,
             account: self.account,
             address,
             category: self.category.into_model(),

--- a/types/src/v24/wallet/mod.rs
+++ b/types/src/v24/wallet/mod.rs
@@ -91,7 +91,7 @@ pub struct GetTransaction {
 pub struct GetTransactionDetail {
     /// Only returns true if imported addresses were involved in transaction. v20 and later only.
     #[serde(rename = "involvesWatchonly")]
-    pub involves_watchonly: Option<bool>,
+    pub involves_watch_only: Option<bool>,
     /// DEPRECATED. The account name involved in the transaction, can be "" for the default account.
     pub account: Option<String>, // Docs are wrong, this is not documented as optional.
     /// The bitcoin address involved in the transaction.

--- a/types/src/v26/network.rs
+++ b/types/src/v26/network.rs
@@ -103,12 +103,15 @@ pub struct PeerInfo {
     /// The heights of blocks we're currently asking from this peer.
     pub inflight: Option<Vec<u64>>,
     /// Whether we participate in address relay with this peer. v23 and later only.
-    pub addr_relay_enabled: Option<bool>,
+    #[serde(rename = "addr_relay_enabled")]
+    pub addresses_relay_enabled: Option<bool>,
     /// The total number of addresses processed, excluding those dropped due to rate limiting. v21 and
     /// later only.
-    pub addr_processed: Option<usize>,
+    #[serde(rename = "addr_processed")]
+    pub addresses_processed: Option<usize>,
     /// The total number of addresses dropped due to rate limiting. v21 and later only.
-    pub addr_rate_limited: Option<usize>,
+    #[serde(rename = "addr_rate_limited")]
+    pub addresses_rate_limited: Option<usize>,
     /// Any special permissions that have been granted to this peer. v0.19 and later only.
     pub permissions: Vec<String>,
     /// The minimum fee rate for transactions this peer accepts. v0.19 and later only.


### PR DESCRIPTION
Some of the renaming of the rpc returned fields was inconsistent.

Go through them all and make them them consistent.

Fixes the issue #298, but not closing it with this PR since there is an open PR that is also affected.