### PR TITLE
Test `enumeratesigners`

### DIFF
--- a/integration_test/tests/signer.rs
+++ b/integration_test/tests/signer.rs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Tests for methods found under the `== Signer ==` section of the API docs.
+
+#![allow(non_snake_case)] // Test names intentionally use double underscore.
+#![allow(unused_imports)] // Because of feature gated tests.
+
+use integration_test::{Node, NodeExt as _, Wallet};
+use node::{mtype, Input, Output};
+use node::vtype::*;             // All the version specific types.
+
+#[test]
+#[cfg(unix)]
+#[cfg(not(feature = "v21_and_below"))]
+fn signer__enumerate_signers() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let script_path = integration_test::random_tmp_file();
+    // `script_body` is minimal JSON array expected by `enumeratesigners` RPC: an array
+    // of signer objects with at least a fingerprint and name. Using a hard-coded
+    // dummy signer (fingerprint "deadbeef").
+    let script_body = "#!/bin/sh\necho '[{\"fingerprint\":\"deadbeef\",\"name\":\"TestSigner\"}]'\n";
+    std::fs::write(&script_path, script_body).expect("write signer script");
+
+    // Script needs to be executable so bitcoind can invoke it via the -signer arg.
+    std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))
+    .expect("chmod");
+
+    let signer_arg = format!("-signer={}", script_path.to_str().unwrap());
+    let node = Node::with_wallet(Wallet::None, &[&signer_arg]);
+    let json: EnumerateSigners = node.client.enumerate_signers().expect("enumeratesigners");
+    let first_tx = json.signers.first().expect("no signers found");
+
+    assert_eq!(first_tx.fingerprint, "deadbeef");
+}

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -144,7 +144,7 @@
 //!
 //! | JSON-RPC Method Name               | Returns         | Notes                                  |
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
-//! | enumeratesigners                   | version         | UNTESTED                               |
+//! | enumeratesigners                   | version         |                                        |
 //!
 //! </details>
 //!

--- a/types/src/v22/signer.rs
+++ b/types/src/v22/signer.rs
@@ -11,15 +11,17 @@ use serde::{Deserialize, Serialize};
 /// > Returns a list of external signers from -signer.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct EnumerateSigners(pub Vec<Signers>);
+pub struct EnumerateSigners {
+    /// List of external signers.
+    pub signers: Vec<Signers>,
+}
 
 /// An item from the list returned by the JSON-RPC method `enumeratesigners`
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Signers {
     /// Master key fingerprint.
-    pub hex: String,
+    pub fingerprint: String,
     /// Device name.
-    #[serde(rename = "str")]
-    pub device_name: String,
+    pub name: String,
 }

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -135,7 +135,7 @@
 //!
 //! | JSON-RPC Method Name               | Returns         | Notes                                  |
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
-//! | enumeratesigners                   | version         | UNTESTED                               |
+//! | enumeratesigners                   | version         |                                        |
 //!
 //! </details>
 //!

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -136,7 +136,7 @@
 //!
 //! | JSON-RPC Method Name               | Returns         | Notes                                  |
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
-//! | enumeratesigners                   | version         | UNTESTED                               |
+//! | enumeratesigners                   | version         |                                        |
 //!
 //! </details>
 //!

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -137,7 +137,7 @@
 //!
 //! | JSON-RPC Method Name               | Returns         | Notes                                  |
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
-//! | enumeratesigners                   | version         | UNTESTED                               |
+//! | enumeratesigners                   | version         |                                        |
 //!
 //! </details>
 //!

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -145,7 +145,7 @@
 //!
 //! | JSON-RPC Method Name               | Returns         | Notes                                  |
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
-//! | enumeratesigners                   | version         | UNTESTED                               |
+//! | enumeratesigners                   | version         |                                        |
 //!
 //! </details>
 //!

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -145,7 +145,7 @@
 //!
 //! | JSON-RPC Method Name               | Returns         | Notes                                  |
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
-//! | enumeratesigners                   | version         | UNTESTED                               |
+//! | enumeratesigners                   | version         |                                        |
 //!
 //! </details>
 //!

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -145,7 +145,7 @@
 //!
 //! | JSON-RPC Method Name               | Returns         | Notes                                  |
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
-//! | enumeratesigners                   | version         | UNTESTED                               |
+//! | enumeratesigners                   | version         |                                        |
 //!
 //! </details>
 //!

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -146,7 +146,7 @@
 //!
 //! | JSON-RPC Method Name               | Returns         | Notes                                  |
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
-//! | enumeratesigners                   | version         | UNTESTED                               |
+//! | enumeratesigners                   | version         |                                        |
 //!
 //! </details>
 //!


### PR DESCRIPTION
`enumeratesigners` is implemented but not tested. Also the v22 help is not correct, it gives incorrect field names which were implemented in the struct. They are correct in v23 and onwards help.

- Fix the v22 struct names.
- Add a test and update the types table.