### PR TITLE
Test `sendmany`

### DIFF
--- a/client/src/client_sync/v17/wallet.rs
+++ b/client/src/client_sync/v17/wallet.rs
@@ -560,7 +560,11 @@ macro_rules! impl_client_v17__send_many {
         impl Client {
             pub fn send_many(&self, amounts: BTreeMap<Address, Amount>) -> Result<SendMany> {
                 let dummy = ""; // Must be set to "" for backwards compatibility.
-                self.call("sendmany", &[into_json(dummy)?, into_json(amounts)?])
+                let amount_btc: BTreeMap<String, f64> = amounts
+                    .into_iter()
+                    .map(|(addr, amount)| (addr.to_string(), amount.to_btc()))
+                    .collect();
+                self.call("sendmany", &[into_json(dummy)?, into_json(amount_btc)?])
             }
         }
     };

--- a/client/src/client_sync/v21/mod.rs
+++ b/client/src/client_sync/v21/mod.rs
@@ -172,6 +172,7 @@ crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v21__send!();
 crate::impl_client_v17__send_many!();
+crate::impl_client_v21__send_many_verbose!();
 crate::impl_client_v17__send_to_address!();
 crate::impl_client_v17__set_hd_seed!();
 crate::impl_client_v17__set_tx_fee!();

--- a/client/src/client_sync/v21/wallet.rs
+++ b/client/src/client_sync/v21/wallet.rs
@@ -98,6 +98,48 @@ macro_rules! impl_client_v21__send {
     };
 }
 
