### PR TITLE
Address all TODO in v24

### DIFF
--- a/client/src/client_sync/mod.rs
+++ b/client/src/client_sync/mod.rs
@@ -83,6 +83,7 @@ macro_rules! define_jsonrpc_minreq_client {
                 let transport = jsonrpc::http::minreq_http::Builder::new()
                     .url(url)
                     .expect("jsonrpc v0.18, this function does not error")
+                    .timeout(std::time::Duration::from_secs(60))
                     .build();
                 let inner = jsonrpc::client::Client::with_transport(transport);
 
@@ -99,6 +100,7 @@ macro_rules! define_jsonrpc_minreq_client {
                 let transport = jsonrpc::http::minreq_http::Builder::new()
                     .url(url)
                     .expect("jsonrpc v0.18, this function does not error")
+                    .timeout(std::time::Duration::from_secs(60))
                     .basic_auth(user.unwrap(), pass)
                     .build();
                 let inner = jsonrpc::client::Client::with_transport(transport);

--- a/client/src/client_sync/v24/blockchain.rs
+++ b/client/src/client_sync/v24/blockchain.rs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Macros for implementing JSON-RPC methods on a client.
+//!
+//! Specifically this is methods found under the `== Blockchain ==` section of the
+//! API docs of Bitcoin Core `v24`.
+//!
+//! All macros require `Client` to be in scope.
+//!
+//! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
+
+/// Implements Bitcoin Core JSON-RPC API method `gettxspendingprevout`
+#[macro_export]
+macro_rules! impl_client_v24__get_tx_spending_prevout {
+    () => {
+        impl Client {
+            pub fn get_tx_spending_prevout(
+                &self,
+                outputs: &[bitcoin::OutPoint],
+            ) -> Result<GetTxSpendingPrevout> {
+                let json_outputs: Vec<_> = outputs.iter().map(|out| {
+                    serde_json::json!({
+                        "txid": out.txid.to_string(),
+                        "vout": out.vout,
+                    })
+                }).collect();
+                self.call("gettxspendingprevout", &[json_outputs.into()])
+            }
+        }
+    };
+}

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -171,6 +171,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v24__migrate_wallet!();
 crate::impl_client_v23__new_keypool!();
 crate::impl_client_v21__psbt_bump_fee!();
 crate::impl_client_v17__remove_pruned_funds!();

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -4,6 +4,8 @@
 //!
 //! We ignore option arguments unless they effect the shape of the returned JSON data.
 
+pub mod blockchain;
+
 use std::collections::BTreeMap;
 use std::path::Path;
 
@@ -48,6 +50,7 @@ crate::impl_client_v17__get_raw_mempool!();
 crate::impl_client_v17__get_tx_out!();
 crate::impl_client_v17__get_tx_out_proof!();
 crate::impl_client_v17__get_tx_out_set_info!();
+crate::impl_client_v24__get_tx_spending_prevout!();
 crate::impl_client_v17__precious_block!();
 crate::impl_client_v17__prune_blockchain!();
 crate::impl_client_v23__save_mempool!();

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -5,6 +5,7 @@
 //! We ignore option arguments unless they effect the shape of the returned JSON data.
 
 pub mod blockchain;
+pub mod wallet;
 
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -176,6 +177,7 @@ crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v23__restore_wallet!();
 crate::impl_client_v21__send!();
+crate::impl_client_v24__send_all!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();
 crate::impl_client_v17__set_hd_seed!();

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -186,6 +186,7 @@ crate::impl_client_v17__set_tx_fee!();
 crate::impl_client_v19__set_wallet_flag!();
 crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
+crate::impl_client_v24__simulate_raw_transaction!();
 crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v21__upgrade_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();

--- a/client/src/client_sync/v24/wallet.rs
+++ b/client/src/client_sync/v24/wallet.rs
@@ -9,6 +9,18 @@
 //!
 //! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
 
+/// Implements Bitcoin Core JSON-RPC API method `migratewallet`.
+#[macro_export]
+macro_rules! impl_client_v24__migrate_wallet {
+    () => {
+        impl Client {
+            pub fn migrate_wallet(&self, wallet_name: &str) -> Result<MigrateWallet> {
+                self.call("migratewallet", &[wallet_name.into()])
+            }
+        }
+    };
+}
+
 /// Implements Bitcoin Core JSON-RPC API method `sendall`.
 #[macro_export]
 macro_rules! impl_client_v24__send_all {

--- a/client/src/client_sync/v24/wallet.rs
+++ b/client/src/client_sync/v24/wallet.rs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Macros for implementing JSON-RPC methods on a client.
+//!
+//! Specifically this is methods found under the `== Wallet ==` section of the
+//! API docs of Bitcoin Core `v24`.
+//!
+//! All macros require `Client` to be in scope.
+//!
+//! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
+
+/// Implements Bitcoin Core JSON-RPC API method `sendall`.
+#[macro_export]
+macro_rules! impl_client_v24__send_all {
+    () => {
+        impl Client {
+            pub fn send_all(&self, recipients: &[Address]) -> Result<SendAll> {
+                self.call("sendall", &[into_json(recipients)?])
+            }
+        }
+    };
+}

--- a/client/src/client_sync/v24/wallet.rs
+++ b/client/src/client_sync/v24/wallet.rs
@@ -32,3 +32,18 @@ macro_rules! impl_client_v24__send_all {
         }
     };
 }
+
+/// Implements Bitcoin Core JSON-RPC API method `simulaterawtransaction`.
+#[macro_export]
+macro_rules! impl_client_v24__simulate_raw_transaction {
+    () => {
+        impl Client {
+            pub fn simulate_raw_transaction(
+                &self,
+                rawtxs: &[String],
+            ) -> Result<SimulateRawTransaction> {
+                self.call("simulaterawtransaction", &[into_json(rawtxs)?])
+            }
+        }
+    };
+}

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -176,6 +176,7 @@ crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v23__restore_wallet!();
 crate::impl_client_v21__send!();
+crate::impl_client_v24__send_all!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();
 crate::impl_client_v17__set_hd_seed!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -170,6 +170,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v24__migrate_wallet!();
 crate::impl_client_v23__new_keypool!();
 crate::impl_client_v21__psbt_bump_fee!();
 crate::impl_client_v17__remove_pruned_funds!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -50,6 +50,7 @@ crate::impl_client_v17__get_raw_mempool!();
 crate::impl_client_v17__get_tx_out!();
 crate::impl_client_v17__get_tx_out_proof!();
 crate::impl_client_v17__get_tx_out_set_info!();
+crate::impl_client_v24__get_tx_spending_prevout!();
 crate::impl_client_v17__precious_block!();
 crate::impl_client_v17__prune_blockchain!();
 crate::impl_client_v23__save_mempool!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -185,6 +185,7 @@ crate::impl_client_v17__set_tx_fee!();
 crate::impl_client_v19__set_wallet_flag!();
 crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
+crate::impl_client_v24__simulate_raw_transaction!();
 crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v21__upgrade_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -180,6 +180,7 @@ crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v23__restore_wallet!();
 crate::impl_client_v21__send!();
+crate::impl_client_v24__send_all!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();
 crate::impl_client_v17__set_hd_seed!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -52,6 +52,7 @@ crate::impl_client_v17__get_raw_mempool!();
 crate::impl_client_v17__get_tx_out!();
 crate::impl_client_v17__get_tx_out_proof!();
 crate::impl_client_v26__get_tx_out_set_info!();
+crate::impl_client_v24__get_tx_spending_prevout!();
 crate::impl_client_v17__precious_block!();
 crate::impl_client_v17__prune_blockchain!();
 crate::impl_client_v23__save_mempool!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -189,6 +189,7 @@ crate::impl_client_v17__set_tx_fee!();
 crate::impl_client_v19__set_wallet_flag!();
 crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
+crate::impl_client_v24__simulate_raw_transaction!();
 crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v21__upgrade_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -174,6 +174,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v24__migrate_wallet!();
 crate::impl_client_v23__new_keypool!();
 crate::impl_client_v21__psbt_bump_fee!();
 crate::impl_client_v17__remove_pruned_funds!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -176,6 +176,7 @@ crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v23__restore_wallet!();
 crate::impl_client_v21__send!();
+crate::impl_client_v24__send_all!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();
 crate::impl_client_v17__set_hd_seed!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -48,6 +48,7 @@ crate::impl_client_v17__get_raw_mempool!();
 crate::impl_client_v17__get_tx_out!();
 crate::impl_client_v17__get_tx_out_proof!();
 crate::impl_client_v26__get_tx_out_set_info!();
+crate::impl_client_v24__get_tx_spending_prevout!();
 crate::impl_client_v17__precious_block!();
 crate::impl_client_v17__prune_blockchain!();
 crate::impl_client_v23__save_mempool!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -170,6 +170,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v24__migrate_wallet!();
 crate::impl_client_v23__new_keypool!();
 crate::impl_client_v21__psbt_bump_fee!();
 crate::impl_client_v17__remove_pruned_funds!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -185,6 +185,7 @@ crate::impl_client_v17__set_tx_fee!();
 crate::impl_client_v19__set_wallet_flag!();
 crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
+crate::impl_client_v24__simulate_raw_transaction!();
 crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v21__upgrade_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -187,6 +187,7 @@ crate::impl_client_v17__set_tx_fee!();
 crate::impl_client_v19__set_wallet_flag!();
 crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
+crate::impl_client_v24__simulate_raw_transaction!();
 crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v21__upgrade_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -178,6 +178,7 @@ crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v23__restore_wallet!();
 crate::impl_client_v21__send!();
+crate::impl_client_v24__send_all!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();
 crate::impl_client_v17__set_hd_seed!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -50,6 +50,7 @@ crate::impl_client_v17__get_raw_mempool!();
 crate::impl_client_v17__get_tx_out!();
 crate::impl_client_v17__get_tx_out_proof!();
 crate::impl_client_v26__get_tx_out_set_info!();
+crate::impl_client_v24__get_tx_spending_prevout!();
 crate::impl_client_v17__precious_block!();
 crate::impl_client_v17__prune_blockchain!();
 crate::impl_client_v23__save_mempool!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -172,6 +172,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v24__migrate_wallet!();
 crate::impl_client_v23__new_keypool!();
 crate::impl_client_v21__psbt_bump_fee!();
 crate::impl_client_v17__remove_pruned_funds!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -187,6 +187,7 @@ crate::impl_client_v17__set_tx_fee!();
 crate::impl_client_v19__set_wallet_flag!();
 crate::impl_client_v17__sign_message!();
 crate::impl_client_v17__sign_raw_transaction_with_wallet!();
+crate::impl_client_v24__simulate_raw_transaction!();
 crate::impl_client_v21__unload_wallet!();
 crate::impl_client_v21__upgrade_wallet!();
 crate::impl_client_v17__wallet_create_funded_psbt!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -178,6 +178,7 @@ crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v23__restore_wallet!();
 crate::impl_client_v21__send!();
+crate::impl_client_v24__send_all!();
 crate::impl_client_v17__send_many!();
 crate::impl_client_v17__send_to_address!();
 crate::impl_client_v17__set_hd_seed!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -50,6 +50,7 @@ crate::impl_client_v17__get_raw_mempool!();
 crate::impl_client_v17__get_tx_out!();
 crate::impl_client_v17__get_tx_out_proof!();
 crate::impl_client_v26__get_tx_out_set_info!();
+crate::impl_client_v24__get_tx_spending_prevout!();
 crate::impl_client_v17__precious_block!();
 crate::impl_client_v17__prune_blockchain!();
 crate::impl_client_v23__save_mempool!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -172,6 +172,7 @@ crate::impl_client_v18__list_wallet_dir!();
 crate::impl_client_v17__list_wallets!();
 crate::impl_client_v22__load_wallet!();
 crate::impl_client_v17__lock_unspent!();
+crate::impl_client_v24__migrate_wallet!();
 crate::impl_client_v23__new_keypool!();
 crate::impl_client_v21__psbt_bump_fee!();
 crate::impl_client_v17__remove_pruned_funds!();

--- a/integration_test/tests/blockchain.rs
+++ b/integration_test/tests/blockchain.rs
@@ -303,6 +303,35 @@ fn blockchain__get_tx_out_set_info__modelled() {
 }
 
 #[test]
+#[cfg(not(feature = "v23_and_below"))]
+fn blockchain__get_tx_spending_prevout__modelled() {
+    let node = Node::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+
+    let (_address1, txid_1) = node.create_mempool_transaction();
+    let (_address2, txid_2) = node.create_mempool_transaction();
+
+    let inputs = vec![
+        bitcoin::OutPoint {
+            txid: txid_1,
+            vout: 0,
+        },
+        bitcoin::OutPoint {
+            txid: txid_2,
+            vout: 0,
+        },
+    ];
+
+    let json: GetTxSpendingPrevout = node.client.get_tx_spending_prevout(&inputs).expect("gettxspendingprevout");
+    let model: Result<mtype::GetTxSpendingPrevout, GetTxSpendingPrevoutError> = json.into_model();
+    let spending_prevout = model.unwrap();
+
+    assert_eq!(spending_prevout.0.len(), 2);
+    assert_eq!(spending_prevout.0[0].outpoint.txid, txid_1);
+    assert_eq!(spending_prevout.0[0].outpoint.vout, 0);
+}
+
+#[test]
 fn blockchain__precious_block() {
     let node = Node::with_wallet(Wallet::Default, &[]);
     node.mine_a_block();

--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -573,6 +573,18 @@ fn wallet__lock_unspent() {
     assert!(json.0);
 }
 
+#[cfg(not(feature = "v23_and_below"))]
+#[test]
+fn wallet__migrate_wallet() {
+    let node = Node::with_wallet(Wallet::None, &["-deprecatedrpc=create_bdb"]);
+    let wallet_name = "legacy_wallet";
+    node.client.create_legacy_wallet(wallet_name).expect("createlegacywallet");
+
+    let json: MigrateWallet = node.client.migrate_wallet(wallet_name).expect("migratewallet");
+
+    assert_eq!(json.wallet_name, wallet_name);
+}
+
 #[cfg(not(feature = "v22_and_below"))]
 #[test]
 fn wallet__new_keypool() {

--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -647,6 +647,18 @@ fn wallet__send__modelled() {
     model.unwrap();
 }
 
+#[cfg(not(feature = "v23_and_below"))]
+#[test]
+fn wallet__send_all__modelled() {
+    let node = Node::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+    let address = node.client.new_address().expect("failed to create new address");
+
+    let json: SendAll = node.client.send_all(&[address]).expect("sendall");
+    let model: Result<mtype::SendAll, SendAllError> = json.into_model();
+    model.unwrap();
+}
+
 #[test]
 fn wallet__send_to_address__modelled() {
     let node = Node::with_wallet(Wallet::Default, &[]);

--- a/types/src/model/blockchain.rs
+++ b/types/src/model/blockchain.rs
@@ -9,8 +9,8 @@ use alloc::collections::BTreeMap;
 
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::{
-    block, Address, Amount, Block, BlockHash, CompactTarget, FeeRate, Network, ScriptBuf, Target,
-    TxMerkleNode, TxOut, Txid, Weight, Work, Wtxid,
+    block, Address, Amount, Block, BlockHash, CompactTarget, FeeRate, Network, OutPoint, ScriptBuf,
+    Target, TxMerkleNode, TxOut, Txid, Weight, Work, Wtxid,
 };
 use serde::{Deserialize, Serialize};
 
@@ -624,6 +624,21 @@ pub struct GetTxOutSetInfo {
     pub disk_size: u32,
     /// The total amount.
     pub total_amount: Amount,
+}
+
+/// Models the result of JSON-RPC method `gettxspendingprevout`.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct GetTxSpendingPrevout(pub Vec<GetTxSpendingPrevoutItem>);
+
+/// An individual result item from `gettxspendingprevout`.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct GetTxSpendingPrevoutItem {
+    /// The outpoint containing the transaction id and vout value of the checked output.
+    pub outpoint: OutPoint,
+    /// The transaction id of the mempool transaction spending this output (omitted if unspent).
+    pub spending_txid: Option<Txid>,
 }
 
 /// Models the result of JSON-RPC method `verifytxoutproof`.

--- a/types/src/model/mod.rs
+++ b/types/src/model/mod.rs
@@ -63,6 +63,6 @@ pub use self::{
         ListTransactions, ListTransactionsItem, ListUnspent, ListUnspentItem, ListWallets,
         LoadWallet, PsbtBumpFee, RescanBlockchain, ScriptType, Send, SendAll, SendMany, SendToAddress,
         SignMessage, TransactionCategory, UnloadWallet, WalletCreateFundedPsbt,
-        WalletDisplayAddress, WalletProcessPsbt,
+        WalletDisplayAddress, WalletProcessPsbt, SimulateRawTransaction
     },
 };

--- a/types/src/model/mod.rs
+++ b/types/src/model/mod.rs
@@ -28,8 +28,9 @@ pub use self::{
         GetChainTxStats, GetDeploymentInfo, GetDescriptorActivity, GetDifficulty,
         GetMempoolAncestors, GetMempoolAncestorsVerbose, GetMempoolDescendants,
         GetMempoolDescendantsVerbose, GetMempoolEntry, GetMempoolInfo, GetRawMempool,
-        GetRawMempoolVerbose, GetTxOut, GetTxOutSetInfo, MempoolEntry, MempoolEntryFees,
-        ReceiveActivity, Softfork, SoftforkType, SpendActivity, VerifyTxOutProof,
+        GetRawMempoolVerbose, GetTxOut, GetTxOutSetInfo, GetTxSpendingPrevout,
+        GetTxSpendingPrevoutItem, MempoolEntry, MempoolEntryFees, ReceiveActivity, Softfork,
+        SoftforkType, SpendActivity, VerifyTxOutProof,
     },
     generating::{Generate, GenerateBlock, GenerateToAddress, GenerateToDescriptor},
     mining::{

--- a/types/src/model/mod.rs
+++ b/types/src/model/mod.rs
@@ -61,7 +61,7 @@ pub use self::{
         ListLockUnspent, ListLockUnspentItem, ListReceivedByAddress, ListReceivedByAddressItem,
         ListReceivedByLabel, ListReceivedByLabelItem, ListSinceBlock, ListSinceBlockTransaction,
         ListTransactions, ListTransactionsItem, ListUnspent, ListUnspentItem, ListWallets,
-        LoadWallet, PsbtBumpFee, RescanBlockchain, ScriptType, Send, SendMany, SendToAddress,
+        LoadWallet, PsbtBumpFee, RescanBlockchain, ScriptType, Send, SendAll, SendMany, SendToAddress,
         SignMessage, TransactionCategory, UnloadWallet, WalletCreateFundedPsbt,
         WalletDisplayAddress, WalletProcessPsbt,
     },

--- a/types/src/model/mod.rs
+++ b/types/src/model/mod.rs
@@ -61,8 +61,8 @@ pub use self::{
         ListLockUnspent, ListLockUnspentItem, ListReceivedByAddress, ListReceivedByAddressItem,
         ListReceivedByLabel, ListReceivedByLabelItem, ListSinceBlock, ListSinceBlockTransaction,
         ListTransactions, ListTransactionsItem, ListUnspent, ListUnspentItem, ListWallets,
-        LoadWallet, PsbtBumpFee, RescanBlockchain, ScriptType, Send, SendAll, SendMany, SendToAddress,
-        SignMessage, TransactionCategory, UnloadWallet, WalletCreateFundedPsbt,
-        WalletDisplayAddress, WalletProcessPsbt, SimulateRawTransaction
+        LoadWallet, PsbtBumpFee, RescanBlockchain, ScriptType, Send, SendAll, SendMany,
+        SendToAddress, SignMessage, SimulateRawTransaction, TransactionCategory, UnloadWallet,
+        WalletCreateFundedPsbt, WalletDisplayAddress, WalletProcessPsbt,
     },
 };

--- a/types/src/model/wallet.rs
+++ b/types/src/model/wallet.rs
@@ -751,6 +751,21 @@ pub struct Send {
     pub psbt: Option<Psbt>,
 }
 
+/// Models the result of JSON-RPC method `sendall`.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SendAll {
+    /// If the transaction has a complete set of signatures.
+    pub complete: bool,
+    /// The transaction id for the send. Only 1 transaction is created regardless of the number of addresses.
+    pub txid: Option<Txid>,
+    /// If add_to_wallet is false, the hex-encoded raw transaction with signature(s).
+    pub hex: Option<Transaction>,
+    /// If more signatures are needed, or if add_to_wallet is false, the base64-encoded (partially)
+    /// signed transaction.
+    pub psbt: Option<Psbt>,
+}
+
 /// Models the result of JSON-RPC method `sendmany`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]

--- a/types/src/model/wallet.rs
+++ b/types/src/model/wallet.rs
@@ -782,6 +782,15 @@ pub struct SendToAddress {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SignMessage(pub sign_message::MessageSignature);
 
+/// Models the result of JSON-RPC method `simulaterawtransaction`.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SimulateRawTransaction {
+    /// The wallet balance change (negative means decrease).
+    #[serde(default, with = "bitcoin::amount::serde::as_btc")]
+    pub balance_change: SignedAmount,
+}
+
 /// Models the result of JSON-RPC method `unloadwallet`.
 ///
 /// Core version v0.21 onwards.

--- a/types/src/v24/blockchain/error.rs
+++ b/types/src/v24/blockchain/error.rs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: CC0-1.0
+
+use core::fmt;
+
+use bitcoin::hex;
+
+use crate::error::write_err;
+
+#[derive(Debug)]
+pub enum GetTxSpendingPrevoutError {
+    /// Conversion of the `outpoint` field failed.
+    Txid(hex::HexToArrayError),
+    /// Conversion of the `spending_txid` field failed.
+    SpendingTxid(hex::HexToArrayError),
+}
+
+impl fmt::Display for GetTxSpendingPrevoutError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use GetTxSpendingPrevoutError as E;
+        match *self {
+            E::Txid(ref e) => write_err!(f, "conversion of the `outpoint` field failed"; e),
+            E::SpendingTxid(ref e) =>
+                write_err!(f, "conversion of the `spending_txid` field failed"; e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for GetTxSpendingPrevoutError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use GetTxSpendingPrevoutError as E;
+        match *self {
+            E::Txid(ref e) => Some(e),
+            E::SpendingTxid(ref e) => Some(e),
+        }
+    }
+}

--- a/types/src/v24/blockchain/mod.rs
+++ b/types/src/v24/blockchain/mod.rs
@@ -4,10 +4,12 @@
 //!
 //! Types for methods found under the `== Blockchain ==` section of the API docs.
 
+mod error;
 mod into;
 
 use serde::{Deserialize, Serialize};
 
+pub use self::error::GetTxSpendingPrevoutError;
 pub use super::{GetMempoolInfoError, MempoolEntryError, MempoolEntryFees};
 
 /// Result of JSON-RPC method `getmempoolentry`.
@@ -109,4 +111,29 @@ pub struct GetMempoolInfo {
     /// only.
     #[serde(rename = "fullrbf")]
     pub full_rbf: bool,
+}
+
+/// Result of JSON-RPC method `gettxspendingprevout`.
+///
+/// > gettxspendingprevout [{"txid":"hex","vout":n},...]
+/// >
+/// > Scans the mempool to find transactions spending any of the given outputs
+/// >
+/// > Arguments:
+/// > 1. outputs                 (json array, required) The transaction outputs that we want to check, and within each, the txid (string) vout (numeric).
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct GetTxSpendingPrevout(pub Vec<GetTxSpendingPrevoutItem>);
+
+/// An individual result item from `gettxspendingprevout`.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct GetTxSpendingPrevoutItem {
+    /// The transaction id of the checked output
+    pub txid: String,
+    /// The vout value of the checked output
+    pub vout: u32,
+    /// The transaction id of the mempool transaction spending this output (omitted if unspent)
+    #[serde(rename = "spendingtxid")]
+    pub spending_txid: Option<String>,
 }

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -193,7 +193,7 @@
 //! | listdescriptors                    | version         |                                        |
 //! | listlabels                         | version + model | UNTESTED                               |
 //! | listlockunspent                    | version + model | UNTESTED                               |
