### PR TITLE
fix: use v26 getpeerinfo for v26, v27, v28, v29

### DIFF
--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -260,7 +260,7 @@ pub use self::{
     blockchain::{GetTxOutSetInfo, GetTxOutSetInfoError},
     control::Logging,
     mining::{GetPrioritisedTransactions, PrioritisedTransaction},
-    network::GetPeerInfo,
+    network::{GetPeerInfo, PeerInfo},
     raw_transactions::{
         DescriptorProcessPsbt, DescriptorProcessPsbtError, SubmitPackage, SubmitPackageError,
         SubmitPackageTxResult, SubmitPackageTxResultError, SubmitPackageTxResultFees,
@@ -315,8 +315,8 @@ pub use crate::{
         GetBalancesWatchOnly, GetBlockFilter, GetBlockFilterError, GetBlockchainInfoError,
         GetChainTxStats, GetDescriptorInfo, GetMempoolAncestors, GetMempoolAncestorsVerbose,
         GetMempoolDescendants, GetMempoolDescendantsVerbose, GetRpcInfo, MapMempoolEntryError,
-        MempoolEntry, MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, PeerInfo,
-        SetWalletFlag, Softfork, SoftforkType,
+        MempoolEntry, MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, SetWalletFlag,
+        Softfork, SoftforkType,
     },
     v20::GenerateToDescriptor,
     v21::{

--- a/types/src/v26/network.rs
+++ b/types/src/v26/network.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! The JSON-RPC API for Bitcoin Core `v23` - network.
+//! The JSON-RPC API for Bitcoin Core `v26` - network.
 //!
 //! Types for methods found under the `== Network ==` section of the API docs.
 
@@ -32,8 +32,10 @@ pub struct PeerInfo {
     /// Local address as reported by the peer.
     #[serde(rename = "addrlocal")]
     pub address_local: Option<String>,
-    /// Network (ipv4, ipv6, or onion) the peer connected through.
-    pub network: Option<String>,
+    /// Network (ipv4, ipv6, onion, i2p, cjdns, not_publicly_routable) the peer connected through.
+    pub network: String,
+    /// Mapped AS (Autonomous System) number at the end of the BGP route to the peer, used for diversifying peer selection (only displayed if the -asmap config option is set).
+    pub mapped_as: Option<u32>,
     /// The services offered.
     pub services: String,
     /// The services offered, in human-readable form. v0.19 and later only.

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -292,8 +292,8 @@ pub use crate::{
         GetBalancesWatchOnly, GetBlockFilter, GetBlockFilterError, GetBlockchainInfoError,
         GetChainTxStats, GetDescriptorInfo, GetMempoolAncestors, GetMempoolAncestorsVerbose,
         GetMempoolDescendants, GetMempoolDescendantsVerbose, GetRpcInfo, MapMempoolEntryError,
-        MempoolEntry, MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, PeerInfo,
-        SetWalletFlag, Softfork, SoftforkType,
+        MempoolEntry, MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, SetWalletFlag,
+        Softfork, SoftforkType,
     },
     v20::GenerateToDescriptor,
     v21::{
@@ -317,8 +317,8 @@ pub use crate::{
         CreateWallet, DescriptorProcessPsbt, DescriptorProcessPsbtError, GetBalances,
         GetBalancesError, GetPeerInfo, GetPrioritisedTransactions, GetTransaction,
         GetTransactionError, GetTxOutSetInfo, GetTxOutSetInfoError, LastProcessedBlock,
-        LastProcessedBlockError, LoadWallet, Logging, PrioritisedTransaction, SubmitPackage,
-        SubmitPackageError, SubmitPackageTxResult, SubmitPackageTxResultError,
+        LastProcessedBlockError, LoadWallet, Logging, PeerInfo, PrioritisedTransaction,
+        SubmitPackage, SubmitPackageError, SubmitPackageTxResult, SubmitPackageTxResultError,
         SubmitPackageTxResultFees, SubmitPackageTxResultFeesError, UnloadWallet,
     },
 };

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -313,8 +313,8 @@ pub use crate::{
         GetBalancesWatchOnly, GetBlockFilter, GetBlockFilterError, GetBlockchainInfoError,
         GetChainTxStats, GetDescriptorInfo, GetMempoolAncestors, GetMempoolAncestorsVerbose,
         GetMempoolDescendants, GetMempoolDescendantsVerbose, GetRpcInfo, MapMempoolEntryError,
-        MempoolEntry, MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, PeerInfo,
-        SetWalletFlag, Softfork, SoftforkType,
+        MempoolEntry, MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, SetWalletFlag,
+        Softfork, SoftforkType,
     },
     v20::GenerateToDescriptor,
     v21::{
@@ -338,6 +338,6 @@ pub use crate::{
         CreateWallet, DescriptorProcessPsbt, DescriptorProcessPsbtError, GetBalances,
         GetBalancesError, GetPeerInfo, GetPrioritisedTransactions, GetTransactionError,
         GetTxOutSetInfo, GetTxOutSetInfoError, LastProcessedBlock, LastProcessedBlockError,
-        LoadWallet, PrioritisedTransaction, UnloadWallet,
+        LoadWallet, PeerInfo, PrioritisedTransaction, UnloadWallet,
     },
 };

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -311,8 +311,8 @@ pub use crate::{
         GetBalancesWatchOnly, GetBlockFilter, GetBlockFilterError, GetChainTxStats,
         GetMempoolAncestors, GetMempoolAncestorsVerbose, GetMempoolDescendants,
         GetMempoolDescendantsVerbose, GetRpcInfo, MapMempoolEntryError, MempoolEntry,
-        MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, PeerInfo, SetWalletFlag,
-        Softfork, SoftforkType,
+        MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, SetWalletFlag, Softfork,
+        SoftforkType,
     },
     v20::GenerateToDescriptor,
     v21::{
@@ -334,12 +334,12 @@ pub use crate::{
     v25::{GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors},
     v26::{
         CreateWallet, DescriptorProcessPsbt, DescriptorProcessPsbtError, GetBalances,
-        GetBalancesError, GetPrioritisedTransactions, GetTransactionError, GetTxOutSetInfo,
-        GetTxOutSetInfoError, LastProcessedBlock, LastProcessedBlockError, LoadWallet,
-        PrioritisedTransaction, UnloadWallet,
+        GetBalancesError, GetPeerInfo, GetPrioritisedTransactions, GetTransactionError,
+        GetTxOutSetInfo, GetTxOutSetInfoError, LastProcessedBlock, LastProcessedBlockError,
+        LoadWallet, PeerInfo, PrioritisedTransaction, UnloadWallet,
     },
     v28::{
-        GetNetworkInfo, GetPeerInfo, GetTransaction, Logging, SubmitPackage, SubmitPackageError,
+        GetNetworkInfo, GetTransaction, Logging, SubmitPackage, SubmitPackageError,
         SubmitPackageTxResult, SubmitPackageTxResultError, SubmitPackageTxResultFees,
         SubmitPackageTxResultFeesError,
     },


### PR DESCRIPTION
Previously, the v0.17 getpeerinfo types were used for v26, v27, v28, and v29.

Also adds the `mapped_as` field to the response that was missing in the v26 type.

I manually checked that the changes since v26 were only minor doc changes for getpeerinfo by diffing `bitcoin-cli help getpeerinfo` for the mentioned version.