+/// Implements Bitcoin Core JSON-RPC API method `sendmany` with `verbose=true` (v21+).
+#[macro_export]
+macro_rules! impl_client_v21__send_many_verbose {
+    () => {
+        impl Client {
+            pub fn send_many_verbose(
+                &self,
+                amounts: BTreeMap<Address, Amount>,
+            ) -> Result<SendManyVerbose> {
+                let dummy = ""; // Backwards compatibility dummy.
+                let amount_btc: BTreeMap<String, f64> = amounts
+                    .into_iter()
+                    .map(|(addr, amount)| (addr.to_string(), amount.to_btc()))
+                    .collect();
+                let minconf = 1u64;
+                let comment = "";
+                let subtract_fee_from: Vec<String> = Vec::new();
+                let replaceable = true;
+                let conf_target = 1u64;
+                let estimate_mode = "unset";
+                let fee_rate = serde_json::Value::Null;
+                let verbose = true;
+                self.call(
+                    "sendmany",
+                    &[
+                        into_json(dummy)?,
+                        into_json(amount_btc)?,
+                        minconf.into(),
+                        comment.into(),
+                        into_json(subtract_fee_from)?,
+                        replaceable.into(),
+                        conf_target.into(),
+                        estimate_mode.into(),
+                        fee_rate,
+                        verbose.into(),
+                    ],
+                )
+            }
+        }
+    };
+}
+
 /// Implements Bitcoin Core JSON-RPC API method `unloadwallet`.
 #[macro_export]
 macro_rules! impl_client_v21__unload_wallet {

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -174,6 +174,7 @@ crate::impl_client_v17__remove_pruned_funds!();
 crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v21__send!();
 crate::impl_client_v17__send_many!();
+crate::impl_client_v21__send_many_verbose!();
 crate::impl_client_v17__send_to_address!();
 crate::impl_client_v17__set_hd_seed!();
 crate::impl_client_v17__set_tx_fee!();

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -179,6 +179,7 @@ crate::impl_client_v17__rescan_blockchain!();
 crate::impl_client_v23__restore_wallet!();
 crate::impl_client_v21__send!();
 crate::impl_client_v17__send_many!();
+crate::impl_client_v21__send_many_verbose!();
 crate::impl_client_v17__send_to_address!();
 crate::impl_client_v17__set_hd_seed!();
 crate::impl_client_v17__set_tx_fee!();

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -182,6 +182,7 @@ crate::impl_client_v23__restore_wallet!();
 crate::impl_client_v21__send!();
 crate::impl_client_v24__send_all!();
 crate::impl_client_v17__send_many!();
+crate::impl_client_v21__send_many_verbose!();
 crate::impl_client_v17__send_to_address!();
 crate::impl_client_v17__set_hd_seed!();
 crate::impl_client_v17__set_tx_fee!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -183,6 +183,7 @@ crate::impl_client_v23__restore_wallet!();
 crate::impl_client_v21__send!();
 crate::impl_client_v24__send_all!();
 crate::impl_client_v17__send_many!();
+crate::impl_client_v21__send_many_verbose!();
 crate::impl_client_v17__send_to_address!();
 crate::impl_client_v17__set_hd_seed!();
 crate::impl_client_v17__set_tx_fee!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -192,6 +192,7 @@ crate::impl_client_v23__restore_wallet!();
 crate::impl_client_v21__send!();
 crate::impl_client_v24__send_all!();
 crate::impl_client_v17__send_many!();
+crate::impl_client_v21__send_many_verbose!();
 crate::impl_client_v17__send_to_address!();
 crate::impl_client_v17__set_hd_seed!();
 crate::impl_client_v17__set_tx_fee!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -186,6 +186,7 @@ crate::impl_client_v23__restore_wallet!();
 crate::impl_client_v21__send!();
 crate::impl_client_v24__send_all!();
 crate::impl_client_v17__send_many!();
+crate::impl_client_v21__send_many_verbose!();
 crate::impl_client_v17__send_to_address!();
 crate::impl_client_v17__set_hd_seed!();
 crate::impl_client_v17__set_tx_fee!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -191,6 +191,7 @@ crate::impl_client_v23__restore_wallet!();
 crate::impl_client_v21__send!();
 crate::impl_client_v24__send_all!();
 crate::impl_client_v17__send_many!();
+crate::impl_client_v21__send_many_verbose!();
 crate::impl_client_v17__send_to_address!();
 crate::impl_client_v17__set_hd_seed!();
 crate::impl_client_v17__set_tx_fee!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -191,6 +191,7 @@ crate::impl_client_v23__restore_wallet!();
 crate::impl_client_v21__send!();
 crate::impl_client_v24__send_all!();
 crate::impl_client_v17__send_many!();
+crate::impl_client_v21__send_many_verbose!();
 crate::impl_client_v17__send_to_address!();
 crate::impl_client_v17__set_hd_seed!();
 crate::impl_client_v17__set_tx_fee!();

--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -857,6 +857,33 @@ fn wallet__unload_wallet() {
     create_load_unload_wallet();
 }
 
+#[test]
+fn wallet__send_many__modelled() {
+    let node = Node::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+
+    let addr1 = node.client.new_address().expect("newaddress");
+    let addr2 = node.client.new_address().expect("newaddress");
+
+    let mut amounts = BTreeMap::new();
+    amounts.insert(addr1, Amount::from_sat(100_000));
+    amounts.insert(addr2, Amount::from_sat(100_000));
+
+    let json: SendMany = node.client.send_many(amounts.clone()).expect("sendmany");
+    let model: Result<mtype::SendMany, _> = json.into_model();
+    model.unwrap();
+
+    #[cfg(not(feature = "v20_and_below"))]
+    {
+        let json_verbose: SendManyVerbose = node
+            .client
+            .send_many_verbose(amounts)
+            .expect("sendmany verbose");
+        let model_verbose: Result<mtype::SendManyVerbose, _> = json_verbose.into_model();
+        model_verbose.unwrap();
+    }
+}
+
 #[cfg(not(feature = "v20_and_below"))]
 #[test]
 fn wallet__send__modelled() {

--- a/types/src/model/mod.rs
+++ b/types/src/model/mod.rs
@@ -60,8 +60,8 @@ pub use self::{
         ListLockUnspentItem, ListReceivedByAddress, ListReceivedByAddressItem, ListReceivedByLabel,
         ListReceivedByLabelItem, ListSinceBlock, ListSinceBlockTransaction, ListTransactions,
         ListTransactionsItem, ListUnspent, ListUnspentItem, ListWallets, LoadWallet, PsbtBumpFee,
-        RescanBlockchain, ScriptType, Send, SendAll, SendMany, SendToAddress, SignMessage,
-        SimulateRawTransaction, TransactionCategory, UnloadWallet, WalletCreateFundedPsbt,
-        WalletDisplayAddress, WalletProcessPsbt,
+        RescanBlockchain, ScriptType, Send, SendAll, SendMany, SendManyVerbose, SendToAddress,
+        SignMessage, SimulateRawTransaction, TransactionCategory, UnloadWallet,
+        WalletCreateFundedPsbt, WalletDisplayAddress, WalletProcessPsbt,
     },
 };

--- a/types/src/model/wallet.rs
+++ b/types/src/model/wallet.rs
@@ -808,6 +808,16 @@ pub struct SendAll {
 #[serde(deny_unknown_fields)]
 pub struct SendMany(pub Txid);
 
+/// Models the verbose result of JSON-RPC method `sendmany` when `verbose=true`.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SendManyVerbose {
+    /// The transaction id for the send. Only 1 transaction is created regardless of the number of addresses.
+    pub txid: Txid,
+    /// The transaction fee reason.
+    pub fee_reason: String,
+}
+
 /// Models the result of JSON-RPC method `sendtoaddress`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]

--- a/types/src/v17/mod.rs
+++ b/types/src/v17/mod.rs
@@ -195,7 +195,7 @@
 //! | removeprunedfunds                  | returns nothing |                                        |
 //! | rescanblockchain                   | version + model |                                        |
 //! | sendfrom                           | returns nothing |                                        |
-//! | sendmany                           | version + model | UNTESTED                               |
+//! | sendmany                           | version + model |                                        |
 //! | sendtoaddress                      | version + model |                                        |
 //! | setaccount                         | returns nothing |                                        |
 //! | sethdseed                          | returns nothing |                                        |

--- a/types/src/v18/mod.rs
+++ b/types/src/v18/mod.rs
@@ -197,7 +197,7 @@
 //! | lockunspent                        | version         |                                        |
 //! | removeprunedfunds                  | returns nothing |                                        |
 //! | rescanblockchain                   | version + model |                                        |
-//! | sendmany                           | version + model | UNTESTED                               |
+//! | sendmany                           | version + model |                                        |
 //! | sendtoaddress                      | version + model |                                        |
 //! | sethdseed                          | returns nothing |                                        |
 //! | setlabel                           | returns nothing |                                        |

--- a/types/src/v19/mod.rs
+++ b/types/src/v19/mod.rs
@@ -198,7 +198,7 @@
 //! | lockunspent                        | version         |                                        |
 //! | removeprunedfunds                  | returns nothing |                                        |
 //! | rescanblockchain                   | version + model |                                        |
-//! | sendmany                           | version + model | UNTESTED                               |
+//! | sendmany                           | version + model |                                        |
 //! | sendtoaddress                      | version + model |                                        |
 //! | sethdseed                          | returns nothing |                                        |
 //! | setlabel                           | returns nothing |                                        |

--- a/types/src/v20/mod.rs
+++ b/types/src/v20/mod.rs
@@ -199,7 +199,7 @@
 //! | lockunspent                        | version         |                                        |
 //! | removeprunedfunds                  | returns nothing |                                        |
 //! | rescanblockchain                   | version + model |                                        |
-//! | sendmany                           | version + model | UNTESTED                               |
+//! | sendmany                           | version + model |                                        |
 //! | sendtoaddress                      | version + model |                                        |
 //! | sethdseed                          | returns nothing |                                        |
 //! | setlabel                           | returns nothing |                                        |

--- a/types/src/v21/mod.rs
+++ b/types/src/v21/mod.rs
@@ -204,7 +204,7 @@
 //! | removeprunedfunds                  | returns nothing |                                        |
 //! | rescanblockchain                   | version + model |                                        |
 //! | send                               | version + model |                                        |
-//! | sendmany                           | version + model | UNTESTED                               |
+//! | sendmany                           | version + model |                                        |
 //! | sendtoaddress                      | version + model |                                        |
 //! | sethdseed                          | returns nothing |                                        |
 //! | setlabel                           | returns nothing |                                        |
@@ -256,7 +256,7 @@ pub use self::{
     util::{GetIndexInfo, GetIndexInfoName},
     wallet::{
         ImportDescriptors, ImportDescriptorsResult, PsbtBumpFee, PsbtBumpFeeError, Send, SendError,
-        UnloadWallet, UpgradeWallet,
+        SendMany, SendManyVerbose, UnloadWallet, UpgradeWallet,
     },
 };
 #[doc(inline)]
@@ -285,11 +285,11 @@ pub use crate::{
         ListSinceBlockTransactionError, ListTransactions, ListTransactionsItem,
         ListTransactionsItemError, ListUnspentItemError, ListWallets, LoadWallet, LockUnspent,
         Locked, PruneBlockchain, RawTransactionError, RawTransactionInput, RawTransactionOutput,
-        RescanBlockchain, ScriptType, SendMany, SendRawTransaction, SendToAddress,
-        SetNetworkActive, SetTxFee, SignMessage, SignMessageWithPrivKey, SignRawTransaction,
-        SignRawTransactionError, SoftforkReject, TransactionCategory, UploadTarget,
-        ValidateAddress, ValidateAddressError, VerifyChain, VerifyMessage, VerifyTxOutProof,
-        WalletCreateFundedPsbt, WalletCreateFundedPsbtError, WalletProcessPsbt, WitnessUtxo,
+        RescanBlockchain, ScriptType, SendRawTransaction, SendToAddress, SetNetworkActive,
+        SetTxFee, SignMessage, SignMessageWithPrivKey, SignRawTransaction, SignRawTransactionError,
+        SoftforkReject, TransactionCategory, UploadTarget, ValidateAddress, ValidateAddressError,
+        VerifyChain, VerifyMessage, VerifyTxOutProof, WalletCreateFundedPsbt,
+        WalletCreateFundedPsbtError, WalletProcessPsbt, WitnessUtxo,
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,

--- a/types/src/v21/wallet/into.rs
+++ b/types/src/v21/wallet/into.rs
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: CC0-1.0
 
-use super::{PsbtBumpFee, PsbtBumpFeeError, Send, SendError, UnloadWallet};
+use bitcoin::{hex, Txid};
+
+use super::{
+    PsbtBumpFee, PsbtBumpFeeError, Send, SendError, SendMany, SendManyVerbose, UnloadWallet,
+};
 use crate::model;
 
 impl UnloadWallet {
@@ -40,5 +44,21 @@ impl Send {
         let psbt = self.psbt.as_ref().map(|p| p.parse()).transpose().map_err(E::Psbt)?;
 
         Ok(model::Send { complete: self.complete, txid, hex, psbt })
+    }
+}
+
+impl SendMany {
+    /// Converts version specific type to a version nonspecific, more strongly typed type.
+    pub fn into_model(self) -> Result<model::SendMany, hex::HexToArrayError> {
+        let txid = self.0.parse::<Txid>()?;
+        Ok(model::SendMany(txid))
+    }
+}
+
+impl SendManyVerbose {
+    /// Converts version specific type to a version nonspecific, more strongly typed type.
+    pub fn into_model(self) -> Result<model::SendManyVerbose, hex::HexToArrayError> {
+        let txid = self.txid.parse::<Txid>()?;
+        Ok(model::SendManyVerbose { txid, fee_reason: self.fee_reason })
     }
 }

--- a/types/src/v21/wallet/mod.rs
+++ b/types/src/v21/wallet/mod.rs
@@ -109,6 +109,36 @@ pub struct Send {
     pub psbt: Option<String>,
 }
 
+/// Result of JSON-RPC method `sendmany` when `verbose=false`.
+///
+/// > sendmany "" {"address":amount}
+/// >
+/// > Send multiple times. Amounts are double-precision floating point numbers.
+/// > Requires wallet passphrase to be set with walletpassphrase call if wallet is encrypted.
+/// >
+/// > Arguments:
+/// > 1. dummy   (string, required) Must be set to "" for backwards compatibility.
+/// > 2. amounts (json object, required) The addresses and amounts
+/// >    { "address": amount, (numeric or string, required) The bitcoin address is the key, the numeric amount (can be string) in BTC is the value }
+/// > ...
+/// > 10. verbose (boolean, optional, default=false) If true, return extra infomration about the transaction.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SendMany(
+    /// The transaction id for the send.
+    pub String,
+);
+
+/// Result of JSON-RPC method `sendmany` when `verbose=true`.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SendManyVerbose {
+    /// The transaction id for the send. Only 1 transaction is created regardless of the number of addresses.
+    pub txid: String,
+    /// The transaction fee reason.
+    pub fee_reason: String,
+}
+
 /// Result of the JSON-RPC method `unloadwallet`.
 ///
 /// > unloadwallet ( "wallet_name" load_on_startup )

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -214,7 +214,7 @@
 //! | removeprunedfunds                  | returns nothing |                                        |
 //! | rescanblockchain                   | version + model |                                        |
 //! | send                               | version + model |                                        |