-//! | migratewallet                      | version + model | TODO                                   |
+//! | migratewallet                      | version         |                                        |
 //! | newkeypool                         | returns nothing |                                        |
 //! | psbtbumpfee                        | version + model |                                        |
 //! | listreceivedbyaddress              | version + model | UNTESTED                               |
@@ -258,7 +258,7 @@ pub use self::{
     },
     wallet::{
         GetTransaction, GetTransactionDetail, GetTransactionError, ListUnspent, ListUnspentItem,
-        SendAll, SendAllError,
+        MigrateWallet, SendAll, SendAllError,
     },
 };
 #[doc(inline)]

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -209,7 +209,7 @@
 //! | rescanblockchain                   | version + model | UNTESTED                               |
 //! | restorewallet                      | version         |                                        |
 //! | send                               | version + model |                                        |
-//! | sendall                            | version + model | TODO                                   |
+//! | sendall                            | version + model |                                        |
 //! | sendmany                           | version + model | UNTESTED                               |
 //! | sendtoaddress                      | version + model |                                        |
 //! | sethdseed                          | returns nothing |                                        |
@@ -258,6 +258,7 @@ pub use self::{
     },
     wallet::{
         GetTransaction, GetTransactionDetail, GetTransactionError, ListUnspent, ListUnspentItem,
+        SendAll, SendAllError,
     },
 };
 #[doc(inline)]

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -218,7 +218,7 @@
 //! | setwalletflag                      | version         |                                        |
 //! | signmessage                        | version + model |                                        |
 //! | signrawtransactionwithwallet       | version + model |                                        |
