### PR TITLE
Address all TODO in v25

### DIFF
--- a/client/src/client_sync/v25/blockchain.rs
+++ b/client/src/client_sync/v25/blockchain.rs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Macros for implementing JSON-RPC methods on a client.
+//!
+//! Specifically this is methods found under the `== Blockchain ==` section of the
+//! API docs of Bitcoin Core `v25`.
+//!
+//! All macros require `Client` to be in scope.
+//!
+//! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
+
+/// Implements Bitcoin Core JSON-RPC API method `scanblocks`
+#[macro_export]
+macro_rules! impl_client_v25__scan_blocks {
+    () => {
+        impl Client {
+            /// Aborts an ongoing `scanblocks` scan.
+            pub fn scan_blocks_abort(&self) -> Result<ScanBlocksAbort> {
+                self.call("scanblocks", &[into_json("abort")?])
+            }
+
+            /// Starts a scan of blocks for specified descriptors.
+            pub fn scan_blocks_start(&self, scan_objects: &[&str]) -> Result<ScanBlocksStart> {
+                self.call("scanblocks", &[into_json("start")?, into_json(scan_objects)?])
+            }
+
+            /// Checks the status of an ongoing `scanblocks` scan.
+            pub fn scan_blocks_status(&self) -> Result<Option<ScanBlocksStatus>> {
+                self.call("scanblocks", &[into_json("status")?])
+            }
+        }
+    };
+}

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -4,6 +4,7 @@
 //!
 //! We ignore option arguments unless they effect the shape of the returned JSON data.
 
+pub mod blockchain;
 pub mod generating;
 
 use std::collections::BTreeMap;
@@ -54,6 +55,7 @@ crate::impl_client_v24__get_tx_spending_prevout!();
 crate::impl_client_v17__precious_block!();
 crate::impl_client_v17__prune_blockchain!();
 crate::impl_client_v23__save_mempool!();
+crate::impl_client_v25__scan_blocks!();
 crate::impl_client_v17__verify_chain!();
 crate::impl_client_v17__verify_tx_out_proof!();
 

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -56,6 +56,7 @@ crate::impl_client_v24__get_tx_spending_prevout!();
 crate::impl_client_v17__precious_block!();
 crate::impl_client_v17__prune_blockchain!();
 crate::impl_client_v23__save_mempool!();
+crate::impl_client_v25__scan_blocks!();
 crate::impl_client_v17__verify_chain!();
 crate::impl_client_v17__verify_tx_out_proof!();
 

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -52,6 +52,7 @@ crate::impl_client_v24__get_tx_spending_prevout!();
 crate::impl_client_v17__precious_block!();
 crate::impl_client_v17__prune_blockchain!();
 crate::impl_client_v23__save_mempool!();
+crate::impl_client_v25__scan_blocks!();
 crate::impl_client_v17__verify_chain!();
 crate::impl_client_v17__verify_tx_out_proof!();
 

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -54,6 +54,7 @@ crate::impl_client_v24__get_tx_spending_prevout!();
 crate::impl_client_v17__precious_block!();
 crate::impl_client_v17__prune_blockchain!();
 crate::impl_client_v23__save_mempool!();
+crate::impl_client_v25__scan_blocks!();
 crate::impl_client_v17__verify_chain!();
 crate::impl_client_v17__verify_tx_out_proof!();
 

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -54,6 +54,7 @@ crate::impl_client_v24__get_tx_spending_prevout!();
 crate::impl_client_v17__precious_block!();
 crate::impl_client_v17__prune_blockchain!();
 crate::impl_client_v23__save_mempool!();
+crate::impl_client_v25__scan_blocks!();
 crate::impl_client_v17__verify_chain!();
 crate::impl_client_v17__verify_tx_out_proof!();
 

--- a/integration_test/tests/blockchain.rs
+++ b/integration_test/tests/blockchain.rs
@@ -373,6 +373,23 @@ fn blockchain__savemempool() {
     }
 }
 