-//! | sendmany                           | version + model | UNTESTED                               |
+//! | sendmany                           | version + model |                                        |
 //! | sendtoaddress                      | version + model |                                        |
 //! | sethdseed                          | returns nothing |                                        |
 //! | setlabel                           | returns nothing |                                        |
@@ -287,7 +287,7 @@ pub use crate::{
         ListSinceBlockError, ListSinceBlockTransaction, ListSinceBlockTransactionError,
         ListTransactions, ListTransactionsItem, ListTransactionsItemError, ListUnspentItemError,
         ListWallets, LoadWallet, LockUnspent, Locked, PruneBlockchain, RawTransactionError,
-        RawTransactionInput, RawTransactionOutput, RescanBlockchain, ScriptType, SendMany,
+        RawTransactionInput, RawTransactionOutput, RescanBlockchain, ScriptType,
         SendRawTransaction, SendToAddress, SetNetworkActive, SetTxFee, SignMessage,
         SignMessageWithPrivKey, SignRawTransaction, SignRawTransactionError, SoftforkReject,
         TransactionCategory, UploadTarget, ValidateAddress, ValidateAddressError, VerifyChain,
@@ -317,7 +317,7 @@ pub use crate::{
         GetIndexInfoName, GetMempoolAncestors, GetMempoolAncestorsVerbose, GetMempoolDescendants,
         GetMempoolDescendantsVerbose, GetMempoolEntry, GetNetworkInfo, ImportDescriptors,
         ImportDescriptorsResult, MempoolEntry, PsbtBumpFee, PsbtBumpFeeError, Send, SendError,
-        Softfork, SoftforkType, UnloadWallet, UpgradeWallet,
+        SendMany, SendManyVerbose, Softfork, SoftforkType, UnloadWallet, UpgradeWallet,
     },
     ScriptPubkey,
 };

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -207,7 +207,7 @@
 //! | rescanblockchain                   | version + model |                                        |
 //! | restorewallet                      | version         |                                        |
 //! | send                               | version + model |                                        |
