### PR TITLE
Only codesign bitcoind if necessary

### DIFF
--- a/node/build.rs
+++ b/node/build.rs
@@ -160,17 +160,26 @@ mod download {
             #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
             {
                 use std::process::Command;
-                let status = Command::new("codesign")
-                    .arg("-s")
-                    .arg("-")
-                    .arg(existing_filename.to_str().unwrap())
+
+                let signing_status = Command::new("codesign")
+                    .arg("-v")
+                    .arg(&existing_filename)
                     .status()
-                    .with_context(|| "failed to execute codesign")?;
-                if !status.success() {
-                    return Err(anyhow::anyhow!(
-                        "codesign failed with exit code {}",
-                        status.code().unwrap_or(-1)
-                    ));
+                    .with_context(|| "failed to verify bitcoind code signature")?;
+
+                if !signing_status.success() {
+                    let status = Command::new("codesign")
+                        .arg("-s")
+                        .arg("-")
+                        .arg(&existing_filename)
+                        .status()
+                        .with_context(|| "failed to sign bitcoind")?;
+                    if !status.success() {
+                        return Err(anyhow::anyhow!(
+                            "codesign failed with exit code {}",
+                            status.code().unwrap_or(-1)
+                        ));
+                    }
                 }
             }
         }


### PR DESCRIPTION
Extension of [PR #71](https://github.com/rust-bitcoin/corepc/pull/71), which introduced initial support for codesigning in the `node` crate. As of version 29, Bitcoin Core has [begun codesigning](https://github.com/bitcoin/bitcoin/pull/31407) the `bitcoind` binary for macOS users. This broke the current logic of the node crate here because we're currently signing every time. This results in the build step of this crate panicking with:

```
  --- stderr
..../target/debug/build/corepc-node-ab8800f75cc98512/out/bitcoin/bitcoin-29.0/bin/bitcoind: is already signed
```

To fix this, I've added some simple validation code that checks if the binary is already signed and subsequently skips the codesign step.

Verified on macOS Sequoia 15.5 (24F74) with M3 silicon using:

```
cargo test --features 29_0,download
cargo test --features 28_0,download
```

to ensure backward compatibility.