+#[cfg(not(feature = "v24_and_below"))]
+#[test]
+fn blockchain__scan_blocks_modelled() {
+    let node = Node::with_wallet(Wallet::None, &["-blockfilterindex=1"]);
+
+    // Arbitrary scan descriptor
+    let scan_desc = "pkh(022afc20bf379bc96a2f4e9e63ffceb8652b2b6a097f63fbee6ecec2a49a48010e)";
+
+    let json: ScanBlocksStart = node.client.scan_blocks_start(&[scan_desc]).expect("scanblocks start");
+    let model: Result<mtype::ScanBlocksStart, ScanBlocksStartError> = json.into_model();
+    model.unwrap();
+
+    let _: Option<ScanBlocksStatus> = node.client.scan_blocks_status().expect("scanblocks status");
+
+    let _: ScanBlocksAbort = node.client.scan_blocks_abort().expect("scanblocks abort");
+}
+
 #[test]
 fn blockchain__verify_tx_out_proof__modelled() {
     let node = Node::with_wallet(Wallet::Default, &[]);

--- a/types/src/model/blockchain.rs
+++ b/types/src/model/blockchain.rs
@@ -702,3 +702,14 @@ pub struct ReceiveActivity {
     /// The ScriptPubKey.
     pub output_spk: ScriptPubkey,
 }
+
+/// Models the result of the JSON-RPC method `scanblocks` start.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct ScanBlocksStart {
+    /// The height we started the scan from
+    pub from_height: u32,
+    /// The height we ended the scan at
+    pub to_height: u32,
+    /// Blocks that may have matched a scanobject
+    pub relevant_blocks: Vec<BlockHash>,
+}

--- a/types/src/model/mod.rs
+++ b/types/src/model/mod.rs
@@ -29,8 +29,8 @@ pub use self::{
         GetMempoolAncestors, GetMempoolAncestorsVerbose, GetMempoolDescendants,
         GetMempoolDescendantsVerbose, GetMempoolEntry, GetMempoolInfo, GetRawMempool,
         GetRawMempoolVerbose, GetTxOut, GetTxOutSetInfo, GetTxSpendingPrevout,
-        GetTxSpendingPrevoutItem, MempoolEntry, MempoolEntryFees, ReceiveActivity, Softfork,
-        SoftforkType, SpendActivity, VerifyTxOutProof,
+        GetTxSpendingPrevoutItem, MempoolEntry, MempoolEntryFees, ReceiveActivity, ScanBlocksStart,
+        Softfork, SoftforkType, SpendActivity, VerifyTxOutProof,
     },
     generating::{Generate, GenerateBlock, GenerateToAddress, GenerateToDescriptor},
     mining::{

--- a/types/src/v25/blockchain/error.rs
+++ b/types/src/v25/blockchain/error.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: CC0-1.0
+
+use core::fmt;
+
+use bitcoin::hex;
+
+use crate::error::write_err;
+use crate::NumericError;
+
+/// Error when converting a `ScanBlocksStart` type into the model type.
+#[derive(Debug)]
+pub enum ScanBlocksStartError {
+    /// Conversion of numeric type to expected type failed.
+    Numeric(NumericError),
+    /// Conversion of the `relevant_blocks` field failed.
+    RelevantBlocks(hex::HexToArrayError),
+}
+
+impl fmt::Display for ScanBlocksStartError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use ScanBlocksStartError as E;
+
+        match *self {
+            E::Numeric(ref e) => write_err!(f, "numeric"; e),
+            E::RelevantBlocks(ref e) =>
+                write_err!(f, "conversion of the `relevant_blocks` field failed"; e),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ScanBlocksStartError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use ScanBlocksStartError as E;
+
+        match *self {
+            E::Numeric(ref e) => Some(e),
+            E::RelevantBlocks(ref e) => Some(e),
+        }
+    }
+}
+
+impl From<NumericError> for ScanBlocksStartError {
+    fn from(e: NumericError) -> Self { Self::Numeric(e) }
+}

--- a/types/src/v25/blockchain/into.rs
+++ b/types/src/v25/blockchain/into.rs
@@ -2,7 +2,8 @@
 
 use bitcoin::{Amount, BlockHash, FeeRate, Weight};
 
