### PR TITLE
Test `listwallets`

### DIFF
--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -718,6 +718,21 @@ fn wallet__list_wallet_dir() {
 }
 
 #[test]
+fn wallet__list_wallets__modelled() {
+    let node = Node::with_wallet(Wallet::None, &[]);
+
+    let wallet_1 = "test_wallet_1";
+    let wallet_2 = "test_wallet_2";
+    node.client.create_wallet(wallet_1).expect("createwallet w1");
+    node.client.create_wallet(wallet_2).expect("createwallet w2");
+
+    let json: ListWallets = node.client.list_wallets().expect("listwallets");
+
+    assert!(json.0.iter().any(|w| w == wallet_1));
+    assert!(json.0.iter().any(|w| w == wallet_2));
+}
+
+#[test]
 fn wallet__load_wallet__modelled() {
     create_load_unload_wallet();
 }

--- a/types/src/v17/mod.rs
+++ b/types/src/v17/mod.rs
@@ -188,7 +188,7 @@
 //! | listsinceblock                     | version + model | UNTESTED                               |
 //! | listtransactions                   | version + model | UNTESTED                               |
 //! | listunspent                        | version + model |                                        |
-//! | listwallets                        | version + model | UNTESTED                               |
+//! | listwallets                        | version + model |                                        |
 //! | loadwallet                         | version + model |                                        |
 //! | lockunspent                        | version         |                                        |
 //! | move                               | returns boolean |                                        |

--- a/types/src/v17/mod.rs
+++ b/types/src/v17/mod.rs
@@ -170,7 +170,7 @@
 //! | getreceivedbyaccount               | returns nothing |                                        |
 //! | getreceivedbyaddress               | version + model |                                        |
 //! | gettransaction                     | version + model |                                        |
-//! | getunconfirmedbalance              | version + model | UNTESTED                               |
+//! | getunconfirmedbalance              | version + model |                                        |
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
 //! | importmulti                        | version         |                                        |

--- a/types/src/v18/mod.rs
+++ b/types/src/v18/mod.rs
@@ -174,7 +174,7 @@
 //! | getreceivedbyaddress               | version + model |                                        |
 //! | getreceivedbylabel                 | version + model |                                        |
 //! | gettransaction                     | version + model |                                        |
-//! | getunconfirmedbalance              | version + model | UNTESTED                               |
+//! | getunconfirmedbalance              | version + model |                                        |
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
 //! | importmulti                        | version         |                                        |

--- a/types/src/v18/mod.rs
+++ b/types/src/v18/mod.rs
@@ -192,7 +192,7 @@
 //! | listtransactions                   | version + model | UNTESTED                               |
 //! | listunspent                        | version + model |                                        |
 //! | listwalletdir                      | version         |                                        |
-//! | listwallets                        | version + model | UNTESTED                               |
+//! | listwallets                        | version + model |                                        |
 //! | loadwallet                         | version + model |                                        |
 //! | lockunspent                        | version         |                                        |
 //! | removeprunedfunds                  | returns nothing |                                        |

--- a/types/src/v19/mod.rs
+++ b/types/src/v19/mod.rs
@@ -193,7 +193,7 @@
 //! | listtransactions                   | version + model | UNTESTED                               |
 //! | listunspent                        | version + model |                                        |
 //! | listwalletdir                      | version         |                                        |
-//! | listwallets                        | version + model | UNTESTED                               |
+//! | listwallets                        | version + model |                                        |
 //! | loadwallet                         | version + model |                                        |
 //! | lockunspent                        | version         |                                        |
 //! | removeprunedfunds                  | returns nothing |                                        |

--- a/types/src/v19/mod.rs
+++ b/types/src/v19/mod.rs
@@ -175,7 +175,7 @@
 //! | getreceivedbyaddress               | version + model |                                        |
 //! | getreceivedbylabel                 | version + model |                                        |
 //! | gettransaction                     | version + model |                                        |
-//! | getunconfirmedbalance              | version + model | UNTESTED                               |
+//! | getunconfirmedbalance              | version + model |                                        |
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
 //! | importmulti                        | version         |                                        |

--- a/types/src/v20/mod.rs
+++ b/types/src/v20/mod.rs
@@ -176,7 +176,7 @@
 //! | getreceivedbyaddress               | version + model |                                        |
 //! | getreceivedbylabel                 | version + model |                                        |
 //! | gettransaction                     | version + model |                                        |
-//! | getunconfirmedbalance              | version + model | UNTESTED                               |
+//! | getunconfirmedbalance              | version + model |                                        |
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
 //! | importmulti                        | version         |                                        |

