### PR TITLE
Fix `addpeeraddress` client macro name

### DIFF
--- a/client/src/client_sync/v21/hidden.rs
+++ b/client/src/client_sync/v21/hidden.rs
@@ -11,7 +11,7 @@
 
 /// Implements Bitcoin Core JSON-RPC API method `addpeeraddress`.
 #[macro_export]
-macro_rules! impl_client_v21_add_peer_address {
+macro_rules! impl_client_v21__add_peer_address {
     () => {
         impl Client {
             pub fn add_peer_address(&self, address: &str, port: u16) -> Result<AddPeerAddress> {

--- a/client/src/client_sync/v21/mod.rs
+++ b/client/src/client_sync/v21/mod.rs
@@ -71,7 +71,7 @@ crate::impl_client_v20__generate_to_descriptor!();
 crate::impl_client_v17__invalidate_block!();
 
 // == Hidden ==
-crate::impl_client_v21_add_peer_address!();
+crate::impl_client_v21__add_peer_address!();
 
 // == Mining ==
 crate::impl_client_v17__get_block_template!();

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -69,7 +69,7 @@ crate::impl_client_v20__generate_to_descriptor!();
 crate::impl_client_v17__invalidate_block!();
 
 // == Hidden ==
-crate::impl_client_v21_add_peer_address!();
+crate::impl_client_v21__add_peer_address!();
 
 // == Mining ==
 crate::impl_client_v17__get_block_template!();

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -72,7 +72,7 @@ crate::impl_client_v20__generate_to_descriptor!();
 crate::impl_client_v17__invalidate_block!();
 
 // == Hidden ==
-crate::impl_client_v21_add_peer_address!();
+crate::impl_client_v21__add_peer_address!();
 
 // == Mining ==
 crate::impl_client_v17__get_block_template!();

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -73,7 +73,7 @@ crate::impl_client_v20__generate_to_descriptor!();
 crate::impl_client_v17__invalidate_block!();
 
 // == Hidden ==
-crate::impl_client_v21_add_peer_address!();
+crate::impl_client_v21__add_peer_address!();
 
 // == Mining ==
 crate::impl_client_v17__get_block_template!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -74,7 +74,7 @@ crate::impl_client_v20__generate_to_descriptor!();
 crate::impl_client_v17__invalidate_block!();
 
 // == Hidden ==
-crate::impl_client_v21_add_peer_address!();
+crate::impl_client_v21__add_peer_address!();
 
 // == Mining ==
 crate::impl_client_v17__get_block_template!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -80,7 +80,7 @@ crate::impl_client_v20__generate_to_descriptor!();
 crate::impl_client_v17__invalidate_block!();
 
 // == Hidden ==
-crate::impl_client_v21_add_peer_address!();
+crate::impl_client_v21__add_peer_address!();
 
 // == Mining ==
 crate::impl_client_v17__get_block_template!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -74,7 +74,7 @@ crate::impl_client_v20__generate_to_descriptor!();
 crate::impl_client_v17__invalidate_block!();
 
 // == Hidden ==
-crate::impl_client_v21_add_peer_address!();
+crate::impl_client_v21__add_peer_address!();
 
 // == Mining ==
 crate::impl_client_v17__get_block_template!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -77,7 +77,7 @@ crate::impl_client_v20__generate_to_descriptor!();
 crate::impl_client_v17__invalidate_block!();
 
 // == Hidden ==
-crate::impl_client_v21_add_peer_address!();
+crate::impl_client_v21__add_peer_address!();
 
 // == Mining ==
 crate::impl_client_v17__get_block_template!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -77,7 +77,7 @@ crate::impl_client_v20__generate_to_descriptor!();
 crate::impl_client_v17__invalidate_block!();
 
 // == Hidden ==
-crate::impl_client_v21_add_peer_address!();
+crate::impl_client_v21__add_peer_address!();
 
 // == Mining ==
 crate::impl_client_v17__get_block_template!();


### PR DESCRIPTION
The macro name had a single underscore where it requried two.

Fix the name.