-use super::{GetBlockStats, GetBlockStatsError};
+use super::error::ScanBlocksStartError;
+use super::{GetBlockStats, GetBlockStatsError, ScanBlocksStart};
 use crate::model;
 
 impl GetBlockStats {
@@ -57,6 +58,23 @@ impl GetBlockStats {
             utxo_size_increase: self.utxo_size_increase,
             utxo_increase_actual: self.utxo_increase_actual,
             utxo_size_increase_actual: self.utxo_size_increase_actual,
+        })
+    }
+}
+
+impl ScanBlocksStart {
+    pub fn into_model(self) -> Result<model::ScanBlocksStart, ScanBlocksStartError> {
+        let relevant_blocks = self
+            .relevant_blocks
+            .iter()
+            .map(|s| s.parse())
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(ScanBlocksStartError::RelevantBlocks)?;
+
+        Ok(model::ScanBlocksStart {
+            from_height: crate::to_u32(self.from_height, "from_height")?,
+            to_height: crate::to_u32(self.to_height, "to_height")?,
+            relevant_blocks,
         })
     }
 }

--- a/types/src/v25/blockchain/mod.rs
+++ b/types/src/v25/blockchain/mod.rs
@@ -4,10 +4,12 @@
 //!
 //! Types for methods found under the `== Blockchain ==` section of the API docs.
 
+mod error;
 mod into;
 
 use serde::{Deserialize, Serialize};
 
+pub use self::error::ScanBlocksStartError;
 pub use super::GetBlockStatsError;
 
 /// Result of JSON-RPC method `getblockstats`.
@@ -114,4 +116,41 @@ pub struct GetBlockStats {
     /// v25 and later only.
     #[serde(rename = "utxo_size_inc_actual")]
     pub utxo_size_increase_actual: Option<i32>,
+}
+
+/// Result of JSON-RPC method `scanblocks` with action "abort".
+///
+/// > scanblocks "abort"
+/// >
+/// > Aborts the current scan and returns whether an abort was successful.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct ScanBlocksAbort(pub bool);
+
+/// Result of JSON-RPC method `scanblocks` with action "start".
+///
+/// > scanblocks "start" [scanobjects,...] ( start_height stop_height "filtertype" "options" )
+/// >
+/// > Arguments:
+/// > 1. scanobjects                            (json array, required) Array of scan objects
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct ScanBlocksStart {
+    /// The height we started the scan from
+    pub from_height: i64,
+    /// The height we ended the scan at
+    pub to_height: i64,
+    /// Blocks that may have matched a scanobject
+    pub relevant_blocks: Vec<String>,
+}
+
+/// Result of JSON-RPC method `scanblocks` with action "status".
+///
+/// > scanblocks "status"
+/// >
+/// > Returns progress report (in %) of the current scan.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct ScanBlocksStatus {
+    /// Approximate percent complete
+    pub progress: f64,
+    /// Height of the block currently being scanned
+    pub current_height: i64,
 }

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -51,7 +51,7 @@
 //! | preciousblock                      | returns nothing |                                        |
 //! | pruneblockchain                    | version         |                                        |
 //! | savemempool                        | version         |                                        |
-//! | scanblocks                         | version + model | TODO                                   |
+//! | scanblocks                         | version + model |                                        |
 //! | scantxoutset                       | omitted         | API marked as experimental             |
 //! | verifychain                        | version         |                                        |
 //! | verifytxoutproof                   | version + model |                                        |
@@ -247,7 +247,9 @@ mod wallet;
 
 #[doc(inline)]
 pub use self::{
-    blockchain::GetBlockStats,
+    blockchain::{
+        GetBlockStats, ScanBlocksAbort, ScanBlocksStart, ScanBlocksStartError, ScanBlocksStatus,
+    },
     control::Logging,
     generating::{GenerateBlock, GenerateBlockError},
     wallet::{CreateWallet, ListDescriptors, LoadWallet, UnloadWallet},

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -55,7 +55,7 @@
 //! | preciousblock                      | returns nothing |                                        |
 //! | pruneblockchain                    | version         |                                        |
 //! | savemempool                        | version         |                                        |
-//! | scanblocks                         | version + model | TODO                                   |
+//! | scanblocks                         | version + model |                                        |
 //! | scantxoutset                       | omitted         | API marked as experimental             |
 //! | verifychain                        | version         |                                        |
 //! | verifytxoutproof                   | version + model |                                        |
@@ -335,5 +335,8 @@ pub use crate::{
         SimulateRawTransaction, TaprootBip32Deriv, TaprootLeaf, TaprootScript,
         TaprootScriptPathSig,
     },
-    v25::{GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors},
+    v25::{
+        GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors, ScanBlocksAbort,
+        ScanBlocksStart, ScanBlocksStartError, ScanBlocksStatus,
+    },
 };

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -55,7 +55,7 @@
 //! | preciousblock                      | returns nothing |                                        |
 //! | pruneblockchain                    | version         |                                        |
 //! | savemempool                        | version         |                                        |