--- a/types/src/v20/mod.rs
+++ b/types/src/v20/mod.rs
@@ -194,7 +194,7 @@
 //! | listtransactions                   | version + model | UNTESTED                               |
 //! | listunspent                        | version + model |                                        |
 //! | listwalletdir                      | version         |                                        |
-//! | listwallets                        | version + model | UNTESTED                               |
+//! | listwallets                        | version + model |                                        |
 //! | loadwallet                         | version + model |                                        |
 //! | lockunspent                        | version         |                                        |
 //! | removeprunedfunds                  | returns nothing |                                        |

--- a/types/src/v21/mod.rs
+++ b/types/src/v21/mod.rs
@@ -198,7 +198,7 @@
 //! | listtransactions                   | version + model | UNTESTED                               |
 //! | listunspent                        | version + model |                                        |
 //! | listwalletdir                      | version         |                                        |
-//! | listwallets                        | version + model | UNTESTED                               |
+//! | listwallets                        | version + model |                                        |
 //! | loadwallet                         | version + model |                                        |
 //! | lockunspent                        | version         |                                        |
 //! | removeprunedfunds                  | returns nothing |                                        |

--- a/types/src/v21/mod.rs
+++ b/types/src/v21/mod.rs
@@ -178,7 +178,7 @@
 //! | getreceivedbyaddress               | version + model |                                        |
 //! | getreceivedbylabel                 | version + model |                                        |
 //! | gettransaction                     | version + model |                                        |
-//! | getunconfirmedbalance              | version + model | UNTESTED                               |
+//! | getunconfirmedbalance              | version + model |                                        |
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
 //! | importdescriptors                  | version         |                                        |

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -187,7 +187,7 @@
 //! | getreceivedbyaddress               | version + model |                                        |
 //! | getreceivedbylabel                 | version + model |                                        |
 //! | gettransaction                     | version + model |                                        |
-//! | getunconfirmedbalance              | version + model | UNTESTED                               |
+//! | getunconfirmedbalance              | version + model |                                        |
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
 //! | importdescriptors                  | version         |                                        |

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -208,7 +208,7 @@
 //! | listtransactions                   | version + model | UNTESTED                               |
 //! | listunspent                        | version + model |                                        |
 //! | listwalletdir                      | version         |                                        |
-//! | listwallets                        | version + model | UNTESTED                               |
+//! | listwallets                        | version + model |                                        |
 //! | loadwallet                         | version + model |                                        |
 //! | lockunspent                        | version         |                                        |
 //! | removeprunedfunds                  | returns nothing |                                        |

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -200,7 +200,7 @@
 //! | listtransactions                   | version + model | UNTESTED                               |
 //! | listunspent                        | version + model |                                        |
 //! | listwalletdir                      | version         |                                        |
-//! | listwallets                        | version + model | UNTESTED                               |
+//! | listwallets                        | version + model |                                        |
 //! | loadwallet                         | version + model |                                        |
 //! | lockunspent                        | version         |                                        |
 //! | removeprunedfunds                  | returns nothing |                                        |

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -178,7 +178,7 @@
 //! | getreceivedbyaddress               | version + model |                                        |
 //! | getreceivedbylabel                 | version + model |                                        |
 //! | gettransaction                     | version + model |                                        |
-//! | getunconfirmedbalance              | version + model | UNTESTED                               |
+//! | getunconfirmedbalance              | version + model |                                        |
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
 //! | importdescriptors                  | version         |                                        |

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -179,7 +179,7 @@
 //! | getreceivedbyaddress               | version + model |                                        |
 //! | getreceivedbylabel                 | version + model |                                        |
 //! | gettransaction                     | version + model |                                        |
-//! | getunconfirmedbalance              | version + model | UNTESTED                               |
+//! | getunconfirmedbalance              | version + model |                                        |
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
 //! | importdescriptors                  | version         |                                        |

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -202,7 +202,7 @@
 //! | listtransactions                   | version + model | UNTESTED                               |
 //! | listunspent                        | version + model |                                        |
 //! | listwalletdir                      | version         |                                        |
-//! | listwallets                        | version + model | UNTESTED                               |
+//! | listwallets                        | version + model |                                        |
 //! | loadwallet                         | version + model |                                        |
 //! | lockunspent                        | version         |                                        |
 //! | removeprunedfunds                  | returns nothing |                                        |

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -203,7 +203,7 @@
 //! | listtransactions                   | version + model | UNTESTED                               |
 //! | listunspent                        | version + model |                                        |
 //! | listwalletdir                      | version         |                                        |