-//! | simulaterawtransaction             | version + model | TODO                                   |
+//! | simulaterawtransaction             | version + model |                                        |
 //! | unloadwallet                       | returns nothing |                                        |
 //! | upgradewallet                      | version         |                                        |
 //! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
@@ -258,7 +258,7 @@ pub use self::{
     },
     wallet::{
         GetTransaction, GetTransactionDetail, GetTransactionError, ListUnspent, ListUnspentItem,
-        MigrateWallet, SendAll, SendAllError,
+        MigrateWallet, SendAll, SendAllError, SimulateRawTransaction,
     },
 };
 #[doc(inline)]

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -47,7 +47,7 @@
 //! | gettxout                           | version + model |                                        |
 //! | gettxoutproof                      | returns string  |                                        |
 //! | gettxoutsetinfo                    | version + model |                                        |
-//! | gettxspendingprevout               | version + model | TODO                                   |
+//! | gettxspendingprevout               | version + model |                                        |
 //! | preciousblock                      | returns nothing |                                        |
 //! | pruneblockchain                    | version         |                                        |
 //! | savemempool                        | version         |                                        |
@@ -247,7 +247,10 @@ mod wallet;
 
 #[doc(inline)]
 pub use self::{
-    blockchain::{GetMempoolEntry, GetMempoolInfo},
+    blockchain::{
+        GetMempoolEntry, GetMempoolInfo, GetTxSpendingPrevout, GetTxSpendingPrevoutError,
+        GetTxSpendingPrevoutItem,
+    },
     network::GetPeerInfo,
     raw_transactions::{
         DecodePsbt, DecodePsbtError, GlobalXpub, Proprietary, PsbtInput, PsbtOutput,

--- a/types/src/v24/wallet/error.rs
+++ b/types/src/v24/wallet/error.rs
@@ -5,6 +5,7 @@ use core::fmt;
 use bitcoin::amount::ParseAmountError;
 use bitcoin::consensus::encode;
 use bitcoin::hex;
+use bitcoin::psbt::PsbtParseError;
 
 use super::GetTransactionDetailError;
 use crate::error::write_err;
@@ -88,4 +89,40 @@ impl std::error::Error for GetTransactionError {
 
 impl From<NumericError> for GetTransactionError {
     fn from(e: NumericError) -> Self { Self::Numeric(e) }
+}
+
+/// Error when converting a `SendAll` type into the model type.
+#[derive(Debug)]
+pub enum SendAllError {
+    /// Conversion of the `txid` field failed.
+    Txid(hex::HexToArrayError),
+    /// Conversion of the `hex` field failed.
+    Hex(encode::FromHexError),
+    /// Conversion of the `psbt` field failed.
+    Psbt(PsbtParseError),
+}
+
+impl fmt::Display for SendAllError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use SendAllError as E;
+
+        match *self {
+            E::Txid(ref e) => write_err!(f, "conversion of the `txid` field failed"; e),
+            E::Hex(ref e) => write_err!(f, "conversion of the `hex` field failed"; e),
+            E::Psbt(ref e) => write_err!(f, "conversion of the `psbt` field failed"; e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for SendAllError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use SendAllError as E;
+
+        match *self {
+            E::Txid(ref e) => Some(e),
+            E::Hex(ref e) => Some(e),
+            E::Psbt(ref e) => Some(e),
+        }
+    }
 }

--- a/types/src/v24/wallet/into.rs
+++ b/types/src/v24/wallet/into.rs
@@ -5,7 +5,7 @@ use bitcoin::{Address, BlockHash, ScriptBuf, SignedAmount, Transaction, Txid};
 
 use super::{
     GetTransaction, GetTransactionDetail, GetTransactionDetailError, GetTransactionError,
-    ListUnspent, ListUnspentItem, ListUnspentItemError,
+    ListUnspent, ListUnspentItem, ListUnspentItemError, SendAll, SendAllError,
 };
 use crate::model;
 
@@ -139,5 +139,21 @@ impl ListUnspentItem {
             safe: self.safe,
             parent_descriptors: self.parent_descriptors,
         })
+    }
+}
+
+impl SendAll {
+    /// Converts version specific type to a version nonspecific, more strongly typed type.
+    pub fn into_model(self) -> Result<model::SendAll, SendAllError> {
+        use SendAllError as E;
+
+        let txid = self.txid.as_ref().map(|s| s.parse()).transpose().map_err(E::Txid)?;
+
+        let hex =
+            self.hex.as_ref().map(|h| encode::deserialize_hex(h)).transpose().map_err(E::Hex)?;
+
+        let psbt = self.psbt.as_ref().map(|p| p.parse()).transpose().map_err(E::Psbt)?;
+
+        Ok(model::SendAll { complete: self.complete, txid, hex, psbt })
     }
 }

