### PR TITLE
Test finalizepsbt

### DIFF
--- a/client/src/client_sync/v17/raw_transactions.rs
+++ b/client/src/client_sync/v17/raw_transactions.rs
@@ -101,7 +101,8 @@ macro_rules! impl_client_v17__finalize_psbt {
         impl Client {
             pub fn finalize_psbt(&self, psbt: &bitcoin::Psbt) -> Result<FinalizePsbt> {
                 let psbt = format!("{}", psbt);
-                self.call("finalizepsbt", &[psbt.into()])
+                // Pass extract=false so Core returns the PSBT field in the response.
+                self.call("finalizepsbt", &[psbt.into(), false.into()])
             }
         }
     };

--- a/types/src/model/raw_transactions.rs
+++ b/types/src/model/raw_transactions.rs
@@ -137,7 +137,7 @@ pub struct DescriptorProcessPsbt {
 #[serde(deny_unknown_fields)]
 pub struct FinalizePsbt {
     /// The partially signed transaction if not extracted.
-    pub psbt: Psbt,
+    pub psbt: Option<Psbt>,
     /// The transaction if extracted.
     pub tx: Option<Transaction>,
     /// If the transaction has a complete set of signatures.

--- a/types/src/v17/mod.rs
+++ b/types/src/v17/mod.rs
@@ -122,7 +122,7 @@
 //! | decodepsbt                         | version + model |                                        |
 //! | decoderawtransaction               | version + model |                                        |
 //! | decodescript                       | version + model |                                        |
-//! | finalizepsbt                       | version + model | UNTESTED                               |
+//! | finalizepsbt                       | version + model |                                        |
 //! | fundrawtransaction                 | version + model |                                        |
 //! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
 //! | sendrawtransaction                 | version + model |                                        |

--- a/types/src/v17/raw_transactions/into.rs
+++ b/types/src/v17/raw_transactions/into.rs
@@ -319,7 +319,7 @@ impl FinalizePsbt {
     pub fn into_model(self) -> Result<model::FinalizePsbt, FinalizePsbtError> {
         use FinalizePsbtError as E;
 
-        let psbt = self.psbt.parse::<Psbt>().map_err(E::Psbt)?;
+        let psbt = self.psbt.map(|s| s.parse::<Psbt>()).transpose().map_err(E::Psbt)?;
         let tx = match self.hex {
             Some(hex) => Some(consensus::encode::deserialize_hex(&hex).map_err(E::Hex)?),
             None => None,

--- a/types/src/v17/raw_transactions/mod.rs
+++ b/types/src/v17/raw_transactions/mod.rs
@@ -270,7 +270,7 @@ pub struct DecodeScriptSegwit {
 #[serde(deny_unknown_fields)]
 pub struct FinalizePsbt {
     /// The base64-encoded partially signed transaction if not extracted.
-    pub psbt: String,
+    pub psbt: Option<String>,
     /// The hex-encoded network transaction if extracted.
     pub hex: Option<String>,
     /// If the transaction has a complete set of signatures.

--- a/types/src/v18/mod.rs
+++ b/types/src/v18/mod.rs
@@ -126,7 +126,7 @@
 //! | decodepsbt                         | version + model |                                        |
 //! | decoderawtransaction               | version + model |                                        |
 //! | decodescript                       | version + model |                                        |
-//! | finalizepsbt                       | version + model | UNTESTED                               |
+//! | finalizepsbt                       | version + model |                                        |
 //! | fundrawtransaction                 | version + model |                                        |
 //! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
 //! | joinpsbts                          | version + model | UNTESTED                               |

--- a/types/src/v19/mod.rs
+++ b/types/src/v19/mod.rs
@@ -126,7 +126,7 @@
 //! | decodepsbt                         | version + model |                                        |
 //! | decoderawtransaction               | version + model |                                        |
 //! | decodescript                       | version + model |                                        |
-//! | finalizepsbt                       | version + model | UNTESTED                               |
+//! | finalizepsbt                       | version + model |                                        |
 //! | fundrawtransaction                 | version + model |                                        |
 //! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
 //! | joinpsbts                          | version + model | UNTESTED                               |

--- a/types/src/v20/mod.rs
+++ b/types/src/v20/mod.rs
@@ -127,7 +127,7 @@
 //! | decodepsbt                         | version + model |                                        |
 //! | decoderawtransaction               | version + model |                                        |
 //! | decodescript                       | version + model |                                        |
-//! | finalizepsbt                       | version + model | UNTESTED                               |
+//! | finalizepsbt                       | version + model |                                        |
 //! | fundrawtransaction                 | version + model |                                        |
 //! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
 //! | joinpsbts                          | version + model | UNTESTED                               |

--- a/types/src/v21/mod.rs
+++ b/types/src/v21/mod.rs
@@ -128,7 +128,7 @@
 //! | decodepsbt                         | version + model |                                        |
 //! | decoderawtransaction               | version + model |                                        |
 //! | decodescript                       | version + model |                                        |
-//! | finalizepsbt                       | version + model | UNTESTED                               |
+//! | finalizepsbt                       | version + model |                                        |
 //! | fundrawtransaction                 | version + model |                                        |
 //! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
 //! | joinpsbts                          | version + model | UNTESTED                               |

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -128,7 +128,7 @@
 //! | decodepsbt                         | version + model |                                        |
 //! | decoderawtransaction               | version + model |                                        |
 //! | decodescript                       | version + model |                                        |
-//! | finalizepsbt                       | version + model | UNTESTED                               |
+//! | finalizepsbt                       | version + model |                                        |
 //! | fundrawtransaction                 | version + model |                                        |
 //! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
 //! | joinpsbts                          | version + model | UNTESTED                               |

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -119,7 +119,7 @@
 //! | decodepsbt                         | version + model |                                        |
 //! | decoderawtransaction               | version + model |                                        |
 //! | decodescript                       | version + model |                                        |
-//! | finalizepsbt                       | version + model | UNTESTED                               |
+//! | finalizepsbt                       | version + model |                                        |
 //! | fundrawtransaction                 | version + model |                                        |
 //! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
 //! | joinpsbts                          | version + model | UNTESTED                               |

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -120,7 +120,7 @@
 //! | decodepsbt                         | version + model |                                        |
 //! | decoderawtransaction               | version + model |                                        |
 //! | decodescript                       | version + model |                                        |
-//! | finalizepsbt                       | version + model | UNTESTED                               |
+//! | finalizepsbt                       | version + model |                                        |
 //! | fundrawtransaction                 | version + model |                                        |
 //! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
 //! | joinpsbts                          | version + model | UNTESTED                               |

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -121,7 +121,7 @@
 //! | decodepsbt                         | version + model |                                        |
 //! | decoderawtransaction               | version + model |                                        |
 //! | decodescript                       | version + model |                                        |
-//! | finalizepsbt                       | version + model | UNTESTED                               |
+//! | finalizepsbt                       | version + model |                                        |
 //! | fundrawtransaction                 | version + model |                                        |
 //! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
 //! | joinpsbts                          | version + model | UNTESTED                               |

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -128,7 +128,7 @@
 //! | descriptorprocesspsbt              | returns boolean |                                        |
 //! | decoderawtransaction               | version + model |                                        |
 //! | decodescript                       | version + model |                                        |
-//! | finalizepsbt                       | version + model | UNTESTED                               |
+//! | finalizepsbt                       | version + model |                                        |
 //! | fundrawtransaction                 | version + model |                                        |
 //! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
 //! | joinpsbts                          | version + model | UNTESTED                               |

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -128,7 +128,7 @@
 //! | descriptorprocesspsbt              | returns boolean |                                        |
 //! | decoderawtransaction               | version + model |                                        |
 //! | decodescript                       | version + model |                                        |
-//! | finalizepsbt                       | version + model | UNTESTED                               |
+//! | finalizepsbt                       | version + model |                                        |
 //! | fundrawtransaction                 | version + model |                                        |
 //! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
 //! | joinpsbts                          | version + model | UNTESTED                               |

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -128,7 +128,7 @@
 //! | descriptorprocesspsbt              | returns boolean |                                        |
 //! | decoderawtransaction               | version + model |                                        |
 //! | decodescript                       | version + model |                                        |
-//! | finalizepsbt                       | version + model | UNTESTED                               |
+//! | finalizepsbt                       | version + model |                                        |
 //! | fundrawtransaction                 | version + model |                                        |
 //! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
 //! | joinpsbts                          | version + model | UNTESTED                               |

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -129,7 +129,7 @@
 //! | descriptorprocesspsbt              | returns boolean |                                        |
 //! | decoderawtransaction               | version + model |                                        |
 //! | decodescript                       | version + model |                                        |
-//! | finalizepsbt                       | version + model | UNTESTED                               |
+//! | finalizepsbt                       | version + model |                                        |
 //! | fundrawtransaction                 | version + model |                                        |
 //! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
 //! | joinpsbts                          | version + model | UNTESTED                               |


### PR DESCRIPTION
Fix the test for `finalizepsbt`.

The field `psbt` is optional for all versions, the help does not specifically say `optional` until v23, before that it says `if not extracted`.

Make `psbt` an `Option`.