### PR TITLE
Improve `GetPeerInfo`

### DIFF
--- a/integration_test/tests/network.rs
+++ b/integration_test/tests/network.rs
@@ -107,6 +107,10 @@ fn get_peer_info_three_node_network() {
     node2.mine_a_block();
     node3.mine_a_block();
 
+    let json: GetPeerInfo = node1.client.get_peer_info().expect("getpeerinfo");
+    // This verifies that we re-exported the correct `PeerInfo` type at the module level.
+    let _: PeerInfo = json.0[0];
+
     // FIXME: Fails if we use equal to 2 ???
     assert!(node1.peers_connected() >= 1);
     assert!(node2.peers_connected() >= 1);

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -918,10 +918,8 @@ mod test {
     }
 
     fn peers_connected(client: &Client) -> usize {
-        // FIXME: Once client implements get_peer_info use it.
-        // This is kinda cool, it shows we can call any RPC method using the client.
-        let result: Vec<serde_json::Value> = client.call("getpeerinfo", &[]).unwrap();
-        result.len()
+        let json = client.get_peer_info().expect("get_peer_info");
+        json.0.len()
     }
 
     fn init() -> String {

--- a/types/src/v17/network/mod.rs
+++ b/types/src/v17/network/mod.rs
@@ -196,8 +196,6 @@ pub struct PeerInfo {
     /// Local address as reported by the peer.
     #[serde(rename = "addrlocal")]
     pub address_local: Option<String>,
-    /// Network (ipv4, ipv6, or onion) the peer connected through.
-    pub network: Option<String>,
     /// The services offered.
     pub services: String,
     /// Whether peer has asked us to relay transactions to it.
@@ -252,7 +250,7 @@ pub struct PeerInfo {
     pub synced_blocks: i64,
     /// The heights of blocks we're currently asking from this peer.
     pub inflight: Vec<u64>,
-    /// Whether the peer is whitelisted (deprecated in v0.21).
+    /// Whether the peer is whitelisted.
     pub whitelisted: Option<bool>,
     /// The total bytes sent aggregated by message type.
     #[serde(rename = "bytessent_per_msg")]
@@ -260,8 +258,6 @@ pub struct PeerInfo {
     /// The total bytes received aggregated by message type.
     #[serde(rename = "bytesrecv_per_msg")]
     pub bytes_received_per_message: BTreeMap<String, u64>,
-    /// Type of connection.
-    pub connection_type: Option<String>,
 }
 
 /// Result of JSON-RPC method `listbanned`.

--- a/types/src/v18/network/mod.rs
+++ b/types/src/v18/network/mod.rs
@@ -57,8 +57,6 @@ pub struct PeerInfo {
     /// Local address as reported by the peer.
     #[serde(rename = "addrlocal")]
     pub address_local: Option<String>,
-    /// Network (ipv4, ipv6, or onion) the peer connected through.
-    pub network: Option<String>,
     /// The services offered.
     pub services: String,
     /// Whether peer has asked us to relay transactions to it.
@@ -113,17 +111,15 @@ pub struct PeerInfo {
     pub synced_blocks: i64,
     /// The heights of blocks we're currently asking from this peer.
     pub inflight: Vec<u64>,
-    /// Whether the peer is whitelisted (deprecated in v0.21).
+    /// Whether the peer is whitelisted.
     pub whitelisted: Option<bool>,
     /// The minimum fee rate for transactions this peer accepts.
     #[serde(rename = "minfeefilter")]
-    pub min_fee_filter: Option<f64>,
+    pub min_fee_filter: f64,
     /// The total bytes sent aggregated by message type.
     #[serde(rename = "bytessent_per_msg")]
     pub bytes_sent_per_message: BTreeMap<String, u64>,
     /// The total bytes received aggregated by message type.
     #[serde(rename = "bytesrecv_per_msg")]
     pub bytes_received_per_message: BTreeMap<String, u64>,
-    /// Type of connection.
-    pub connection_type: Option<String>,
 }

--- a/types/src/v19/network/mod.rs
+++ b/types/src/v19/network/mod.rs
@@ -30,7 +30,7 @@ pub struct GetNetworkInfo {
     /// The services we offer to the network (hex string).
     #[serde(rename = "localservices")]
     pub local_services: String,
-    /// The services we offer to the network. v0.19 and later only.
+    /// The services we offer to the network.
     #[serde(rename = "localservicesnames")]
     pub local_services_names: Vec<String>,
     /// `true` if transaction relay is requested from peers.
@@ -83,11 +83,9 @@ pub struct PeerInfo {
     /// Local address as reported by the peer.
     #[serde(rename = "addrlocal")]
     pub address_local: Option<String>,
-    /// Network (ipv4, ipv6, or onion) the peer connected through.
-    pub network: Option<String>,
     /// The services offered.
     pub services: String,
-    /// The services offered, in human-readable form. v0.19 and later only.
+    /// The services offered, in human-readable form.
     #[serde(rename = "servicesnames")]
     pub services_names: Vec<String>,
     /// Whether peer has asked us to relay transactions to it.
@@ -144,17 +142,15 @@ pub struct PeerInfo {
     pub inflight: Vec<u64>,
     /// Any special permissions that have been granted to this peer. v0.19 and later only.
     pub permissions: Vec<String>,
-    /// The minimum fee rate for transactions this peer accepts. v0.19 and later only.
-    #[serde(rename = "minfeefilter")]
-    pub minimum_fee_filter: f64,
-    /// Whether the peer is whitelisted (deprecated in v0.21).
+    /// Whether the peer is whitelisted.
     pub whitelisted: Option<bool>,
+    /// The minimum fee rate for transactions this peer accepts.
+    #[serde(rename = "minfeefilter")]
+    pub min_fee_filter: f64,
     /// The total bytes sent aggregated by message type.
     #[serde(rename = "bytessent_per_msg")]
     pub bytes_sent_per_message: BTreeMap<String, u64>,
     /// The total bytes received aggregated by message type.
     #[serde(rename = "bytesrecv_per_msg")]
     pub bytes_received_per_message: BTreeMap<String, u64>,
-    /// Type of connection.
-    pub connection_type: Option<String>,
 }

--- a/types/src/v21/mod.rs
+++ b/types/src/v21/mod.rs
@@ -245,7 +245,7 @@ pub use self::{
         SoftforkType,
     },
     generating::GenerateBlock,
-    network::{GetNetworkInfo, GetPeerInfo},
+    network::{GetNetworkInfo, GetPeerInfo, PeerInfo},
     util::{GetIndexInfo, GetIndexInfoName},
     wallet::{
         ImportDescriptors, ImportDescriptorsResult, PsbtBumpFee, PsbtBumpFeeError, Send, SendError,
@@ -298,8 +298,7 @@ pub use crate::{
         GetBalancesWatchOnly, GetBlockFilter, GetBlockFilterError, GetBlockchainInfoError,
         GetChainTxStats, GetDescriptorInfo, GetMempoolAncestors, GetMempoolAncestorsVerbose,
         GetMempoolDescendants, GetMempoolDescendantsVerbose, GetRpcInfo, MapMempoolEntryError,
-        MempoolEntry, MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, PeerInfo,
-        SetWalletFlag,
+        MempoolEntry, MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, SetWalletFlag,
     },
     v20::{
         Banned, CreateMultisig, GenerateToDescriptor, GetTransaction, GetTransactionDetail,

--- a/types/src/v21/network/mod.rs
+++ b/types/src/v21/network/mod.rs
@@ -91,7 +91,7 @@ pub struct PeerInfo {
     pub network: Option<String>,
     /// The services offered.
     pub services: String,
-    /// The services offered, in human-readable form. v0.19 and later only.
+    /// The services offered, in human-readable form.
     #[serde(rename = "servicesnames")]
     pub services_names: Vec<String>,
     /// Whether peer has asked us to relay transactions to it.
@@ -141,9 +141,6 @@ pub struct PeerInfo {
     /// The starting height (block) of the peer.
     #[serde(rename = "startingheight")]
     pub starting_height: i64,
-    /// The ban score.
-    #[serde(rename = "banscore")]
-    pub ban_score: Option<i64>,
     /// The last header we have in common with this peer.
     pub synced_headers: i64,
     /// The last block we have in common with this peer.
@@ -159,11 +156,11 @@ pub struct PeerInfo {
     pub addresses_rate_limited: usize,
     /// Any special permissions that have been granted to this peer. v0.19 and later only.
     pub permissions: Vec<String>,
-    /// The minimum fee rate for transactions this peer accepts. v0.19 and later only.
-    #[serde(rename = "minfeefilter")]
-    pub minimum_fee_filter: f64,
-    /// Whether the peer is whitelisted (deprecated in v0.21).
+    /// Whether the peer is whitelisted.
     pub whitelisted: Option<bool>,
+    /// The minimum fee rate for transactions this peer accepts.
+    #[serde(rename = "minfeefilter")]
+    pub min_fee_filter: Option<f64>, // Docs rekon this exists.
     /// The total bytes sent aggregated by message type.
     #[serde(rename = "bytessent_per_msg")]
     pub bytes_sent_per_message: BTreeMap<String, u64>,

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -254,7 +254,7 @@ mod wallet;
 pub use self::{
     blockchain::GetMempoolInfo,
     control::Logging,
-    network::{Banned, GetPeerInfo, ListBanned},
+    network::{Banned, GetPeerInfo, ListBanned, PeerInfo},
     raw_transactions::{DecodeScript, DecodeScriptError},
     signer::EnumerateSigners,
     wallet::{ListDescriptors, WalletDisplayAddress},
@@ -305,8 +305,7 @@ pub use crate::{
         GetBalancesWatchOnly, GetBlockFilter, GetBlockFilterError, GetBlockchainInfoError,
         GetChainTxStats, GetDescriptorInfo, GetMempoolAncestors, GetMempoolAncestorsVerbose,
         GetMempoolDescendants, GetMempoolDescendantsVerbose, GetRpcInfo, MapMempoolEntryError,
-        MempoolEntry, MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, PeerInfo,
-        SetWalletFlag,
+        MempoolEntry, MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, SetWalletFlag,
     },
     v20::{CreateMultisig, GenerateToDescriptor, GetTransaction, GetTransactionDetail},
     v21::{

--- a/types/src/v22/network.rs
+++ b/types/src/v22/network.rs
@@ -61,7 +61,7 @@ pub struct PeerInfo {
     pub network: Option<String>,
     /// The services offered.
     pub services: String,
-    /// The services offered, in human-readable form. v0.19 and later only.
+    /// The services offered, in human-readable form.
     #[serde(rename = "servicesnames")]
     pub services_names: Vec<String>,
     /// Whether peer has asked us to relay transactions to it.
@@ -105,9 +105,9 @@ pub struct PeerInfo {
     pub subversion: String,
     /// Inbound (true) or Outbound (false).
     pub inbound: bool,
-    /// Whether we selected peer as (compact blocks) high-bandwidth peer. v22 and later only.
+    /// Whether we selected peer as (compact blocks) high-bandwidth peer.
     pub bip152_hb_to: bool,
-    /// Whether peer selected us as (compact blocks) high-bandwidth peer. v22 and later only.
+    /// Whether peer selected us as (compact blocks) high-bandwidth peer.
     pub bip152_hb_from: bool,
     /// Whether connection was due to addnode/-connect or if it was an automatic/inbound connection.
     #[serde(rename = "addnode")]
@@ -115,9 +115,6 @@ pub struct PeerInfo {
     /// The starting height (block) of the peer.
     #[serde(rename = "startingheight")]
     pub starting_height: i64,
-    /// The ban score.
-    #[serde(rename = "banscore")]
-    pub ban_score: Option<i64>,
     /// The last header we have in common with this peer.
     pub synced_headers: i64,
     /// The last block we have in common with this peer.
@@ -133,11 +130,11 @@ pub struct PeerInfo {
     pub addresses_rate_limited: usize,
     /// Any special permissions that have been granted to this peer. v0.19 and later only.
     pub permissions: Vec<String>,
-    /// The minimum fee rate for transactions this peer accepts. v0.19 and later only.
-    #[serde(rename = "minfeefilter")]
-    pub minimum_fee_filter: f64,
-    /// Whether the peer is whitelisted (deprecated in v0.21).
+    /// Whether the peer is whitelisted.
     pub whitelisted: Option<bool>,
+    /// The minimum fee rate for transactions this peer accepts.
+    #[serde(rename = "minfeefilter")]
+    pub min_fee_filter: Option<f64>, // Docs rekon this exists.
     /// The total bytes sent aggregated by message type.
     #[serde(rename = "bytessent_per_msg")]
     pub bytes_sent_per_message: BTreeMap<String, u64>,

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -250,7 +250,7 @@ pub use self::{
         GetDeploymentInfoError, GetMempoolEntry, SaveMempool,
     },
     control::Logging,
-    network::GetPeerInfo,
+    network::{GetPeerInfo, PeerInfo},
     raw_transactions::{
         DecodePsbt, DecodePsbtError, DecodeScript, DecodeScriptError, GlobalXpub, Proprietary,
         PsbtInput, PsbtOutput,
@@ -304,8 +304,8 @@ pub use crate::{
         GetBlockFilterError, GetBlockchainInfoError, GetChainTxStats, GetDescriptorInfo,
         GetMempoolAncestors, GetMempoolAncestorsVerbose, GetMempoolDescendants,
         GetMempoolDescendantsVerbose, GetRpcInfo, MapMempoolEntryError, MempoolEntry,
-        MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, PeerInfo, SetWalletFlag,
-        Softfork, SoftforkType,
+        MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, SetWalletFlag, Softfork,
+        SoftforkType,
     },
     v20::{GenerateToDescriptor, GetTransactionDetail},
     v21::{

--- a/types/src/v23/network.rs
+++ b/types/src/v23/network.rs
@@ -99,23 +99,20 @@ pub struct PeerInfo {
     pub synced_blocks: Option<i64>,
     /// The heights of blocks we're currently asking from this peer.
     pub inflight: Option<Vec<u64>>,
-    /// Whether we participate in address relay with this peer. v23 and later only.
+    /// Whether we participate in address relay with this peer.
     #[serde(rename = "addr_relay_enabled")]
     pub addresses_relay_enabled: Option<bool>,
-    /// The total number of addresses processed, excluding those dropped due to rate limiting. v21 and
-    /// later only.
+    /// The total number of addresses processed, excluding those dropped due to rate limiting.
     #[serde(rename = "addr_processed")]
     pub addresses_processed: Option<usize>,
-    /// The total number of addresses dropped due to rate limiting. v21 and later only.
+    /// The total number of addresses dropped due to rate limiting.
     #[serde(rename = "addr_rate_limited")]
     pub addresses_rate_limited: Option<usize>,
-    /// Any special permissions that have been granted to this peer. v0.19 and later only.
+    /// Any special permissions that have been granted to this peer.
     pub permissions: Vec<String>,
-    /// The minimum fee rate for transactions this peer accepts. v0.19 and later only.
+    /// The minimum fee rate for transactions this peer accepts.
     #[serde(rename = "minfeefilter")]
     pub minimum_fee_filter: f64,
-    /// Whether the peer is whitelisted (deprecated in v0.21).
-    pub whitelisted: Option<bool>,
     /// The total bytes sent aggregated by message type.
     #[serde(rename = "bytessent_per_msg")]
     pub bytes_sent_per_message: BTreeMap<String, u64>,

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -251,7 +251,7 @@ pub use self::{
         GetMempoolEntry, GetMempoolInfo, GetTxSpendingPrevout, GetTxSpendingPrevoutError,
         GetTxSpendingPrevoutItem,
     },
-    network::GetPeerInfo,
+    network::{GetPeerInfo, PeerInfo},
     raw_transactions::{
         DecodePsbt, DecodePsbtError, GlobalXpub, Proprietary, PsbtInput, PsbtOutput,
         TaprootBip32Deriv, TaprootLeaf, TaprootScript, TaprootScriptPathSig,
@@ -306,8 +306,8 @@ pub use crate::{
         GetBlockFilterError, GetBlockchainInfoError, GetChainTxStats, GetDescriptorInfo,
         GetMempoolAncestors, GetMempoolAncestorsVerbose, GetMempoolDescendants,
         GetMempoolDescendantsVerbose, GetRpcInfo, MapMempoolEntryError, MempoolEntry,
-        MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, PeerInfo, SetWalletFlag,
-        Softfork, SoftforkType,
+        MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, SetWalletFlag, Softfork,
+        SoftforkType,
     },
     v20::GenerateToDescriptor,
     v21::{

--- a/types/src/v24/network.rs
+++ b/types/src/v24/network.rs
@@ -91,7 +91,7 @@ pub struct PeerInfo {
     #[serde(rename = "startingheight")]
     pub starting_height: Option<i64>,
     /// The current height of header pre-synchronization with this peer, or -1 if no low-work sync is
-    /// in progress. v24 and later only.
+    /// in progress.
     pub presynced_headers: Option<i64>,
     /// The ban score.
     #[serde(rename = "banscore")]
@@ -102,23 +102,20 @@ pub struct PeerInfo {
     pub synced_blocks: Option<i64>,
     /// The heights of blocks we're currently asking from this peer.
     pub inflight: Option<Vec<u64>>,
-    /// Whether we participate in address relay with this peer. v23 and later only.
+    /// Whether we participate in address relay with this peer.
     #[serde(rename = "addr_relay_enabled")]
     pub addresses_relay_enabled: Option<bool>,
-    /// The total number of addresses processed, excluding those dropped due to rate limiting. v21 and
-    /// later only.
+    /// The total number of addresses processed, excluding those dropped due to rate limiting.
     #[serde(rename = "addr_processed")]
     pub addresses_processed: Option<usize>,
-    /// The total number of addresses dropped due to rate limiting. v21 and later only.
+    /// The total number of addresses dropped due to rate limiting.
     #[serde(rename = "addr_rate_limited")]
     pub addresses_rate_limited: Option<usize>,
-    /// Any special permissions that have been granted to this peer. v0.19 and later only.
+    /// Any special permissions that have been granted to this peer.
     pub permissions: Vec<String>,
-    /// The minimum fee rate for transactions this peer accepts. v0.19 and later only.
+    /// The minimum fee rate for transactions this peer accepts.
     #[serde(rename = "minfeefilter")]
     pub minimum_fee_filter: f64,
-    /// Whether the peer is whitelisted (deprecated in v0.21).
-    pub whitelisted: Option<bool>,
     /// The total bytes sent aggregated by message type.
     #[serde(rename = "bytessent_per_msg")]
     pub bytes_sent_per_message: BTreeMap<String, u64>,

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -299,8 +299,8 @@ pub use crate::{
         GetBlockFilterError, GetBlockchainInfoError, GetChainTxStats, GetDescriptorInfo,
         GetMempoolAncestors, GetMempoolAncestorsVerbose, GetMempoolDescendants,
         GetMempoolDescendantsVerbose, GetRpcInfo, MapMempoolEntryError, MempoolEntry,
-        MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, PeerInfo, SetWalletFlag,
-        Softfork, SoftforkType,
+        MempoolEntryError, MempoolEntryFees, MempoolEntryFeesError, SetWalletFlag, Softfork,
+        SoftforkType,
     },
     v20::GenerateToDescriptor,
     v21::{
@@ -315,7 +315,7 @@ pub use crate::{
     v24::{
         DecodePsbt, DecodePsbtError, GetMempoolEntry, GetMempoolInfo, GetPeerInfo, GetTransaction,
         GetTransactionDetail, GetTransactionError, GetTxSpendingPrevout, GetTxSpendingPrevoutError,
-        GlobalXpub, ListUnspent, ListUnspentItem, MigrateWallet, Proprietary, PsbtInput,
+        GlobalXpub, ListUnspent, ListUnspentItem, MigrateWallet, PeerInfo, Proprietary, PsbtInput,
         PsbtOutput, SendAll, SendAllError, SimulateRawTransaction, TaprootBip32Deriv, TaprootLeaf,
         TaprootScript, TaprootScriptPathSig,
     },

--- a/types/src/v26/network.rs
+++ b/types/src/v26/network.rs
@@ -38,7 +38,7 @@ pub struct PeerInfo {
     pub mapped_as: Option<u32>,
     /// The services offered.
     pub services: String,
-    /// The services offered, in human-readable form. v0.19 and later only.
+    /// The services offered, in human-readable form.
     #[serde(rename = "servicesnames")]
     pub services_names: Vec<String>,
     /// Whether peer has asked us to relay transactions to it.
@@ -50,9 +50,9 @@ pub struct PeerInfo {
     /// The time in seconds since epoch (Jan 1 1970 GMT) of the last receive.
     #[serde(rename = "lastrecv")]
     pub last_received: i64,
-    /// The UNIX epoch time of the last valid transaction received from this peer. v21 and later only.
+    /// The UNIX epoch time of the last valid transaction received from this peer.
     pub last_transaction: i64,
-    /// The UNIX epoch time of the last block received from this peer. v21 and later only.
+    /// The UNIX epoch time of the last block received from this peer.
     pub last_block: i64,
     /// The total bytes sent.
     #[serde(rename = "bytessent")]
@@ -82,9 +82,9 @@ pub struct PeerInfo {
     pub subversion: String,
     /// Inbound (true) or Outbound (false).
     pub inbound: bool,
-    /// Whether we selected peer as (compact blocks) high-bandwidth peer. v22 and later only.
+    /// Whether we selected peer as (compact blocks) high-bandwidth peer.
     pub bip152_hb_to: bool,
-    /// Whether peer selected us as (compact blocks) high-bandwidth peer. v22 and later only.
+    /// Whether peer selected us as (compact blocks) high-bandwidth peer.
     pub bip152_hb_from: bool,
     /// Whether connection was due to addnode/-connect or if it was an automatic/inbound connection.
     #[serde(rename = "addnode")]
@@ -93,7 +93,7 @@ pub struct PeerInfo {
     #[serde(rename = "startingheight")]
     pub starting_height: Option<i64>,
     /// The current height of header pre-synchronization with this peer, or -1 if no low-work sync is
-    /// in progress. v24 and later only.
+    /// in progress.
     pub presynced_headers: Option<i64>,
     /// The ban score.
     #[serde(rename = "banscore")]
@@ -104,19 +104,18 @@ pub struct PeerInfo {
     pub synced_blocks: Option<i64>,
     /// The heights of blocks we're currently asking from this peer.
     pub inflight: Option<Vec<u64>>,
-    /// Whether we participate in address relay with this peer. v23 and later only.
+    /// Whether we participate in address relay with this peer.
     #[serde(rename = "addr_relay_enabled")]
     pub addresses_relay_enabled: Option<bool>,
-    /// The total number of addresses processed, excluding those dropped due to rate limiting. v21 and
-    /// later only.
+    /// The total number of addresses processed, excluding those dropped due to rate limiting.
     #[serde(rename = "addr_processed")]
     pub addresses_processed: Option<usize>,
-    /// The total number of addresses dropped due to rate limiting. v21 and later only.
+    /// The total number of addresses dropped due to rate limiting.
     #[serde(rename = "addr_rate_limited")]
     pub addresses_rate_limited: Option<usize>,
-    /// Any special permissions that have been granted to this peer. v0.19 and later only.
+    /// Any special permissions that have been granted to this peer.
     pub permissions: Vec<String>,
-    /// The minimum fee rate for transactions this peer accepts. v0.19 and later only.
+    /// The minimum fee rate for transactions this peer accepts.
     #[serde(rename = "minfeefilter")]
     pub minimum_fee_filter: f64,
     /// Whether the peer is whitelisted (deprecated in v0.21).
@@ -129,7 +128,7 @@ pub struct PeerInfo {
     pub bytes_received_per_message: BTreeMap<String, u64>,
     /// Type of connection.
     pub connection_type: Option<String>,
-    /// Type of transport protocol. v0.26 and later only:
+    /// Type of transport protocol:
     /// detecting (peer could be v1 or v2),
     /// v1 (plaintext transport protocol),
     /// v2 (BIP324 encrypted transport protocol).


### PR DESCRIPTION
In #310 I got mixed up and added fields to the v17 types `GetPeerInfo` struct that do not appear in the docs.

This was masked by using `Option`. And not helped by the fact that a bunch of other `Option`s are used because the docs do not match what Core returns.

These bugs propagated up through the version numbers. Go over them all and sort it out.

Note also that we were incorrectly re-exporting `PeerInfo` from v19 even though the `PeerInfo` struct that was actually being used is found in the version specific file along with `GetPeerInfo` - face palm.

And finally, remove all the 'vXY and later' docs, this is implied by the module. These sorts of comments should only be found in `model`.