--- a/types/src/v24/wallet/into.rs
+++ b/types/src/v24/wallet/into.rs
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: CC0-1.0
 
+use bitcoin::amount::ParseAmountError;
 use bitcoin::consensus::encode;
 use bitcoin::{Address, BlockHash, ScriptBuf, SignedAmount, Transaction, Txid};
 
 use super::{
     GetTransaction, GetTransactionDetail, GetTransactionDetailError, GetTransactionError,
     ListUnspent, ListUnspentItem, ListUnspentItemError, SendAll, SendAllError,
+    SimulateRawTransaction,
 };
 use crate::model;
 
@@ -155,5 +157,13 @@ impl SendAll {
         let psbt = self.psbt.as_ref().map(|p| p.parse()).transpose().map_err(E::Psbt)?;
 
         Ok(model::SendAll { complete: self.complete, txid, hex, psbt })
+    }
+}
+
+impl SimulateRawTransaction {
+    /// Converts version specific type to a version nonspecific, more strongly typed type.
+    pub fn into_model(self) -> Result<model::SimulateRawTransaction, ParseAmountError> {
+        let balance_change = SignedAmount::from_btc(self.balance_change)?;
+        Ok(model::SimulateRawTransaction { balance_change })
     }
 }

--- a/types/src/v24/wallet/mod.rs
+++ b/types/src/v24/wallet/mod.rs
@@ -222,3 +222,18 @@ pub struct SendAll {
     /// If more signatures are needed, or if add_to_wallet is false, the base64-encoded (partially) signed transaction.
     pub psbt: Option<String>,
 }
+
+/// Result of JSON-RPC method `simulaterawtransaction`.
+///
+/// > simulaterawtransaction ( ["rawtx",...] {"include_watchonly":bool,...} )
+/// >
+/// > Calculate the balance change resulting in the signing and broadcasting of the given transaction(s).
+/// >
+/// > Arguments:
+/// > 1. rawtxs                            (json array, optional) An array of hex strings of raw transactions.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SimulateRawTransaction {
+    /// The wallet balance change (negative means decrease).
+    pub balance_change: f64,
+}

