### PR TITLE
Test `utxoupdatepsbt` and `joinpsbts`

### DIFF
--- a/client/src/client_sync/v18/raw_transactions.rs
+++ b/client/src/client_sync/v18/raw_transactions.rs
@@ -35,14 +35,14 @@ macro_rules! impl_client_v18__join_psbts {
     };
 }
 
-/// Implements Bitcoin Core JSON-RPC API method `uxtoupdatepsbt`.
+/// Implements Bitcoin Core JSON-RPC API method `utxoupdatepsbt`.
 #[macro_export]
 macro_rules! impl_client_v18__utxo_update_psbt {
     () => {
         impl Client {
-            pub fn utxo_update_psbt(&self, psbt: &bitcoin::Psbt) -> Result<JoinPsbts> {
+            pub fn utxo_update_psbt(&self, psbt: &bitcoin::Psbt) -> Result<UtxoUpdatePsbt> {
                 let psbt = format!("{}", psbt);
-                self.call("uxtoupdatepsbt", &[psbt.into()])
+                self.call("utxoupdatepsbt", &[psbt.into()])
             }
         }
     };

--- a/integration_test/tests/raw_transactions.rs
+++ b/integration_test/tests/raw_transactions.rs
@@ -310,6 +310,24 @@ fn raw_transactions__get_raw_transaction__modelled() {
 }
 
 #[test]
+#[cfg(not(feature = "v17"))]
+fn raw_transactions__join_psbts__modelled() {
+    let node = Node::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+
+    let psbt1 = create_a_psbt(&node);
+    let psbt2 = create_a_psbt(&node);
+
+    let json: JoinPsbts = node
+        .client
+        .join_psbts(&[psbt1.clone(), psbt2.clone()])
+        .expect("joinpsbts");
+    let model: mtype::JoinPsbts = json.into_model().expect("JoinPsbts into model");
+
+    assert_eq!(model.0.inputs.len(), psbt1.inputs.len() + psbt2.inputs.len());
+}
+
+#[test]
 fn raw_transactions__sign_raw_transaction__modelled() {
     let node = Node::with_wallet(Wallet::Default, &[]);
     node.fund_wallet();

--- a/integration_test/tests/raw_transactions.rs
+++ b/integration_test/tests/raw_transactions.rs
@@ -412,8 +412,20 @@ fn raw_transactions__test_mempool_accept__modelled() {
 }
 
 #[test]
-#[cfg(not(feature = "v17"))]    // utxoupdatepsbt was added in v0.18.
-fn raw_transactions__utxo_update_psbt() {}
+#[cfg(not(feature = "v17"))]
+fn raw_transactions__utxo_update_psbt__modelled() {
+    let node = Node::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+
+    let psbt = create_a_psbt(&node);
+    let json: UtxoUpdatePsbt = node
+        .client
+        .utxo_update_psbt(&psbt)
+        .expect("utxoupdatepsbt");
+    let model: mtype::UtxoUpdatePsbt = json.into_model().expect("UtxoUpdatePsbt into model");
+
+    assert!(model.0.inputs.len() >= psbt.inputs.len());
+}
 
 // Manipulates raw transactions.
 //

--- a/types/src/v18/mod.rs
+++ b/types/src/v18/mod.rs
@@ -133,7 +133,7 @@
 //! | sendrawtransaction                 | version + model |                                        |
 //! | signrawtransactionwithkey          | version + model |                                        |
 //! | testmempoolaccept                  | version + model |                                        |
-//! | utxoupdatepsbt                     | version + model | UNTESTED                               |
+//! | utxoupdatepsbt                     | version + model |                                        |
 //!
 //! </details>
 //!

--- a/types/src/v18/mod.rs
+++ b/types/src/v18/mod.rs
@@ -129,7 +129,7 @@
 //! | finalizepsbt                       | version + model |                                        |
 //! | fundrawtransaction                 | version + model |                                        |
 //! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
-//! | joinpsbts                          | version + model | UNTESTED                               |
+//! | joinpsbts                          | version + model |                                        |
 //! | sendrawtransaction                 | version + model |                                        |
 //! | signrawtransactionwithkey          | version + model |                                        |
 //! | testmempoolaccept                  | version + model |                                        |

--- a/types/src/v19/mod.rs
+++ b/types/src/v19/mod.rs
@@ -133,7 +133,7 @@
 //! | sendrawtransaction                 | version + model |                                        |
 //! | signrawtransactionwithkey          | version + model |                                        |
 //! | testmempoolaccept                  | version + model |                                        |
-//! | utxoupdatepsbt                     | version + model | UNTESTED                               |
+//! | utxoupdatepsbt                     | version + model |                                        |
 //!
 //! </details>
 //!

--- a/types/src/v19/mod.rs
+++ b/types/src/v19/mod.rs
@@ -129,7 +129,7 @@
 //! | finalizepsbt                       | version + model |                                        |
 //! | fundrawtransaction                 | version + model |                                        |
 //! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
-//! | joinpsbts                          | version + model | UNTESTED                               |
+//! | joinpsbts                          | version + model |                                        |
 //! | sendrawtransaction                 | version + model |                                        |
 //! | signrawtransactionwithkey          | version + model |                                        |
 //! | testmempoolaccept                  | version + model |                                        |

--- a/types/src/v20/mod.rs
+++ b/types/src/v20/mod.rs
@@ -134,7 +134,7 @@
 //! | sendrawtransaction                 | version + model |                                        |
 //! | signrawtransactionwithkey          | version + model |                                        |
 //! | testmempoolaccept                  | version + model |                                        |
-//! | utxoupdatepsbt                     | version + model | UNTESTED                               |
+//! | utxoupdatepsbt                     | version + model |                                        |
 //!
 //! </details>
 //!

--- a/types/src/v20/mod.rs
+++ b/types/src/v20/mod.rs
@@ -130,7 +130,7 @@
 //! | finalizepsbt                       | version + model |                                        |
 //! | fundrawtransaction                 | version + model |                                        |
 //! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
-//! | joinpsbts                          | version + model | UNTESTED                               |
+//! | joinpsbts                          | version + model |                                        |
 //! | sendrawtransaction                 | version + model |                                        |
 //! | signrawtransactionwithkey          | version + model |                                        |
 //! | testmempoolaccept                  | version + model |                                        |

--- a/types/src/v21/mod.rs
+++ b/types/src/v21/mod.rs
@@ -131,7 +131,7 @@
 //! | finalizepsbt                       | version + model |                                        |
 //! | fundrawtransaction                 | version + model |                                        |
 //! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
-//! | joinpsbts                          | version + model | UNTESTED                               |
+//! | joinpsbts                          | version + model |                                        |
 //! | sendrawtransaction                 | version + model |                                        |
 //! | signrawtransactionwithkey          | version + model |                                        |
 //! | testmempoolaccept                  | version + model |                                        |

--- a/types/src/v21/mod.rs
+++ b/types/src/v21/mod.rs
@@ -135,7 +135,7 @@
 //! | sendrawtransaction                 | version + model |                                        |
 //! | signrawtransactionwithkey          | version + model |                                        |
 //! | testmempoolaccept                  | version + model |                                        |
-//! | utxoupdatepsbt                     | version + model | UNTESTED                               |
+//! | utxoupdatepsbt                     | version + model |                                        |
 //!
 //! </details>
 //!

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -131,7 +131,7 @@
 //! | finalizepsbt                       | version + model |                                        |
 //! | fundrawtransaction                 | version + model |                                        |
 //! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
-//! | joinpsbts                          | version + model | UNTESTED                               |
+//! | joinpsbts                          | version + model |                                        |
 //! | sendrawtransaction                 | version + model |                                        |
 //! | signrawtransactionwithkey          | version + model |                                        |
 //! | testmempoolaccept                  | version + model |                                        |

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -135,7 +135,7 @@
 //! | sendrawtransaction                 | version + model |                                        |
 //! | signrawtransactionwithkey          | version + model |                                        |
 //! | testmempoolaccept                  | version + model |                                        |
-//! | utxoupdatepsbt                     | version + model | UNTESTED                               |
+//! | utxoupdatepsbt                     | version + model |                                        |
 //!
 //! </details>
 //!

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -126,7 +126,7 @@
 //! | sendrawtransaction                 | version + model |                                        |
 //! | signrawtransactionwithkey          | version + model |                                        |
 //! | testmempoolaccept                  | version + model |                                        |
-//! | utxoupdatepsbt                     | version + model | UNTESTED                               |
+//! | utxoupdatepsbt                     | version + model |                                        |
 //!
 //! </details>
 //!

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -122,7 +122,7 @@
 //! | finalizepsbt                       | version + model |                                        |
 //! | fundrawtransaction                 | version + model |                                        |
 //! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
-//! | joinpsbts                          | version + model | UNTESTED                               |
+//! | joinpsbts                          | version + model |                                        |
 //! | sendrawtransaction                 | version + model |                                        |
 //! | signrawtransactionwithkey          | version + model |                                        |
 //! | testmempoolaccept                  | version + model |                                        |

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -127,7 +127,7 @@
 //! | sendrawtransaction                 | version + model |                                        |
 //! | signrawtransactionwithkey          | version + model |                                        |
 //! | testmempoolaccept                  | version + model |                                        |
-//! | utxoupdatepsbt                     | version + model | UNTESTED                               |
+//! | utxoupdatepsbt                     | version + model |                                        |
 //!
 //! </details>
 //!

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -123,7 +123,7 @@
 //! | finalizepsbt                       | version + model |                                        |
 //! | fundrawtransaction                 | version + model |                                        |
 //! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
-//! | joinpsbts                          | version + model | UNTESTED                               |
+//! | joinpsbts                          | version + model |                                        |
 //! | sendrawtransaction                 | version + model |                                        |
 //! | signrawtransactionwithkey          | version + model |                                        |
 //! | testmempoolaccept                  | version + model |                                        |

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -128,7 +128,7 @@
 //! | sendrawtransaction                 | version + model |                                        |
 //! | signrawtransactionwithkey          | version + model |                                        |
 //! | testmempoolaccept                  | version + model |                                        |
-//! | utxoupdatepsbt                     | version + model | UNTESTED                               |
+//! | utxoupdatepsbt                     | version + model |                                        |
 //!
 //! </details>
 //!

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -124,7 +124,7 @@
 //! | finalizepsbt                       | version + model |                                        |
 //! | fundrawtransaction                 | version + model |                                        |
 //! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
-//! | joinpsbts                          | version + model | UNTESTED                               |
+//! | joinpsbts                          | version + model |                                        |
 //! | sendrawtransaction                 | version + model |                                        |
 //! | signrawtransactionwithkey          | version + model |                                        |
 //! | testmempoolaccept                  | version + model |                                        |

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -131,7 +131,7 @@
 //! | finalizepsbt                       | version + model |                                        |
 //! | fundrawtransaction                 | version + model |                                        |
 //! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
-//! | joinpsbts                          | version + model | UNTESTED                               |
+//! | joinpsbts                          | version + model |                                        |
 //! | sendrawtransaction                 | version + model |                                        |
 //! | signrawtransactionwithkey          | version + model |                                        |
 //! | submitpackage                      | version + model |                                        |

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -136,7 +136,7 @@
 //! | signrawtransactionwithkey          | version + model |                                        |
 //! | submitpackage                      | version + model |                                        |
 //! | testmempoolaccept                  | version + model |                                        |
-//! | utxoupdatepsbt                     | version + model | UNTESTED                               |
+//! | utxoupdatepsbt                     | version + model |                                        |
 //!
 //! </details>
 //!

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -131,7 +131,7 @@
 //! | finalizepsbt                       | version + model |                                        |
 //! | fundrawtransaction                 | version + model |                                        |
 //! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
-//! | joinpsbts                          | version + model | UNTESTED                               |
+//! | joinpsbts                          | version + model |                                        |
 //! | sendrawtransaction                 | version + model |                                        |
 //! | signrawtransactionwithkey          | version + model |                                        |
 //! | submitpackage                      | version + model |                                        |

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -136,7 +136,7 @@
 //! | signrawtransactionwithkey          | version + model |                                        |
 //! | submitpackage                      | version + model |                                        |
 //! | testmempoolaccept                  | version + model |                                        |
-//! | utxoupdatepsbt                     | version + model | UNTESTED                               |
+//! | utxoupdatepsbt                     | version + model |                                        |
 //!
 //! </details>
 //!

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -131,7 +131,7 @@
 //! | finalizepsbt                       | version + model |                                        |
 //! | fundrawtransaction                 | version + model |                                        |
 //! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
-//! | joinpsbts                          | version + model | UNTESTED                               |
+//! | joinpsbts                          | version + model |                                        |
 //! | sendrawtransaction                 | version + model |                                        |
 //! | signrawtransactionwithkey          | version + model |                                        |
 //! | submitpackage                      | version + model |                                        |

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -136,7 +136,7 @@
 //! | signrawtransactionwithkey          | version + model |                                        |
 //! | submitpackage                      | version + model |                                        |
 //! | testmempoolaccept                  | version + model |                                        |
-//! | utxoupdatepsbt                     | version + model | UNTESTED                               |
+//! | utxoupdatepsbt                     | version + model |                                        |
 //!
 //! </details>
 //!

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -132,7 +132,7 @@
 //! | finalizepsbt                       | version + model |                                        |
 //! | fundrawtransaction                 | version + model |                                        |
 //! | getrawtransaction                  | version + model | Includes additional 'verbose' type     |
-//! | joinpsbts                          | version + model | UNTESTED                               |
+//! | joinpsbts                          | version + model |                                        |
 //! | sendrawtransaction                 | version + model |                                        |
 //! | signrawtransactionwithkey          | version + model |                                        |
 //! | submitpackage                      | version + model |                                        |

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -137,7 +137,7 @@
 //! | signrawtransactionwithkey          | version + model |                                        |
 //! | submitpackage                      | version + model |                                        |
 //! | testmempoolaccept                  | version + model |                                        |
-//! | utxoupdatepsbt                     | version + model | UNTESTED                               |
+//! | utxoupdatepsbt                     | version + model |                                        |
 //!
 //! </details>
 //!


### PR DESCRIPTION
`utxoupdatepsbt` and `joinpsbts` are implemented but untested. The client macro for `utxoupdatepsbt` had a typo and the incorrect return type. Neither RPC has any return changes up to v29.

- Fix the typo and return type in `utxoupdatepsbt` client macro.
- Test `utxoupdatepsbt` and update the types table.
- Test `joinpsbts` and update the types table.