-//! | listwallets                        | version + model | UNTESTED                               |
+//! | listwallets                        | version + model |                                        |
 //! | loadwallet                         | version + model |                                        |
 //! | lockunspent                        | version         |                                        |
 //! | removeprunedfunds                  | returns nothing |                                        |

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -180,7 +180,7 @@
 //! | getreceivedbyaddress               | version + model |                                        |
 //! | getreceivedbylabel                 | version + model |                                        |
 //! | gettransaction                     | version + model |                                        |
-//! | getunconfirmedbalance              | version + model | UNTESTED                               |
+//! | getunconfirmedbalance              | version + model |                                        |
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
 //! | importdescriptors                  | version         |                                        |

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -188,7 +188,7 @@
 //! | getreceivedbyaddress               | version + model |                                        |
 //! | getreceivedbylabel                 | version + model |                                        |
 //! | gettransaction                     | version + model |                                        |
-//! | getunconfirmedbalance              | version + model | UNTESTED                               |
+//! | getunconfirmedbalance              | version + model |                                        |
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
 //! | importdescriptors                  | version         |                                        |

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -211,7 +211,7 @@
 //! | listtransactions                   | version + model | UNTESTED                               |
 //! | listunspent                        | version + model |                                        |
 //! | listwalletdir                      | version         |                                        |
-//! | listwallets                        | version + model | UNTESTED                               |
+//! | listwallets                        | version + model |                                        |
 //! | loadwallet                         | version + model |                                        |
 //! | lockunspent                        | version         |                                        |
 //! | removeprunedfunds                  | returns nothing |                                        |

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -188,7 +188,7 @@
 //! | getreceivedbyaddress               | version + model |                                        |
 //! | getreceivedbylabel                 | version + model |                                        |
 //! | gettransaction                     | version + model |                                        |
-//! | getunconfirmedbalance              | version + model | UNTESTED                               |
+//! | getunconfirmedbalance              | version + model |                                        |
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
 //! | importdescriptors                  | version         |                                        |

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -211,7 +211,7 @@
 //! | listtransactions                   | version + model | UNTESTED                               |
 //! | listunspent                        | version + model |                                        |
 //! | listwalletdir                      | version         |                                        |
-//! | listwallets                        | version + model | UNTESTED                               |
+//! | listwallets                        | version + model |                                        |
 //! | loadwallet                         | version + model |                                        |
 //! | lockunspent                        | version         |                                        |
 //! | removeprunedfunds                  | returns nothing |                                        |

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -213,7 +213,7 @@
 //! | listtransactions                   | version + model | UNTESTED                               |
 //! | listunspent                        | version + model |                                        |
 //! | listwalletdir                      | version         |                                        |
-//! | listwallets                        | version + model | UNTESTED                               |
+//! | listwallets                        | version + model |                                        |
 //! | loadwallet                         | version + model |                                        |
 //! | lockunspent                        | version         |                                        |
 //! | removeprunedfunds                  | returns nothing |                                        |

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -190,7 +190,7 @@
 //! | getreceivedbyaddress               | version + model |                                        |
 //! | getreceivedbylabel                 | version + model |                                        |
 //! | gettransaction                     | version + model |                                        |
-//! | getunconfirmedbalance              | version + model | UNTESTED                               |
+//! | getunconfirmedbalance              | version + model |                                        |
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
 //! | importdescriptors                  | version         |                                        |

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -214,7 +214,7 @@
 //! | listtransactions                   | version + model | UNTESTED                               |
 //! | listunspent                        | version + model |                                        |
 //! | listwalletdir                      | version         |                                        |
-//! | listwallets                        | version + model | UNTESTED                               |
+//! | listwallets                        | version + model |                                        |
 //! | loadwallet                         | version + model |                                        |
 //! | lockunspent                        | version         |                                        |
 //! | removeprunedfunds                  | returns nothing |                                        |

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -191,7 +191,7 @@
 //! | getreceivedbyaddress               | version + model |                                        |
 //! | getreceivedbylabel                 | version + model |                                        |
 //! | gettransaction                     | version + model |                                        |
-//! | getunconfirmedbalance              | version + model | UNTESTED                               |
+//! | getunconfirmedbalance              | version + model |                                        |
 //! | getwalletinfo                      | version + model | UNTESTED                               |
 //! | importaddress                      | returns nothing |                                        |
 //! | importdescriptors                  | version         |                                        |


### PR DESCRIPTION
`listwallets` is implemented but untested. Also the `getunconfirmedbalance` test was added in a previous PR but the types table was not updated.

- Remove `getunconfirmedbalance` `UNTESTED` from the types table.

- Add a test for `listwallet` and update the types table.