--- a/types/src/v24/wallet/mod.rs
+++ b/types/src/v24/wallet/mod.rs
@@ -167,6 +167,36 @@ pub struct ListUnspentItem {
     pub parent_descriptors: Option<Vec<String>>,
 }
 
+/// Result of JSON-RPC method `migratewallet`.
+///
+/// > migratewallet ( "wallet_name" "passphrase" )
+/// >
+/// > EXPERIMENTAL warning: This call may not work as expected and may be changed in future releases
+/// >
+/// > Migrate the wallet to a descriptor wallet.
+/// > A new wallet backup will need to be made.
+/// >
+/// > The migration process will create a backup of the wallet before migrating. This backup
+/// > file will be named {wallet name}-{timestamp}.legacy.bak and can be found in the directory
+/// > for this wallet. In the event of an incorrect migration, the backup can be restored using restorewallet.
+/// > Encrypted wallets must have the passphrase provided as an argument to this call.
+/// >
+/// > Arguments:
+/// > 1. wallet_name    (string, optional, default=the wallet name from the RPC endpoint) The name of the wallet to migrate. If provided both here and in the RPC endpoint, the two must be identical.
+/// > 2. passphrase     (string) The wallet passphrase
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MigrateWallet {
+    /// The name of the primary migrated wallet
+    pub wallet_name: String,
+    /// The name of the migrated wallet containing the watchonly scripts
+    pub watchonly_name: Option<String>,
+    /// The name of the migrated wallet containing solvable but not watched scripts
+    pub solvables_name: Option<String>,
+    /// The location of the backup of the original wallet
+    pub backup_path: String,
+}
+
 /// Result of JSON-RPC method `sendall`.
 ///
 /// > sendall ["address",{"address":amount,...},...] ( conf_target "estimate_mode" fee_rate options )

--- a/types/src/v24/wallet/mod.rs
+++ b/types/src/v24/wallet/mod.rs
@@ -10,7 +10,7 @@ mod into;
 use bitcoin::Transaction;
 use serde::{Deserialize, Serialize};
 
-pub use self::error::GetTransactionError;
+pub use self::error::{GetTransactionError, SendAllError};
 pub use super::{
     Bip125Replaceable, GetTransactionDetailError, ListUnspentItemError, TransactionCategory,
 };
@@ -165,4 +165,30 @@ pub struct ListUnspentItem {
     /// List of parent descriptors for the scriptPubKey of this coin. v24 and later only.
     #[serde(rename = "parent_descs")]
     pub parent_descriptors: Option<Vec<String>>,
+}
+
+/// Result of JSON-RPC method `sendall`.
+///
+/// > sendall ["address",{"address":amount,...},...] ( conf_target "estimate_mode" fee_rate options )
+/// >
+/// > EXPERIMENTAL warning: this call may be changed in future releases.
+/// >
+/// > Spend the value of all (or specific) confirmed UTXOs in the wallet to one or more recipients.
+/// > Unconfirmed inbound UTXOs and locked UTXOs will not be spent. Sendall will respect the avoid_reuse wallet flag.
+/// > If your wallet contains many small inputs, either because it received tiny payments or as a result of accumulating change, consider using `send_max` to exclude inputs that are worth less than the fees needed to spend them.
+/// >
+/// > Arguments:
+/// > 1. recipients                       (json array, required) The sendall destinations. Each address may only appear once.
+/// >                                     Optionally some recipients can be specified with an amount to perform payments, but at least one address must appear without a specified amount.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SendAll {
+    /// If the transaction has a complete set of signatures.
+    pub complete: bool,
+    /// The transaction id for the send. Only 1 transaction is created regardless of the number of addresses.
+    pub txid: Option<String>,
+    /// If add_to_wallet is false, the hex-encoded raw transaction with signature(s).
+    pub hex: Option<String>,
+    /// If more signatures are needed, or if add_to_wallet is false, the base64-encoded (partially) signed transaction.
+    pub psbt: Option<String>,
 }

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -210,7 +210,7 @@
 //! | rescanblockchain                   | version + model | UNTESTED                               |
 //! | restorewallet                      | version         |                                        |
 //! | send                               | version + model |                                        |
-//! | sendall                            | version + model | TODO                                   |
+//! | sendall                            | version + model |                                        |
 //! | sendmany                           | version + model | UNTESTED                               |
 //! | sendtoaddress                      | version + model |                                        |
 //! | sethdseed                          | returns nothing |                                        |
@@ -314,6 +314,6 @@ pub use crate::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetPeerInfo, GetTransaction,
         GetTransactionDetail, GetTransactionError, GlobalXpub, ListUnspent, ListUnspentItem,
         Proprietary, PsbtInput, PsbtOutput, TaprootBip32Deriv, TaprootLeaf, TaprootScript,
-        TaprootScriptPathSig, GetTxSpendingPrevout, GetTxSpendingPrevoutError,
+        TaprootScriptPathSig, GetTxSpendingPrevout, GetTxSpendingPrevoutError, SendAll, SendAllError,
     },
 };

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -47,7 +47,7 @@
 //! | gettxout                           | version + model |                                        |
 //! | gettxoutproof                      | returns string  |                                        |
 //! | gettxoutsetinfo                    | version + model |                                        |
-//! | gettxspendingprevout               | version + model | TODO                                   |
+//! | gettxspendingprevout               | version + model |                                        |
 //! | preciousblock                      | returns nothing |                                        |
 //! | pruneblockchain                    | version         |                                        |
 //! | savemempool                        | version         |                                        |
@@ -314,6 +314,6 @@ pub use crate::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetPeerInfo, GetTransaction,
         GetTransactionDetail, GetTransactionError, GlobalXpub, ListUnspent, ListUnspentItem,
         Proprietary, PsbtInput, PsbtOutput, TaprootBip32Deriv, TaprootLeaf, TaprootScript,
-        TaprootScriptPathSig,
+        TaprootScriptPathSig, GetTxSpendingPrevout, GetTxSpendingPrevoutError,
     },
 };

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -194,7 +194,7 @@
 //! | listdescriptors                    | version         |                                        |
 //! | listlabels                         | version + model | UNTESTED                               |
 //! | listlockunspent                    | version + model | UNTESTED                               |
-//! | migratewallet                      | version + model | TODO                                   |
+//! | migratewallet                      | version         |                                        |
 //! | newkeypool                         | returns nothing |                                        |
 //! | psbtbumpfee                        | version + model |                                        |
 //! | listreceivedbyaddress              | version + model | UNTESTED                               |
@@ -314,6 +314,6 @@ pub use crate::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetPeerInfo, GetTransaction,
         GetTransactionDetail, GetTransactionError, GlobalXpub, ListUnspent, ListUnspentItem,
         Proprietary, PsbtInput, PsbtOutput, TaprootBip32Deriv, TaprootLeaf, TaprootScript,
-        TaprootScriptPathSig, GetTxSpendingPrevout, GetTxSpendingPrevoutError, SendAll, SendAllError,
+        TaprootScriptPathSig, GetTxSpendingPrevout, GetTxSpendingPrevoutError, SendAll, SendAllError, MigrateWallet,
     },
 };

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -219,7 +219,7 @@
 //! | setwalletflag                      | version         |                                        |
 //! | signmessage                        | version + model |                                        |
 //! | signrawtransactionwithwallet       | version + model |                                        |
-//! | simulaterawtransaction             | version + model | TODO                                   |
+//! | simulaterawtransaction             | version + model |                                        |
 //! | unloadwallet                       | returns nothing |                                        |
 //! | upgradewallet                      | version         |                                        |
 //! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
@@ -314,6 +314,6 @@ pub use crate::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetPeerInfo, GetTransaction,
         GetTransactionDetail, GetTransactionError, GlobalXpub, ListUnspent, ListUnspentItem,
         Proprietary, PsbtInput, PsbtOutput, TaprootBip32Deriv, TaprootLeaf, TaprootScript,
-        TaprootScriptPathSig, GetTxSpendingPrevout, GetTxSpendingPrevoutError, SendAll, SendAllError, MigrateWallet,
+        TaprootScriptPathSig, GetTxSpendingPrevout, GetTxSpendingPrevoutError, SendAll, SendAllError, MigrateWallet, SimulateRawTransaction,
     },
 };

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -312,8 +312,9 @@ pub use crate::{
     },
     v24::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetPeerInfo, GetTransaction,