-//! | sendmany                           | version + model | UNTESTED                               |
+//! | sendmany                           | version + model |                                        |
 //! | sendtoaddress                      | version + model |                                        |
 //! | sethdseed                          | returns nothing |                                        |
 //! | setlabel                           | returns nothing |                                        |
@@ -285,12 +285,11 @@ pub use crate::{
         ListSinceBlockTransaction, ListSinceBlockTransactionError, ListTransactions,
         ListTransactionsItem, ListTransactionsItemError, ListUnspentItemError, ListWallets,
         LoadWallet, LockUnspent, Locked, PruneBlockchain, RawTransactionError, RawTransactionInput,
-        RawTransactionOutput, RescanBlockchain, ScriptType, SendMany, SendRawTransaction,
-        SendToAddress, SetNetworkActive, SetTxFee, SignMessage, SignMessageWithPrivKey,
-        SignRawTransaction, SignRawTransactionError, SoftforkReject, TransactionCategory,
-        UploadTarget, ValidateAddress, ValidateAddressError, VerifyChain, VerifyMessage,
-        VerifyTxOutProof, WalletCreateFundedPsbt, WalletCreateFundedPsbtError, WalletProcessPsbt,
-        WitnessUtxo,
+        RawTransactionOutput, RescanBlockchain, ScriptType, SendRawTransaction, SendToAddress,
+        SetNetworkActive, SetTxFee, SignMessage, SignMessageWithPrivKey, SignRawTransaction,
+        SignRawTransactionError, SoftforkReject, TransactionCategory, UploadTarget,
+        ValidateAddress, ValidateAddressError, VerifyChain, VerifyMessage, VerifyTxOutProof,
+        WalletCreateFundedPsbt, WalletCreateFundedPsbtError, WalletProcessPsbt, WitnessUtxo,
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
@@ -311,7 +310,7 @@ pub use crate::{
     v21::{
         AddPeerAddress, GenerateBlock, GetIndexInfo, GetIndexInfoName, GetNetworkInfo,
         ImportDescriptors, ImportDescriptorsResult, PsbtBumpFee, PsbtBumpFeeError, Send, SendError,
-        UnloadWallet, UpgradeWallet,
+        SendMany, SendManyVerbose, UnloadWallet, UpgradeWallet,
     },
     v22::{
         Banned, EnumerateSigners, GetAddressInfo, GetAddressInfoEmbedded, GetMempoolInfo,

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -210,7 +210,7 @@
 //! | restorewallet                      | version         |                                        |
 //! | send                               | version + model |                                        |
 //! | sendall                            | version + model |                                        |
-//! | sendmany                           | version + model | UNTESTED                               |
+//! | sendmany                           | version + model |                                        |
 //! | sendtoaddress                      | version + model |                                        |
 //! | sethdseed                          | returns nothing |                                        |
 //! | setlabel                           | returns nothing |                                        |
@@ -287,12 +287,11 @@ pub use crate::{
         ListSinceBlockTransaction, ListSinceBlockTransactionError, ListTransactions,
         ListTransactionsItem, ListTransactionsItemError, ListUnspentItemError, ListWallets,
         LoadWallet, LockUnspent, Locked, PruneBlockchain, RawTransactionError, RawTransactionInput,
-        RawTransactionOutput, RescanBlockchain, ScriptType, SendMany, SendRawTransaction,
-        SendToAddress, SetNetworkActive, SetTxFee, SignMessage, SignMessageWithPrivKey,
-        SignRawTransaction, SignRawTransactionError, SoftforkReject, TransactionCategory,
-        UploadTarget, ValidateAddress, ValidateAddressError, VerifyChain, VerifyMessage,
-        VerifyTxOutProof, WalletCreateFundedPsbt, WalletCreateFundedPsbtError, WalletProcessPsbt,
-        WitnessUtxo,
+        RawTransactionOutput, RescanBlockchain, ScriptType, SendRawTransaction, SendToAddress,
+        SetNetworkActive, SetTxFee, SignMessage, SignMessageWithPrivKey, SignRawTransaction,
+        SignRawTransactionError, SoftforkReject, TransactionCategory, UploadTarget,
+        ValidateAddress, ValidateAddressError, VerifyChain, VerifyMessage, VerifyTxOutProof,
+        WalletCreateFundedPsbt, WalletCreateFundedPsbtError, WalletProcessPsbt, WitnessUtxo,
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
@@ -312,7 +311,7 @@ pub use crate::{
     v21::{
         AddPeerAddress, GenerateBlock, GetIndexInfo, GetIndexInfoName, GetNetworkInfo,
         ImportDescriptors, ImportDescriptorsResult, PsbtBumpFee, PsbtBumpFeeError, Send, SendError,
-        UnloadWallet, UpgradeWallet,
+        SendMany, SendManyVerbose, UnloadWallet, UpgradeWallet,
     },
     v22::{
         Banned, EnumerateSigners, GetAddressInfo, GetAddressInfoEmbedded, GetNodeAddresses,

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -211,7 +211,7 @@
 //! | restorewallet                      | version         |                                        |
 //! | send                               | version + model |                                        |
 //! | sendall                            | version + model |                                        |
-//! | sendmany                           | version + model | UNTESTED                               |
+//! | sendmany                           | version + model |                                        |
 //! | sendtoaddress                      | version + model |                                        |
 //! | sethdseed                          | returns nothing |                                        |
 //! | setlabel                           | returns nothing |                                        |
@@ -283,12 +283,11 @@ pub use crate::{
         ListSinceBlockTransaction, ListSinceBlockTransactionError, ListTransactions,
         ListTransactionsItem, ListTransactionsItemError, ListUnspentItemError, ListWallets,
         LockUnspent, Locked, PruneBlockchain, RawTransactionError, RawTransactionInput,
-        RawTransactionOutput, RescanBlockchain, ScriptType, SendMany, SendRawTransaction,
-        SendToAddress, SetNetworkActive, SetTxFee, SignMessage, SignMessageWithPrivKey,
-        SignRawTransaction, SignRawTransactionError, SoftforkReject, TransactionCategory,
-        UploadTarget, ValidateAddress, ValidateAddressError, VerifyChain, VerifyMessage,
-        VerifyTxOutProof, WalletCreateFundedPsbt, WalletCreateFundedPsbtError, WalletProcessPsbt,
-        WitnessUtxo,
+        RawTransactionOutput, RescanBlockchain, ScriptType, SendRawTransaction, SendToAddress,
+        SetNetworkActive, SetTxFee, SignMessage, SignMessageWithPrivKey, SignRawTransaction,
+        SignRawTransactionError, SoftforkReject, TransactionCategory, UploadTarget,
+        ValidateAddress, ValidateAddressError, VerifyChain, VerifyMessage, VerifyTxOutProof,
+        WalletCreateFundedPsbt, WalletCreateFundedPsbtError, WalletProcessPsbt, WitnessUtxo,
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
@@ -307,7 +306,8 @@ pub use crate::{
     v20::GenerateToDescriptor,
     v21::{
         AddPeerAddress, GetIndexInfo, GetIndexInfoName, GetNetworkInfo, ImportDescriptors,
-        ImportDescriptorsResult, PsbtBumpFee, PsbtBumpFeeError, Send, SendError, UpgradeWallet,
+        ImportDescriptorsResult, PsbtBumpFee, PsbtBumpFeeError, Send, SendError, SendMany,
+        SendManyVerbose, UpgradeWallet,
     },
     v22::{
         Banned, EnumerateSigners, GetAddressInfo, GetAddressInfoEmbedded, GetNodeAddresses,

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -219,7 +219,7 @@
 //! | restorewallet                      | version         |                                        |
 //! | send                               | version + model |                                        |
 //! | sendall                            | version + model |                                        |
-//! | sendmany                           | version + model | UNTESTED                               |
+//! | sendmany                           | version + model |                                        |
 //! | sendtoaddress                      | version + model |                                        |
 //! | sethdseed                          | returns nothing |                                        |
 //! | setlabel                           | returns nothing |                                        |
@@ -299,11 +299,11 @@ pub use crate::{
         ListSinceBlockTransactionError, ListTransactions, ListTransactionsItem,
         ListTransactionsItemError, ListUnspentItemError, ListWallets, LockUnspent, Locked,
         PruneBlockchain, RawTransactionError, RawTransactionInput, RawTransactionOutput,
-        RescanBlockchain, ScriptType, SendMany, SendRawTransaction, SendToAddress,
-        SetNetworkActive, SetTxFee, SignMessage, SignMessageWithPrivKey, SignRawTransaction,
-        SignRawTransactionError, SoftforkReject, TransactionCategory, UploadTarget,
-        ValidateAddress, ValidateAddressError, VerifyChain, VerifyMessage, VerifyTxOutProof,
-        WalletCreateFundedPsbt, WalletCreateFundedPsbtError, WitnessUtxo,
+        RescanBlockchain, ScriptType, SendRawTransaction, SendToAddress, SetNetworkActive,
+        SetTxFee, SignMessage, SignMessageWithPrivKey, SignRawTransaction, SignRawTransactionError,
+        SoftforkReject, TransactionCategory, UploadTarget, ValidateAddress, ValidateAddressError,
+        VerifyChain, VerifyMessage, VerifyTxOutProof, WalletCreateFundedPsbt,
+        WalletCreateFundedPsbtError, WitnessUtxo,
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
@@ -321,7 +321,8 @@ pub use crate::{
     v20::GenerateToDescriptor,
     v21::{
         AddPeerAddress, GetIndexInfo, GetIndexInfoName, GetNetworkInfo, ImportDescriptors,
-        ImportDescriptorsResult, PsbtBumpFee, PsbtBumpFeeError, Send, SendError, UpgradeWallet,
+        ImportDescriptorsResult, PsbtBumpFee, PsbtBumpFeeError, Send, SendError, SendMany,
+        SendManyVerbose, UpgradeWallet,
     },
     v22::{
         Banned, EnumerateSigners, GetAddressInfo, GetAddressInfoEmbedded, GetNodeAddresses,

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -219,7 +219,7 @@
 //! | restorewallet                      | version         |                                        |
 //! | send                               | version + model |                                        |
 //! | sendall                            | version + model |                                        |
-//! | sendmany                           | version + model | UNTESTED                               |
+//! | sendmany                           | version + model |                                        |
 //! | sendtoaddress                      | version + model |                                        |
 //! | sethdseed                          | returns nothing |                                        |
 //! | setlabel                           | returns nothing |                                        |
@@ -277,11 +277,11 @@ pub use crate::{
         ListSinceBlockTransactionError, ListTransactions, ListTransactionsItem,
         ListTransactionsItemError, ListUnspentItemError, ListWallets, LockUnspent, Locked,
         PruneBlockchain, RawTransactionError, RawTransactionInput, RawTransactionOutput,
-        RescanBlockchain, ScriptType, SendMany, SendRawTransaction, SendToAddress,
-        SetNetworkActive, SetTxFee, SignMessage, SignMessageWithPrivKey, SignRawTransaction,
-        SignRawTransactionError, SoftforkReject, TransactionCategory, UploadTarget,
-        ValidateAddress, ValidateAddressError, VerifyChain, VerifyMessage, VerifyTxOutProof,
-        WalletCreateFundedPsbt, WalletCreateFundedPsbtError, WitnessUtxo,
+        RescanBlockchain, ScriptType, SendRawTransaction, SendToAddress, SetNetworkActive,
+        SetTxFee, SignMessage, SignMessageWithPrivKey, SignRawTransaction, SignRawTransactionError,
+        SoftforkReject, TransactionCategory, UploadTarget, ValidateAddress, ValidateAddressError,
+        VerifyChain, VerifyMessage, VerifyTxOutProof, WalletCreateFundedPsbt,
+        WalletCreateFundedPsbtError, WitnessUtxo,
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
@@ -299,7 +299,8 @@ pub use crate::{
     v20::GenerateToDescriptor,
     v21::{
         AddPeerAddress, GetIndexInfo, GetIndexInfoName, GetNetworkInfo, ImportDescriptors,
-        ImportDescriptorsResult, PsbtBumpFee, PsbtBumpFeeError, Send, SendError, UpgradeWallet,
+        ImportDescriptorsResult, PsbtBumpFee, PsbtBumpFeeError, Send, SendError, SendMany,
+        SendManyVerbose, UpgradeWallet,
     },
     v22::{
         Banned, EnumerateSigners, GetAddressInfo, GetAddressInfoEmbedded, GetNodeAddresses,

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -221,7 +221,7 @@
 //! | restorewallet                      | version         |                                        |
 //! | send                               | version + model |                                        |
 //! | sendall                            | version + model |                                        |
-//! | sendmany                           | version + model | UNTESTED                               |
+//! | sendmany                           | version + model |                                        |
 //! | sendtoaddress                      | version + model |                                        |
 //! | sethdseed                          | returns nothing |                                        |
 //! | setlabel                           | returns nothing |                                        |
@@ -297,11 +297,11 @@ pub use crate::{
         ListSinceBlockTransactionError, ListTransactions, ListTransactionsItem,
         ListTransactionsItemError, ListUnspentItemError, ListWallets, LockUnspent, Locked,
         PruneBlockchain, RawTransactionError, RawTransactionInput, RawTransactionOutput,
-        RescanBlockchain, ScriptType, SendMany, SendRawTransaction, SendToAddress,
-        SetNetworkActive, SetTxFee, SignMessage, SignMessageWithPrivKey, SignRawTransaction,
-        SignRawTransactionError, SoftforkReject, TransactionCategory, UploadTarget,
-        ValidateAddress, ValidateAddressError, VerifyChain, VerifyMessage, VerifyTxOutProof,
-        WalletCreateFundedPsbt, WalletCreateFundedPsbtError, WitnessUtxo,
+        RescanBlockchain, ScriptType, SendRawTransaction, SendToAddress, SetNetworkActive,
+        SetTxFee, SignMessage, SignMessageWithPrivKey, SignRawTransaction, SignRawTransactionError,
+        SoftforkReject, TransactionCategory, UploadTarget, ValidateAddress, ValidateAddressError,
+        VerifyChain, VerifyMessage, VerifyTxOutProof, WalletCreateFundedPsbt,
+        WalletCreateFundedPsbtError, WitnessUtxo,
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
@@ -319,7 +319,7 @@ pub use crate::{
     v20::GenerateToDescriptor,
     v21::{
         AddPeerAddress, GetIndexInfo, GetIndexInfoName, ImportDescriptors, ImportDescriptorsResult,
-        PsbtBumpFee, PsbtBumpFeeError, Send, SendError, UpgradeWallet,
+        PsbtBumpFee, PsbtBumpFeeError, Send, SendError, SendMany, SendManyVerbose, UpgradeWallet,
     },
     v22::{
         Banned, EnumerateSigners, GetNodeAddresses, ListBanned, NodeAddress, ScriptPubkey,

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -222,7 +222,7 @@
 //! | restorewallet                      | version         |                                        |
 //! | send                               | version + model |                                        |
 //! | sendall                            | version + model |                                        |
-//! | sendmany                           | version + model | UNTESTED                               |
+//! | sendmany                           | version + model |                                        |
 //! | sendtoaddress                      | version + model |                                        |
 //! | sethdseed                          | returns nothing |                                        |
 //! | setlabel                           | returns nothing |                                        |
@@ -294,11 +294,11 @@ pub use crate::{
         ListSinceBlockTransactionError, ListTransactions, ListTransactionsItem,
         ListTransactionsItemError, ListUnspentItemError, ListWallets, LockUnspent, Locked,
         PruneBlockchain, RawTransactionError, RawTransactionInput, RawTransactionOutput,
-        RescanBlockchain, ScriptType, SendMany, SendRawTransaction, SendToAddress,
-        SetNetworkActive, SetTxFee, SignMessage, SignMessageWithPrivKey, SignRawTransaction,
-        SignRawTransactionError, TransactionCategory, UploadTarget, ValidateAddress,
-        ValidateAddressError, VerifyChain, VerifyMessage, VerifyTxOutProof, WalletCreateFundedPsbt,
-        WalletCreateFundedPsbtError, WitnessUtxo,
+        RescanBlockchain, ScriptType, SendRawTransaction, SendToAddress, SetNetworkActive,
+        SetTxFee, SignMessage, SignMessageWithPrivKey, SignRawTransaction, SignRawTransactionError,
+        TransactionCategory, UploadTarget, ValidateAddress, ValidateAddressError, VerifyChain,
+        VerifyMessage, VerifyTxOutProof, WalletCreateFundedPsbt, WalletCreateFundedPsbtError,
+        WitnessUtxo,
     },
     v18::{
         ActiveCommand, AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
@@ -316,7 +316,7 @@ pub use crate::{
     v20::GenerateToDescriptor,
     v21::{
         AddPeerAddress, GetIndexInfo, GetIndexInfoName, ImportDescriptors, ImportDescriptorsResult,
-        PsbtBumpFee, PsbtBumpFeeError, Send, SendError, UpgradeWallet,
+        PsbtBumpFee, PsbtBumpFeeError, Send, SendError, SendMany, SendManyVerbose, UpgradeWallet,
     },
     v22::{
         Banned, EnumerateSigners, GetNodeAddresses, ListBanned, NodeAddress, ScriptPubkey,


### PR DESCRIPTION
`sendmany` is implemented for v17 but untested and it has a new verbose return type in v18.

The client macro sends the amount in sats but the RPC takes BTC.

- Add the verbose struct to v18 and model.
- Update the client macro.
- Add a verbose client macro, test and update the types table.