-//! | scanblocks                         | version + model | TODO                                   |
+//! | scanblocks                         | version + model |                                        |
 //! | scantxoutset                       | omitted         | API marked as experimental             |
 //! | verifychain                        | version         |                                        |
 //! | verifytxoutproof                   | version + model |                                        |
@@ -312,7 +312,10 @@ pub use crate::{
         SimulateRawTransaction, TaprootBip32Deriv, TaprootLeaf, TaprootScript,
         TaprootScriptPathSig,
     },
-    v25::{GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors},
+    v25::{
+        GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors, ScanBlocksAbort,
+        ScanBlocksStart, ScanBlocksStartError, ScanBlocksStatus,
+    },
     v26::{
         CreateWallet, DescriptorProcessPsbt, DescriptorProcessPsbtError, GetBalances,
         GetBalancesError, GetPeerInfo, GetPrioritisedTransactions, GetTransaction,

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -55,7 +55,7 @@
 //! | preciousblock                      | returns nothing |                                        |
 //! | pruneblockchain                    | version         |                                        |
 //! | savemempool                        | version         |                                        |
-//! | scanblocks                         | version + model | TODO                                   |
+//! | scanblocks                         | version + model |                                        |
 //! | scantxoutset                       | omitted         | API marked as experimental             |
 //! | verifychain                        | version         |                                        |
 //! | verifytxoutproof                   | version + model |                                        |
@@ -333,7 +333,10 @@ pub use crate::{
         SimulateRawTransaction, TaprootBip32Deriv, TaprootLeaf, TaprootScript,
         TaprootScriptPathSig,
     },
-    v25::{GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors},
+    v25::{
+        GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors, ScanBlocksAbort,
+        ScanBlocksStart, ScanBlocksStartError, ScanBlocksStatus,
+    },
     v26::{
         CreateWallet, DescriptorProcessPsbt, DescriptorProcessPsbtError, GetBalances,
         GetBalancesError, GetPeerInfo, GetPrioritisedTransactions, GetTransactionError,

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -56,7 +56,7 @@
 //! | preciousblock                      | returns nothing |                                        |
 //! | pruneblockchain                    | version         |                                        |
 //! | savemempool                        | version         |                                        |
-//! | scanblocks                         | version + model | TODO                                   |
+//! | scanblocks                         | version + model |                                        |
 //! | scantxoutset                       | omitted         | API marked as experimental             |
 //! | verifychain                        | version         |                                        |
 //! | verifytxoutproof                   | version + model |                                        |
@@ -331,7 +331,10 @@ pub use crate::{
         SimulateRawTransaction, TaprootBip32Deriv, TaprootLeaf, TaprootScript,
         TaprootScriptPathSig,
     },
-    v25::{GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors},
+    v25::{
+        GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors, ScanBlocksAbort,
+        ScanBlocksStart, ScanBlocksStartError, ScanBlocksStatus,
+    },
     v26::{
         CreateWallet, DescriptorProcessPsbt, DescriptorProcessPsbtError, GetBalances,
         GetBalancesError, GetPrioritisedTransactions, GetTransactionError, GetTxOutSetInfo,


### PR DESCRIPTION
Go through all the TODO in the v25 types table. Add all the missing RPCs.

One missing RPC in v25, `scanblocks` which has 3 different return shapes, one each  for `abort`, `start` and `status`. Create a struct for each one.

`status` returns null if there is no ongoing scan, use an Option in the client macro to deal with this.