-        GetTransactionDetail, GetTransactionError, GlobalXpub, ListUnspent, ListUnspentItem,
-        Proprietary, PsbtInput, PsbtOutput, TaprootBip32Deriv, TaprootLeaf, TaprootScript,
-        TaprootScriptPathSig, GetTxSpendingPrevout, GetTxSpendingPrevoutError, SendAll, SendAllError, MigrateWallet, SimulateRawTransaction,
+        GetTransactionDetail, GetTransactionError, GetTxSpendingPrevout, GetTxSpendingPrevoutError,
+        GlobalXpub, ListUnspent, ListUnspentItem, MigrateWallet, Proprietary, PsbtInput,
+        PsbtOutput, SendAll, SendAllError, SimulateRawTransaction, TaprootBip32Deriv, TaprootLeaf,
+        TaprootScript, TaprootScriptPathSig,
     },
 };

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -202,7 +202,7 @@
 //! | listdescriptors                    | version         |                                        |
 //! | listlabels                         | version + model | UNTESTED                               |
 //! | listlockunspent                    | version + model | UNTESTED                               |
-//! | migratewallet                      | version + model | TODO                                   |
+//! | migratewallet                      | version         |                                        |
 //! | newkeypool                         | returns nothing |                                        |
 //! | psbtbumpfee                        | version + model |                                        |
 //! | listreceivedbyaddress              | version + model | UNTESTED                               |
@@ -332,7 +332,7 @@ pub use crate::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,
         GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,
         TaprootBip32Deriv, TaprootLeaf, TaprootScript, TaprootScriptPathSig,
-        GetTxSpendingPrevout, GetTxSpendingPrevoutError, SendAll, SendAllError,
+        GetTxSpendingPrevout, GetTxSpendingPrevoutError, SendAll, SendAllError, MigrateWallet,
     },
     v25::{GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors},
 };

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -227,7 +227,7 @@
 //! | setwalletflag                      | version         |                                        |
 //! | signmessage                        | version + model |                                        |
 //! | signrawtransactionwithwallet       | version + model |                                        |
-//! | simulaterawtransaction             | version + model | TODO                                   |
+//! | simulaterawtransaction             | version + model |                                        |
 //! | unloadwallet                       | returns nothing |                                        |
 //! | upgradewallet                      | version         |                                        |
 //! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
@@ -332,7 +332,7 @@ pub use crate::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,
         GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,
         TaprootBip32Deriv, TaprootLeaf, TaprootScript, TaprootScriptPathSig,
-        GetTxSpendingPrevout, GetTxSpendingPrevoutError, SendAll, SendAllError, MigrateWallet,
+        GetTxSpendingPrevout, GetTxSpendingPrevoutError, SendAll, SendAllError, MigrateWallet, SimulateRawTransaction,
     },
     v25::{GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors},
 };

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -330,9 +330,10 @@ pub use crate::{
     },
     v24::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,
-        GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,
-        TaprootBip32Deriv, TaprootLeaf, TaprootScript, TaprootScriptPathSig,
-        GetTxSpendingPrevout, GetTxSpendingPrevoutError, SendAll, SendAllError, MigrateWallet, SimulateRawTransaction,
+        GetTxSpendingPrevout, GetTxSpendingPrevoutError, GlobalXpub, ListUnspent, ListUnspentItem,
+        MigrateWallet, Proprietary, PsbtInput, PsbtOutput, SendAll, SendAllError,
+        SimulateRawTransaction, TaprootBip32Deriv, TaprootLeaf, TaprootScript,
+        TaprootScriptPathSig,
     },
     v25::{GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors},
 };

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -218,7 +218,7 @@
 //! | rescanblockchain                   | version + model | UNTESTED                               |
 //! | restorewallet                      | version         |                                        |
 //! | send                               | version + model |                                        |
-//! | sendall                            | version + model | TODO                                   |
+//! | sendall                            | version + model |                                        |
 //! | sendmany                           | version + model | UNTESTED                               |
 //! | sendtoaddress                      | version + model |                                        |
 //! | sethdseed                          | returns nothing |                                        |
@@ -332,7 +332,7 @@ pub use crate::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,
         GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,
         TaprootBip32Deriv, TaprootLeaf, TaprootScript, TaprootScriptPathSig,
-        GetTxSpendingPrevout, GetTxSpendingPrevoutError,
+        GetTxSpendingPrevout, GetTxSpendingPrevoutError, SendAll, SendAllError,
     },
     v25::{GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors},
 };

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -49,7 +49,7 @@
 //! | gettxout                           | version + model |                                        |
 //! | gettxoutproof                      | returns string  |                                        |
 //! | gettxoutsetinfo                    | version + model |                                        |
-//! | gettxspendingprevout               | version + model | TODO                                   |
+//! | gettxspendingprevout               | version + model |                                        |
 //! | importmempool                      | version + model | TODO                                   |
 //! | loadtxoutset                       | version + model | TODO                                   |
 //! | preciousblock                      | returns nothing |                                        |
@@ -332,6 +332,7 @@ pub use crate::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,
         GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,
         TaprootBip32Deriv, TaprootLeaf, TaprootScript, TaprootScriptPathSig,
+        GetTxSpendingPrevout, GetTxSpendingPrevoutError,
     },
     v25::{GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors},
 };

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -307,9 +307,10 @@ pub use crate::{
     },
     v24::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,
