### PR TITLE
Address all TODO in v29

### DIFF
--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -5,6 +5,7 @@
 //! We ignore option arguments unless they effect the shape of the returned JSON data.
 
 pub mod blockchain;
+pub mod util;
 
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -126,7 +127,7 @@ crate::impl_client_v22__enumerate_signers!();
 
 // == Util ==
 crate::impl_client_v17__create_multisig!();
-crate::impl_client_v18__derive_addresses!();
+crate::impl_client_v29__derive_addresses!();
 crate::impl_client_v17__estimate_smart_fee!();
 crate::impl_client_v18__get_descriptor_info!();
 crate::impl_client_v21__get_index_info!();

--- a/client/src/client_sync/v29/util.rs
+++ b/client/src/client_sync/v29/util.rs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Macros for implementing JSON-RPC methods on a client.
+//!
+//! Specifically this is methods found under the `== Util ==` section of the
+//! API docs of Bitcoin Core `v29`.
+//!
+//! All macros require `Client` to be in scope.
+//!
+//! See or use the `define_jsonrpc_minreq_client!` macro to define a `Client`.
+
+/// Implements Bitcoin Core JSON-RPC API method `deriveaddresses`.
+#[macro_export]
+macro_rules! impl_client_v29__derive_addresses {
+    () => {
+        impl Client {
+            // For single derivation descriptors.
+            pub fn derive_addresses(&self, descriptor: &str) -> Result<DeriveAddresses> {
+                self.call("deriveaddresses", &[descriptor.into()])
+            }
+
+            // For multipath descriptors.
+            pub fn derive_addresses_multipath(
+                &self,
+                descriptor: &str,
+                range: (u32, u32),
+            ) -> Result<DeriveAddressesMultipath> {
+                let range = json!([range.0, range.1]);
+                self.call("deriveaddresses", &[descriptor.into(), range.into()])
+            }
+        }
+    };
+}

--- a/integration_test/tests/util.rs
+++ b/integration_test/tests/util.rs
@@ -41,6 +41,24 @@ fn util__derive_addresses__modelled() {
     let json: DeriveAddresses = node.client.derive_addresses(descriptor).expect("deriveaddresses");
     let res: Result<mtype::DeriveAddresses, _> = json.into_model();
     let _ = res.expect("DeriveAddresses into model");
+
+    // For v29 and above test a multipath descriptor.
+    #[cfg(not(feature = "v28_and_below"))]
+    {
+        // Create a multipath descriptor taken from running `listdescriptors` on the node. With 2 derivation paths.
+        let multipath_descriptor = "wpkh([26b4ed16/84h/1h/0h]tpubDDe7JUw2CGU1rYZxupmNrhDXuE1fv25gs4je3BBuWCFwTW9QHGgyh5cjAEugd14ysJXTVshPvnUVABfD66HZKCS9gp5AYFd5K2WN2oVFp8t/<0;1>/*)#grvmsm8m";
+
+        let range = (0, 3);
+        let json: DeriveAddressesMultipath = node.client.derive_addresses_multipath(multipath_descriptor, range)
+            .expect("deriveaddresses");
+        let res: Result<mtype::DeriveAddressesMultipath, _> = json.into_model();
+        let derived = res.expect("DeriveAddressesMultipath into model");
+
+        // Should return 2 `DeriveAddresses`, one for each derivation path (0 and 1).
+        assert_eq!(derived.addresses.len(), 2);
+        // Each `DeriveAddresses` should contain 4 addresses for range [0, 3].
+        assert_eq!(derived.addresses[0].addresses.len(), 4);
+    }
 }
 
 #[test]

--- a/types/src/model/mod.rs
+++ b/types/src/model/mod.rs
@@ -47,7 +47,8 @@ pub use self::{
         TestMempoolAccept, UtxoUpdatePsbt,
     },
     util::{
-        CreateMultisig, DeriveAddresses, EstimateSmartFee, SignMessageWithPrivKey, ValidateAddress,
+        CreateMultisig, DeriveAddresses, DeriveAddressesMultipath, EstimateSmartFee,
+        SignMessageWithPrivKey, ValidateAddress,
     },
     wallet::{
         AddMultisigAddress, AddressInformation, AddressLabel, AddressPurpose, Bip125Replaceable,

--- a/types/src/model/util.rs
+++ b/types/src/model/util.rs
@@ -48,6 +48,14 @@ pub struct DeriveAddresses {
     pub addresses: Vec<Address<NetworkUnchecked>>,
 }
 
+/// Models the result of JSON-RPC method `deriveaddresses` for multipath descriptors.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DeriveAddressesMultipath {
+    /// The derived addresses for each of the multipath expansions of the descriptor, in multipath specifier order.
+    pub addresses: Vec<DeriveAddresses>,
+}
+
 /// Models the result of JSON-RPC method `signmessagewithprivkey`.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SignMessageWithPrivKey(pub sign_message::MessageSignature);

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -156,7 +156,7 @@
 //! | JSON-RPC Method Name               | Returns         | Notes                                  |
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
 //! | createmultisig                     | version + model |                                        |
-//! | deriveaddresses                    | version + model | TODO                                   |
+//! | deriveaddresses                    | version + model |                                        |
 //! | estimatesmartfee                   | version + model |                                        |
 //! | getdescriptorinfo                  | version         |                                        |
 //! | getindexinfo                       | version         |                                        |
@@ -267,7 +267,7 @@ pub use self::{
         BlockTemplateTransaction, GetMiningInfo, GetMiningInfoError, NextBlockInfo,
         NextBlockInfoError,
     },
-    util::GetDescriptorInfo,
+    util::{DeriveAddressesMultipath, GetDescriptorInfo},
 };
 #[doc(inline)]
 pub use crate::{

--- a/types/src/v29/util.rs
+++ b/types/src/v29/util.rs
@@ -4,7 +4,33 @@
 //!
 //! Types for methods found under the `== Util ==` section of the API docs.
 
+use bitcoin::address;
 use serde::{Deserialize, Serialize};
+
+use super::DeriveAddresses;
+use crate::model;
+
+/// Result of JSON-RPC method `deriveaddresses` for multipath descriptors.
+///
+/// > deriveaddresses "descriptor" ( range )
+/// >
+/// > Derives one or more addresses corresponding to an output descriptor.
+/// > Returns an array of derived addresses.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DeriveAddressesMultipath(pub Vec<DeriveAddresses>);
+
+impl DeriveAddressesMultipath {
+    /// Converts version specific type to a version nonspecific, more strongly typed type.
+    pub fn into_model(self) -> Result<model::DeriveAddressesMultipath, address::ParseError> {
+        let derive_addresses = self
+            .0
+            .into_iter()
+            .map(|derive_addresses| derive_addresses.into_model())
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(model::DeriveAddressesMultipath { addresses: derive_addresses })
+    }
+}
 
 /// Result of JSON-RPC method `getdescriptorinfo`.
 ///


### PR DESCRIPTION
One TODO in v29 for `deriveaddresses`

The change is that it now supports multipath descriptors when calling `deriveaddresses`.

Add a new struct, model and client function for DeriveAddressesMultipath.

Update the test for v29 to check a multipath descriptor.