### PR TITLE
Add support for run-bitcoind.sh start all

### DIFF
--- a/contrib/run-bitcoind.sh
+++ b/contrib/run-bitcoind.sh
@@ -55,6 +55,14 @@ main() {
     local cmd="${1:-usage}"
     local version="${2:-}"
 
+    # Handle 'run all' or 'start all' the same as 'all'
+    if [ "$cmd" = "start" ] || [ "$cmd" = "run" ]; then
+        if [ "$version" = "all" ]; then
+            cmd="all"
+            version=""
+        fi
+    fi
+
     # FIXME: This is a hackish way to get the help flag.
     if [ "$cmd" = "usage" ] || [ "$cmd" = "-h" ] || [ "$cmd" = "--help" ] || [ "$cmd" = "help" ]; then
         usage


### PR DESCRIPTION
On more than one occasion I have tried to start all nodes by passing `run all` or `start all` instead of just `all`.

Handle this the same as passing `all` as the argument to the script.