-        GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,
-        TaprootBip32Deriv, TaprootLeaf, TaprootScript, TaprootScriptPathSig,
-        GetTxSpendingPrevout, GetTxSpendingPrevoutError, SendAll, SendAllError, MigrateWallet, SimulateRawTransaction,
+        GetTxSpendingPrevout, GetTxSpendingPrevoutError, GlobalXpub, ListUnspent, ListUnspentItem,
+        MigrateWallet, Proprietary, PsbtInput, PsbtOutput, SendAll, SendAllError,
+        SimulateRawTransaction, TaprootBip32Deriv, TaprootLeaf, TaprootScript,
+        TaprootScriptPathSig,
     },
     v25::{GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors},
     v26::{

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -49,7 +49,7 @@
 //! | gettxout                           | version + model |                                        |
 //! | gettxoutproof                      | returns string  |                                        |
 //! | gettxoutsetinfo                    | version + model |                                        |
-//! | gettxspendingprevout               | version + model | TODO                                   |
+//! | gettxspendingprevout               | version + model |                                        |
 //! | importmempool                      | version + model | TODO                                   |
 //! | loadtxoutset                       | version + model | TODO                                   |
 //! | preciousblock                      | returns nothing |                                        |
@@ -309,6 +309,7 @@ pub use crate::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,
         GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,
         TaprootBip32Deriv, TaprootLeaf, TaprootScript, TaprootScriptPathSig,
+        GetTxSpendingPrevout, GetTxSpendingPrevoutError,
     },
     v25::{GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors},
     v26::{

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -227,7 +227,7 @@
 //! | setwalletflag                      | version         |                                        |
 //! | signmessage                        | version + model |                                        |
 //! | signrawtransactionwithwallet       | version + model |                                        |
-//! | simulaterawtransaction             | version + model | TODO                                   |
+//! | simulaterawtransaction             | version + model |                                        |
 //! | unloadwallet                       | returns nothing |                                        |
 //! | upgradewallet                      | version         |                                        |
 //! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
@@ -309,7 +309,7 @@ pub use crate::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,
         GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,
         TaprootBip32Deriv, TaprootLeaf, TaprootScript, TaprootScriptPathSig,
-        GetTxSpendingPrevout, GetTxSpendingPrevoutError, SendAll, SendAllError, MigrateWallet,
+        GetTxSpendingPrevout, GetTxSpendingPrevoutError, SendAll, SendAllError, MigrateWallet, SimulateRawTransaction,
     },
     v25::{GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors},
     v26::{

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -218,7 +218,7 @@
 //! | rescanblockchain                   | version + model | UNTESTED                               |
 //! | restorewallet                      | version         |                                        |
 //! | send                               | version + model |                                        |
-//! | sendall                            | version + model | TODO                                   |
+//! | sendall                            | version + model |                                        |
 //! | sendmany                           | version + model | UNTESTED                               |
 //! | sendtoaddress                      | version + model |                                        |
 //! | sethdseed                          | returns nothing |                                        |
@@ -309,7 +309,7 @@ pub use crate::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,
         GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,
         TaprootBip32Deriv, TaprootLeaf, TaprootScript, TaprootScriptPathSig,
-        GetTxSpendingPrevout, GetTxSpendingPrevoutError,
+        GetTxSpendingPrevout, GetTxSpendingPrevoutError, SendAll, SendAllError,
     },
     v25::{GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors},
     v26::{

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -202,7 +202,7 @@
 //! | listdescriptors                    | version         |                                        |
 //! | listlabels                         | version + model | UNTESTED                               |
 //! | listlockunspent                    | version + model | UNTESTED                               |
-//! | migratewallet                      | version + model | TODO                                   |
+//! | migratewallet                      | version         |                                        |
 //! | newkeypool                         | returns nothing |                                        |
 //! | psbtbumpfee                        | version + model |                                        |
 //! | listreceivedbyaddress              | version + model | UNTESTED                               |
@@ -309,7 +309,7 @@ pub use crate::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,
         GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,
         TaprootBip32Deriv, TaprootLeaf, TaprootScript, TaprootScriptPathSig,
-        GetTxSpendingPrevout, GetTxSpendingPrevoutError, SendAll, SendAllError,
+        GetTxSpendingPrevout, GetTxSpendingPrevoutError, SendAll, SendAllError, MigrateWallet,
     },
     v25::{GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors},
     v26::{

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -229,7 +229,7 @@
 //! | setwalletflag                      | version         |                                        |
 //! | signmessage                        | version + model |                                        |
 //! | signrawtransactionwithwallet       | version + model |                                        |
-//! | simulaterawtransaction             | version + model | TODO                                   |
+//! | simulaterawtransaction             | version + model |                                        |
 //! | unloadwallet                       | returns nothing |                                        |
 //! | upgradewallet                      | version         |                                        |
 //! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
@@ -330,7 +330,7 @@ pub use crate::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,
         GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,
         TaprootBip32Deriv, TaprootLeaf, TaprootScript, TaprootScriptPathSig,
-        GetTxSpendingPrevout, GetTxSpendingPrevoutError, SendAll, SendAllError, MigrateWallet,
+        GetTxSpendingPrevout, GetTxSpendingPrevoutError, SendAll, SendAllError, MigrateWallet, SimulateRawTransaction,
     },
     v25::{GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors},
     v26::{

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -204,7 +204,7 @@
 //! | listdescriptors                    | version         |                                        |
 //! | listlabels                         | version + model | UNTESTED                               |
 //! | listlockunspent                    | version + model | UNTESTED                               |
-//! | migratewallet                      | version + model | TODO                                   |
+//! | migratewallet                      | version         |                                        |
 //! | newkeypool                         | returns nothing |                                        |
 //! | psbtbumpfee                        | version + model |                                        |
 //! | listreceivedbyaddress              | version + model | UNTESTED                               |
@@ -330,7 +330,7 @@ pub use crate::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,
         GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,
         TaprootBip32Deriv, TaprootLeaf, TaprootScript, TaprootScriptPathSig,
-        GetTxSpendingPrevout, GetTxSpendingPrevoutError, SendAll, SendAllError,
+        GetTxSpendingPrevout, GetTxSpendingPrevoutError, SendAll, SendAllError, MigrateWallet,
     },
     v25::{GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors},
     v26::{

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -328,9 +328,10 @@ pub use crate::{
     },
     v24::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,
-        GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,
-        TaprootBip32Deriv, TaprootLeaf, TaprootScript, TaprootScriptPathSig,
-        GetTxSpendingPrevout, GetTxSpendingPrevoutError, SendAll, SendAllError, MigrateWallet, SimulateRawTransaction,
+        GetTxSpendingPrevout, GetTxSpendingPrevoutError, GlobalXpub, ListUnspent, ListUnspentItem,
+        MigrateWallet, Proprietary, PsbtInput, PsbtOutput, SendAll, SendAllError,
+        SimulateRawTransaction, TaprootBip32Deriv, TaprootLeaf, TaprootScript,
+        TaprootScriptPathSig,
     },
     v25::{GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors},
     v26::{

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -49,7 +49,7 @@
 //! | gettxout                           | version + model |                                        |
 //! | gettxoutproof                      | returns string  |                                        |
 //! | gettxoutsetinfo                    | version + model |                                        |
-//! | gettxspendingprevout               | version + model | TODO                                   |
+//! | gettxspendingprevout               | version + model |                                        |
 //! | importmempool                      | version + model | TODO                                   |
 //! | loadtxoutset                       | version + model | TODO                                   |
 //! | preciousblock                      | returns nothing |                                        |
@@ -330,6 +330,7 @@ pub use crate::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,
         GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,
         TaprootBip32Deriv, TaprootLeaf, TaprootScript, TaprootScriptPathSig,
+        GetTxSpendingPrevout, GetTxSpendingPrevoutError,
     },
     v25::{GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors},
     v26::{

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -220,7 +220,7 @@
 //! | rescanblockchain                   | version + model | UNTESTED                               |
 //! | restorewallet                      | version         |                                        |
 //! | send                               | version + model |                                        |
-//! | sendall                            | version + model | TODO                                   |
+//! | sendall                            | version + model |                                        |
 //! | sendmany                           | version + model | UNTESTED                               |
 //! | sendtoaddress                      | version + model |                                        |
 //! | sethdseed                          | returns nothing |                                        |
@@ -330,7 +330,7 @@ pub use crate::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,
         GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,
         TaprootBip32Deriv, TaprootLeaf, TaprootScript, TaprootScriptPathSig,
-        GetTxSpendingPrevout, GetTxSpendingPrevoutError,
+        GetTxSpendingPrevout, GetTxSpendingPrevoutError, SendAll, SendAllError,
     },
     v25::{GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors},
     v26::{

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -50,7 +50,7 @@
 //! | gettxout                           | version + model |                                        |
 //! | gettxoutproof                      | returns string  |                                        |
 //! | gettxoutsetinfo                    | version + model |                                        |
-//! | gettxspendingprevout               | version + model | TODO                                   |
+//! | gettxspendingprevout               | version + model |                                        |
 //! | importmempool                      | version + model | TODO                                   |
 //! | loadtxoutset                       | version + model | TODO                                   |
 //! | preciousblock                      | returns nothing |                                        |
@@ -328,6 +328,7 @@ pub use crate::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,
         GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,
         TaprootBip32Deriv, TaprootLeaf, TaprootScript, TaprootScriptPathSig,
+        GetTxSpendingPrevout, GetTxSpendingPrevoutError,
     },
     v25::{GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors},
     v26::{

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -230,7 +230,7 @@
 //! | setwalletflag                      | version         |                                        |
 //! | signmessage                        | version + model |                                        |
 //! | signrawtransactionwithwallet       | version + model |                                        |
-//! | simulaterawtransaction             | version + model | TODO                                   |
+//! | simulaterawtransaction             | version + model |                                        |
 //! | unloadwallet                       | returns nothing |                                        |
 //! | upgradewallet                      | version         |                                        |
 //! | walletcreatefundedpsbt             | version + model | UNTESTED                               |
@@ -328,7 +328,7 @@ pub use crate::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,
         GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,
         TaprootBip32Deriv, TaprootLeaf, TaprootScript, TaprootScriptPathSig,
-        GetTxSpendingPrevout, GetTxSpendingPrevoutError, SendAll, SendAllError, MigrateWallet,
+        GetTxSpendingPrevout, GetTxSpendingPrevoutError, SendAll, SendAllError, MigrateWallet, SimulateRawTransaction,
     },
     v25::{GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors},
     v26::{

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -205,7 +205,7 @@
 //! | listdescriptors                    | version         |                                        |
 //! | listlabels                         | version + model | UNTESTED                               |
 //! | listlockunspent                    | version + model | UNTESTED                               |
-//! | migratewallet                      | version + model | TODO                                   |
+//! | migratewallet                      | version         |                                        |
 //! | newkeypool                         | returns nothing |                                        |
 //! | psbtbumpfee                        | version + model |                                        |
 //! | listreceivedbyaddress              | version + model | UNTESTED                               |
@@ -328,7 +328,7 @@ pub use crate::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,
         GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,
         TaprootBip32Deriv, TaprootLeaf, TaprootScript, TaprootScriptPathSig,
-        GetTxSpendingPrevout, GetTxSpendingPrevoutError, SendAll, SendAllError,
+        GetTxSpendingPrevout, GetTxSpendingPrevoutError, SendAll, SendAllError, MigrateWallet,
     },
     v25::{GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors},
     v26::{

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -326,9 +326,10 @@ pub use crate::{
     },
     v24::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,
-        GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,
-        TaprootBip32Deriv, TaprootLeaf, TaprootScript, TaprootScriptPathSig,
-        GetTxSpendingPrevout, GetTxSpendingPrevoutError, SendAll, SendAllError, MigrateWallet, SimulateRawTransaction,
+        GetTxSpendingPrevout, GetTxSpendingPrevoutError, GlobalXpub, ListUnspent, ListUnspentItem,
+        MigrateWallet, Proprietary, PsbtInput, PsbtOutput, SendAll, SendAllError,
+        SimulateRawTransaction, TaprootBip32Deriv, TaprootLeaf, TaprootScript,
+        TaprootScriptPathSig,
     },
     v25::{GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors},
     v26::{

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -221,7 +221,7 @@
 //! | rescanblockchain                   | version + model | UNTESTED                               |
 //! | restorewallet                      | version         |                                        |
 //! | send                               | version + model |                                        |
-//! | sendall                            | version + model | TODO                                   |
+//! | sendall                            | version + model |                                        |
 //! | sendmany                           | version + model | UNTESTED                               |
 //! | sendtoaddress                      | version + model |                                        |
 //! | sethdseed                          | returns nothing |                                        |
@@ -328,7 +328,7 @@ pub use crate::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetTransactionDetail,
         GlobalXpub, ListUnspent, ListUnspentItem, Proprietary, PsbtInput, PsbtOutput,
         TaprootBip32Deriv, TaprootLeaf, TaprootScript, TaprootScriptPathSig,
-        GetTxSpendingPrevout, GetTxSpendingPrevoutError,
+        GetTxSpendingPrevout, GetTxSpendingPrevoutError, SendAll, SendAllError,
     },
     v25::{GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors},
     v26::{

--- a/verify/src/method/v24.rs
+++ b/verify/src/method/v24.rs
@@ -133,7 +133,7 @@ pub const METHODS: &[Method] = &[
     Method::new_no_model("listdescriptors", "ListDescriptors", "list_descriptors"),
     Method::new_modelled("listlabels", "ListLabels", "list_labels"),
     Method::new_modelled("listlockunspent", "ListLockUnspent", "list_lock_unspent"),
-    Method::new_modelled("migratewallet", "MigrateWallet", "migrate_wallet"),
+    Method::new_no_model("migratewallet", "MigrateWallet", "migrate_wallet"),
     Method::new_modelled("newkeypool", "NewKeyPool", "new_key_pool"),
     Method::new_modelled("psbtbumpfee", "PsbtBumpFee", "psbt_bump_fee"),
     Method::new_modelled(

--- a/verify/src/method/v25.rs
+++ b/verify/src/method/v25.rs
@@ -134,7 +134,7 @@ pub const METHODS: &[Method] = &[
     Method::new_no_model("listdescriptors", "ListDescriptors", "list_descriptors"),
     Method::new_modelled("listlabels", "ListLabels", "list_labels"),
     Method::new_modelled("listlockunspent", "ListLockUnspent", "list_lock_unspent"),
-    Method::new_modelled("migratewallet", "MigrateWallet", "migrate_wallet"),
+    Method::new_no_model("migratewallet", "MigrateWallet", "migrate_wallet"),
     Method::new_modelled("newkeypool", "NewKeyPool", "new_key_pool"),
     Method::new_modelled("psbtbumpfee", "PsbtBumpFee", "psbt_bump_fee"),
     Method::new_modelled(

--- a/verify/src/method/v26.rs
+++ b/verify/src/method/v26.rs
@@ -142,7 +142,7 @@ pub const METHODS: &[Method] = &[
     Method::new_no_model("listdescriptors", "ListDescriptors", "list_descriptors"),
     Method::new_modelled("listlabels", "ListLabels", "list_labels"),
     Method::new_modelled("listlockunspent", "ListLockUnspent", "list_lock_unspent"),
-    Method::new_modelled("migratewallet", "MigrateWallet", "migrate_wallet"),
+    Method::new_no_model("migratewallet", "MigrateWallet", "migrate_wallet"),
     Method::new_modelled("newkeypool", "NewKeyPool", "new_key_pool"),
     Method::new_modelled("psbtbumpfee", "PsbtBumpFee", "psbt_bump_fee"),
     Method::new_modelled(

--- a/verify/src/method/v27.rs
+++ b/verify/src/method/v27.rs
@@ -144,7 +144,7 @@ pub const METHODS: &[Method] = &[
     Method::new_no_model("listdescriptors", "ListDescriptors", "list_descriptors"),
     Method::new_modelled("listlabels", "ListLabels", "list_labels"),
     Method::new_modelled("listlockunspent", "ListLockUnspent", "list_lock_unspent"),
-    Method::new_modelled("migratewallet", "MigrateWallet", "migrate_wallet"),
+    Method::new_no_model("migratewallet", "MigrateWallet", "migrate_wallet"),
     Method::new_modelled("newkeypool", "NewKeyPool", "new_key_pool"),
     Method::new_modelled("psbtbumpfee", "PsbtBumpFee", "psbt_bump_fee"),
     Method::new_modelled(

--- a/verify/src/method/v28.rs
+++ b/verify/src/method/v28.rs
@@ -146,7 +146,7 @@ pub const METHODS: &[Method] = &[
     Method::new_no_model("listdescriptors", "ListDescriptors", "list_descriptors"),
     Method::new_modelled("listlabels", "ListLabels", "list_labels"),
     Method::new_modelled("listlockunspent", "ListLockUnspent", "list_lock_unspent"),
-    Method::new_modelled("migratewallet", "MigrateWallet", "migrate_wallet"),
+    Method::new_no_model("migratewallet", "MigrateWallet", "migrate_wallet"),
     Method::new_modelled("newkeypool", "NewKeyPool", "new_key_pool"),
     Method::new_modelled("psbtbumpfee", "PsbtBumpFee", "psbt_bump_fee"),
     Method::new_modelled(

--- a/verify/src/method/v29.rs
+++ b/verify/src/method/v29.rs
@@ -147,7 +147,7 @@ pub const METHODS: &[Method] = &[
     Method::new_no_model("listdescriptors", "ListDescriptors", "list_descriptors"),
     Method::new_modelled("listlabels", "ListLabels", "list_labels"),
     Method::new_modelled("listlockunspent", "ListLockUnspent", "list_lock_unspent"),
-    Method::new_modelled("migratewallet", "MigrateWallet", "migrate_wallet"),
+    Method::new_no_model("migratewallet", "MigrateWallet", "migrate_wallet"),
     Method::new_modelled("newkeypool", "NewKeyPool", "new_key_pool"),
     Method::new_modelled("psbtbumpfee", "PsbtBumpFee", "psbt_bump_fee"),
     Method::new_modelled(


### PR DESCRIPTION
Go through all the TODO in the v24 types table. Add all the missing RPCs.

- Add `gettxspendingprevout` method, model and test
- Add `sendall` method, model and test
- Increase `client` timeout - The `migratewallet` RPC call takes about 30sec on v24, it's a lot faster on v29. The default timeout was 15sec, increase it to 60 to prevent the timeout during testing. To quote Core "This RPC may take a long time to complete. Increasing the RPC client timeout is recommended."
- Add `migratewallet` method, and test - The help says that `passphrase` is required in v24, but it isn't. The optional argument `wallet_name` was required for testing.  There is nothing to model so the types table was updated accordingly.
- Add `simulaterawtransaction` method, model and test - The help says that the `rawtxs` are optional, but they
 are required for testing or nothing is simulated.
- Run the formatter