### PR TITLE
Address all TODO in v27

### DIFF
--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -104,7 +104,7 @@
 //! | getconnectioncount                 | version         |                                        |
 //! | getnettotals                       | version         |                                        |
 //! | getnetworkinfo                     | version + model |                                        |
-//! | getnodeaddresses                   | version         | TODO                                   |
+//! | getnodeaddresses                   | version         |                                        |
 //! | getpeerinfo                        | version         |                                        |
 //! | listbanned                         | version         |                                        |
 //! | ping                               | returns nothing |                                        |
@@ -249,9 +249,13 @@
 //! </details>
 
 mod mining;
+mod network;
 
 #[doc(inline)]
-pub use self::mining::{GetPrioritisedTransactions, PrioritisedTransaction};
+pub use self::{
+    mining::{GetPrioritisedTransactions, PrioritisedTransaction},
+    network::{GetNodeAddresses, NodeAddress},
+};
 #[doc(inline)]
 pub use crate::{
     v17::{
@@ -287,9 +291,9 @@ pub use crate::{
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
-        AnalyzePsbtInputMissingError, DeriveAddresses, GetNodeAddresses, GetReceivedByLabel,
+        AnalyzePsbtInputMissingError, DeriveAddresses, GetReceivedByLabel,
         ImportMulti, ImportMultiEntry, JoinPsbts, JsonRpcError, ListReceivedByLabel,
-        ListReceivedByLabelError, ListWalletDir, ListWalletDirWallet, NodeAddress, UtxoUpdatePsbt,
+        ListReceivedByLabelError, ListWalletDir, ListWalletDirWallet, UtxoUpdatePsbt,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalancesMine,

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -291,9 +291,9 @@ pub use crate::{
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
-        AnalyzePsbtInputMissingError, DeriveAddresses, GetReceivedByLabel,
-        ImportMulti, ImportMultiEntry, JoinPsbts, JsonRpcError, ListReceivedByLabel,
-        ListReceivedByLabelError, ListWalletDir, ListWalletDirWallet, UtxoUpdatePsbt,
+        AnalyzePsbtInputMissingError, DeriveAddresses, GetReceivedByLabel, ImportMulti,
+        ImportMultiEntry, JoinPsbts, JsonRpcError, ListReceivedByLabel, ListReceivedByLabelError,
+        ListWalletDir, ListWalletDirWallet, UtxoUpdatePsbt,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalancesMine,

--- a/types/src/v27/network/mod.rs
+++ b/types/src/v27/network/mod.rs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! The JSON-RPC API for Bitcoin Core `v27` - network.
+//!
+//! Types for methods found under the `== Network ==` section of the API docs.
+
+use serde::{Deserialize, Serialize};
+
+/// Result of JSON-RPC method `getnodeaddresses`.
+///
+/// > getnodeaddresses ( count "network" )
+/// >
+/// > Return known addresses, after filtering for quality and recency.
+/// > These can potentially be used to find new peers in the network.
+/// > The total number of addresses known to the node may be higher.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct GetNodeAddresses(pub Vec<NodeAddress>);
+
+/// An item from the list returned by the JSON-RPC method `getnodeaddresses`.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct NodeAddress {
+    /// Timestamp in seconds since epoch (Jan 1 1970 GMT) when the node was last seen.
+    pub time: u64,
+    /// The services offered.
+    pub services: u64,
+    /// The address of the node.
+    pub address: String,
+    /// The port of the node.
+    pub port: u16,
+    /// The network (ipv4, ipv6, onion, i2p, cjdns) the node connected through.
+    pub network: String,
+}

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -304,9 +304,9 @@ pub use crate::{
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
-        AnalyzePsbtInputMissingError, DeriveAddresses, GetReceivedByLabel,
-        ImportMulti, ImportMultiEntry, JoinPsbts, JsonRpcError, ListReceivedByLabel,
-        ListReceivedByLabelError, ListWalletDir, ListWalletDirWallet, UtxoUpdatePsbt,
+        AnalyzePsbtInputMissingError, DeriveAddresses, GetReceivedByLabel, ImportMulti,
+        ImportMultiEntry, JoinPsbts, JsonRpcError, ListReceivedByLabel, ListReceivedByLabelError,
+        ListWalletDir, ListWalletDirWallet, UtxoUpdatePsbt,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalancesMine,
@@ -344,5 +344,5 @@ pub use crate::{
         GetTxOutSetInfo, GetTxOutSetInfoError, LastProcessedBlock, LastProcessedBlockError,
         LoadTxOutSet, LoadTxOutSetError, LoadWallet, PeerInfo, UnloadWallet,
     },
-    v27::{GetNodeAddresses, NodeAddress, GetPrioritisedTransactions, PrioritisedTransaction},
+    v27::{GetNodeAddresses, GetPrioritisedTransactions, NodeAddress, PrioritisedTransaction},
 };

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -304,9 +304,9 @@ pub use crate::{
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
-        AnalyzePsbtInputMissingError, DeriveAddresses, GetNodeAddresses, GetReceivedByLabel,
+        AnalyzePsbtInputMissingError, DeriveAddresses, GetReceivedByLabel,
         ImportMulti, ImportMultiEntry, JoinPsbts, JsonRpcError, ListReceivedByLabel,
-        ListReceivedByLabelError, ListWalletDir, ListWalletDirWallet, NodeAddress, UtxoUpdatePsbt,
+        ListReceivedByLabelError, ListWalletDir, ListWalletDirWallet, UtxoUpdatePsbt,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalancesMine,
@@ -344,5 +344,5 @@ pub use crate::{
         GetTxOutSetInfo, GetTxOutSetInfoError, LastProcessedBlock, LastProcessedBlockError,
         LoadTxOutSet, LoadTxOutSetError, LoadWallet, PeerInfo, UnloadWallet,
     },
-    v27::{GetPrioritisedTransactions, PrioritisedTransaction},
+    v27::{GetNodeAddresses, NodeAddress, GetPrioritisedTransactions, PrioritisedTransaction},
 };

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -302,9 +302,9 @@ pub use crate::{
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
-        AnalyzePsbtInputMissingError, DeriveAddresses, GetReceivedByLabel,
-        ImportMulti, ImportMultiEntry, JoinPsbts, JsonRpcError, ListReceivedByLabel,
-        ListReceivedByLabelError, ListWalletDir, ListWalletDirWallet, UtxoUpdatePsbt,
+        AnalyzePsbtInputMissingError, DeriveAddresses, GetReceivedByLabel, ImportMulti,
+        ImportMultiEntry, JoinPsbts, JsonRpcError, ListReceivedByLabel, ListReceivedByLabelError,
+        ListWalletDir, ListWalletDirWallet, UtxoUpdatePsbt,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalancesMine,
@@ -342,7 +342,7 @@ pub use crate::{
         LastProcessedBlock, LastProcessedBlockError, LoadTxOutSet, LoadTxOutSetError, LoadWallet,
         PeerInfo, UnloadWallet,
     },
-    v27::{GetNodeAddresses, NodeAddress, GetPrioritisedTransactions, PrioritisedTransaction},
+    v27::{GetNodeAddresses, GetPrioritisedTransactions, NodeAddress, PrioritisedTransaction},
     v28::{
         GetNetworkInfo, GetTransaction, Logging, SubmitPackage, SubmitPackageError,
         SubmitPackageTxResult, SubmitPackageTxResultError, SubmitPackageTxResultFees,

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -302,9 +302,9 @@ pub use crate::{
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
-        AnalyzePsbtInputMissingError, DeriveAddresses, GetNodeAddresses, GetReceivedByLabel,
+        AnalyzePsbtInputMissingError, DeriveAddresses, GetReceivedByLabel,
         ImportMulti, ImportMultiEntry, JoinPsbts, JsonRpcError, ListReceivedByLabel,
-        ListReceivedByLabelError, ListWalletDir, ListWalletDirWallet, NodeAddress, UtxoUpdatePsbt,
+        ListReceivedByLabelError, ListWalletDir, ListWalletDirWallet, UtxoUpdatePsbt,
     },
     v19::{
         Bip9SoftforkInfo, Bip9SoftforkStatistics, Bip9SoftforkStatus, GetBalancesMine,
@@ -342,7 +342,7 @@ pub use crate::{
         LastProcessedBlock, LastProcessedBlockError, LoadTxOutSet, LoadTxOutSetError, LoadWallet,
         PeerInfo, UnloadWallet,
     },
-    v27::{GetPrioritisedTransactions, PrioritisedTransaction},
+    v27::{GetNodeAddresses, NodeAddress, GetPrioritisedTransactions, PrioritisedTransaction},
     v28::{
         GetNetworkInfo, GetTransaction, Logging, SubmitPackage, SubmitPackageError,
         SubmitPackageTxResult, SubmitPackageTxResultError, SubmitPackageTxResultFees,


### PR DESCRIPTION
Go through all the TODO in the v26 types table.

- Redefine `getnodeaddresses`: There were return field changes in v27. Redefine the struct and update the reexports. Update the types tables.
- Run the formatter: Done separately to make it easier to see the changes in patch 1.

DRAFT because on top of #321. This PR is the last 2 patches.