### PR TITLE
Improve `types` struct and enum rustdocs

### DIFF
--- a/integration_test/tests/network.rs
+++ b/integration_test/tests/network.rs
@@ -81,7 +81,7 @@ fn network__get_network_info__modelled() {
     let model: Result<mtype::GetNetworkInfo, GetNetworkInfoError> = json.into_model();
     model.unwrap();
 
-    // Server version is returned as part of the getnetworkinfo method.
+    // Server version is part of the getnetworkinfo method.
     node.client.check_expected_server_version().expect("unexpected version");
 }
 

--- a/types/src/model/blockchain.rs
+++ b/types/src/model/blockchain.rs
@@ -135,7 +135,7 @@ pub struct GetBlockchainInfo {
     pub warnings: Vec<String>,
 }
 
-/// Status of softfork.
+/// Softfork status. Part of `getblockchaininfo`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Softfork {
@@ -150,7 +150,7 @@ pub struct Softfork {
     pub active: bool,
 }
 
-/// The softfork type: one of "buried", "bip9".
+/// The softfork type. Part of `getblockchaininfo`.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum SoftforkType {
@@ -164,7 +164,7 @@ pub enum SoftforkType {
     Bip9,
 }
 
-/// Status of BIP-9 softforks.
+/// BIP-9 softfork info. Part of `getblockchaininfo`.
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Bip9SoftforkInfo {
@@ -184,7 +184,7 @@ pub struct Bip9SoftforkInfo {
     pub statistics: Option<Bip9SoftforkStatistics>,
 }
 
-/// BIP-9 softfork status: one of "defined", "started", "locked_in", "active", "failed".
+/// BIP-9 softfork status. Part of `getblockchaininfo`.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 pub enum Bip9SoftforkStatus {
     /// BIP-9 softfork status "defined".
@@ -199,7 +199,7 @@ pub enum Bip9SoftforkStatus {
     Failed,
 }
 
-/// Statistics for a BIP-9 softfork.
+/// BIP-9 softfork statistics. Part of `getblockchaininfo`.
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Bip9SoftforkStatistics {
@@ -356,7 +356,7 @@ pub struct GetChainStates {
     pub chain_states: Vec<ChainState>,
 }
 
-/// A single chainstate returned as part of `getchainstates`.
+/// A single chainstate. Part of `getchainstates`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ChainState {
@@ -401,7 +401,7 @@ pub struct ChainTips {
     pub status: ChainTipsStatus,
 }
 
-/// The `status` field from an individual list item from the result of JSON-RPC method `getchaintips`.
+/// Chain tips status. Part of `getchaintips`.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum ChainTipsStatus {
@@ -451,7 +451,7 @@ pub struct GetDeploymentInfo {
     pub deployments: std::collections::BTreeMap<String, DeploymentInfo>,
 }
 
-/// Deployment info. Returned as part of `getdeploymentinfo`.
+/// Deployment info. Part of `getdeploymentinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DeploymentInfo {
@@ -465,7 +465,7 @@ pub struct DeploymentInfo {
     pub bip9: Option<Bip9Info>,
 }
 
-/// Status of bip9 softforks. Returned as part of `getdeploymentinfo`.
+/// Status of bip9 softforks. Part of `getdeploymentinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Bip9Info {
@@ -489,7 +489,7 @@ pub struct Bip9Info {
     pub signalling: Option<String>,
 }
 
-/// Numeric statistics about signalling for a softfork. Returned as part of `getdeploymentinfo`.
+/// Numeric statistics about signalling for a softfork. Part of `getdeploymentinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Bip9Statistics {
@@ -535,7 +535,7 @@ pub struct GetMempoolDescendantsVerbose(pub BTreeMap<Txid, MempoolEntry>);
 #[serde(deny_unknown_fields)]
 pub struct GetMempoolEntry(pub MempoolEntry);
 
-/// A relative (ancestor or descendant) transaction of a transaction in the mempool.
+/// Mempool data. Part of `getmempoolentry`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MempoolEntry {
@@ -565,7 +565,7 @@ pub struct MempoolEntry {
     pub ancestor_size: u32,
     /// Hash of serialized transaction, including witness data.
     pub wtxid: Wtxid,
-    /// (No docs in Core v0.17.)
+    /// (No docs in Core v0.17). Part of `getmempoolentry`.
     pub fees: MempoolEntryFees,
     /// Unconfirmed transactions used as inputs for this transaction (parent transaction id).
     pub depends: Vec<Txid>,
@@ -578,7 +578,7 @@ pub struct MempoolEntry {
     pub unbroadcast: Option<bool>,
 }
 
-/// (No docs in Core v0.17.)
+/// Fee object. Part of `getmempoolentry`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MempoolEntryFees {
@@ -686,7 +686,7 @@ pub struct GetTxOutSetInfo {
 #[serde(deny_unknown_fields)]
 pub struct GetTxSpendingPrevout(pub Vec<GetTxSpendingPrevoutItem>);
 
-/// An individual result item from `gettxspendingprevout`.
+/// A transaction item. Part of `gettxspendingprevout`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GetTxSpendingPrevoutItem {
@@ -709,7 +709,7 @@ pub struct GetDescriptorActivity {
     pub activity: Vec<ActivityEntry>,
 }
 
-/// Enum representing either a spend or receive activity entry using model types.
+/// A spend or receive activity entry. Part of `getdescriptoractivity`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub enum ActivityEntry {
     /// The spend activity using `model::SpendActivity`.
@@ -718,7 +718,7 @@ pub enum ActivityEntry {
     Receive(ReceiveActivity),
 }
 
-/// Models a 'spend' activity event with strongly typed fields.
+/// Models a 'spend' activity event. Part of `getdescriptoractivity`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SpendActivity {
@@ -740,7 +740,7 @@ pub struct SpendActivity {
     pub prevout_spk: ScriptPubkey,
 }
 
-/// Models a 'receive' activity event with strongly typed fields.
+/// Models a 'receive' activity event. Part of `getdescriptoractivity`
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReceiveActivity {
@@ -772,7 +772,7 @@ pub struct LoadTxOutSet {
     pub path: String,
 }
 
-/// Models the result of the JSON-RPC method `scanblocks` start.
+/// Models the result of the JSON-RPC method `scanblocks` whan `action = start`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct ScanBlocksStart {
     /// The height we started the scan from

--- a/types/src/model/mining.rs
+++ b/types/src/model/mining.rs
@@ -70,9 +70,7 @@ pub struct GetBlockTemplate {
     pub default_witness_commitment: Option<String>,
 }
 
-/// Contents of non-coinbase transactions that should be included in the next block.
-///
-/// Returned as part of `getblocktemplate`.
+/// Non-coinbase transaction contents. Part of `getblocktemplate`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct BlockTemplateTransaction {
@@ -132,7 +130,7 @@ pub struct GetMiningInfo {
     pub warnings: Vec<String>,
 }
 
-/// Represents the `next` block information within the GetMiningInfo result.
+/// Represents the `next` block information. Part of `getmininginfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct NextBlockInfo {
@@ -151,6 +149,7 @@ pub struct NextBlockInfo {
 #[serde(deny_unknown_fields)]
 pub struct GetPrioritisedTransactions(pub BTreeMap<Txid, PrioritisedTransaction>);
 
+/// An individual prioritised transaction. Part of `getprioritisedtransactions`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PrioritisedTransaction {

--- a/types/src/model/network.rs
+++ b/types/src/model/network.rs
@@ -46,7 +46,7 @@ pub struct GetNetworkInfo {
     pub warnings: Vec<String>,
 }
 
-/// Part of the result of the JSON-RPC method `getnetworkinfo` (information per network).
+/// Information per network. Part of `getnetworkinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GetNetworkInfoNetwork {
@@ -62,7 +62,7 @@ pub struct GetNetworkInfoNetwork {
     pub proxy_randomize_credentials: bool,
 }
 
-/// Part of the result of the JSON-RPC method `getnetworkinfo` (local address info).
+/// Local address info. Part of `getnetworkinfo`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GetNetworkInfoAddress {

--- a/types/src/model/raw_transactions.rs
+++ b/types/src/model/raw_transactions.rs
@@ -30,7 +30,7 @@ pub struct AnalyzePsbt {
     pub next: String,
 }
 
-/// Represents an input in a PSBT operation.
+/// An input in a PSBT operation. Part of `analyzepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AnalyzePsbtInput {
@@ -44,7 +44,7 @@ pub struct AnalyzePsbtInput {
     pub next: Option<String>,
 }
 
-/// Represents missing elements required to complete an input.
+/// Missing elements required to complete an input. Part of `analyzepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AnalyzePsbtInputMissing {
@@ -202,7 +202,7 @@ pub struct SignRawTransaction {
     pub errors: Vec<SignFail>,
 }
 
-/// Represents a script verification error.
+/// A script verification error. Part of `signrawtransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SignFail {
@@ -272,7 +272,7 @@ pub struct TestMempoolAccept {
     pub results: Vec<MempoolAcceptance>,
 }
 
-/// Models a single mempool acceptance test result. Returned as part of `testmempoolaccept`.
+/// Models a single mempool acceptance test result. Part of `testmempoolaccept`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MempoolAcceptance {
@@ -292,7 +292,7 @@ pub struct MempoolAcceptance {
     pub reject_details: Option<String>,
 }
 
-/// Models the fees field. Returned as part of `testmempoolaccept`.
+/// Models the fees field. Part of `testmempoolaccept`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MempoolAcceptanceFees {

--- a/types/src/model/wallet.rs
+++ b/types/src/model/wallet.rs
@@ -16,7 +16,7 @@ use bitcoin::{
 };
 use serde::{Deserialize, Serialize};
 
-/// The purpose of an address.
+/// The purpose of an address. Part of `getaddressesbylabel`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub enum AddressPurpose {
     /// A send-to address.
@@ -25,7 +25,7 @@ pub enum AddressPurpose {
     Receive,
 }
 
-/// The category of a transaction.
+/// The category of a transaction. Part of `gettransaction`, `listsinceblock` and `listtransactions`.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 pub enum TransactionCategory {
     /// Transactions sent.
@@ -40,7 +40,8 @@ pub enum TransactionCategory {
     Orphan,
 }
 
-/// Whether this transaction can be RBF'ed.
+/// Whether this transaction can be RBF'ed. Part of `gettransaction`, `listsinceblock` and
+/// `listtransactions`.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 pub enum Bip125Replaceable {
     /// Yes, can be replaced due to BIP-125 (RBF).
@@ -101,7 +102,7 @@ pub struct DumpPrivKey(pub PrivateKey);
 #[serde(deny_unknown_fields)]
 pub struct GetAddressesByLabel(pub BTreeMap<Address<NetworkUnchecked>, AddressInformation>);
 
-/// Information about address.
+/// Address information. Part of `getaddressesbylabel`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AddressInformation {
@@ -169,7 +170,7 @@ pub struct GetAddressInfo {
     pub labels: Vec<String>,
 }
 
-/// An address script type.
+/// The script field. Part of `getaddressinfo` and `getaddressinfoembedded`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub enum ScriptType {
     /// Non-standard output script type.
@@ -192,7 +193,7 @@ pub enum ScriptType {
     WitnessUnknown,
 }
 
-/// The `embedded` field of `GetAddressInfo`.
+/// The `embedded` address info field. Part of `getaddressinfo`.
 ///
 /// It includes all getaddressinfo output fields for the embedded address, excluding metadata
 /// ("timestamp", "hdkeypath", "hdseedid") and relation to the wallet ("ismine", "iswatchonly",
@@ -261,7 +262,7 @@ pub struct GetBalances {
     pub last_processed_block: Option<LastProcessedBlock>,
 }
 
-/// Balances from outputs that the wallet can sign.
+/// Balances from outputs that the wallet can sign. Part of `getbalances`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GetBalancesMine {
@@ -277,7 +278,7 @@ pub struct GetBalancesMine {
     pub used: Option<Amount>,
 }
 
-/// Hash and height of the block this information was generated on.
+/// Hash and height of the block this information was generated on. Part of `getbalances`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GetBalancesWatchOnly {
@@ -294,7 +295,7 @@ pub struct GetBalancesWatchOnly {
 #[serde(deny_unknown_fields)]
 pub struct GetHdKeys(pub Vec<HdKey>);
 
-/// An HD key entry returned by `gethdkeys`.
+/// An HD key entry. Part of `gethdkeys`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct HdKey {
@@ -308,7 +309,7 @@ pub struct HdKey {
     pub descriptors: Vec<HdKeyDescriptor>,
 }
 
-/// Descriptor object used in `gethdkeys` result.
+/// Descriptor object. Part of `gethdkeys`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct HdKeyDescriptor {
@@ -399,7 +400,7 @@ pub struct GetTransaction {
     pub tx: Transaction,
 }
 
-/// Part of the `GetTransaction`.
+/// Transaction detail. Part of the `gettransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GetTransactionDetail {
@@ -432,7 +433,7 @@ pub struct GetTransactionDetail {
     pub parent_descriptors: Option<Vec<String>>,
 }
 
-/// Part of the `GetTransaction`.
+/// Last processed block item. Part of of `gettransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LastProcessedBlock {
@@ -497,7 +498,7 @@ pub struct GetWalletInfo {
     pub last_processed_block: Option<LastProcessedBlock>,
 }
 
-/// Models the `scanning` field of `getwalletinfo` (v19+). When not scanning Core returns `false`.
+/// Current scanning details. Part of `getwalletinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum GetWalletInfoScanning {
@@ -515,7 +516,7 @@ pub enum GetWalletInfoScanning {
 #[serde(deny_unknown_fields)]
 pub struct ListAddressGroupings(pub Vec<Vec<ListAddressGroupingsItem>>);
 
-/// List item type returned as part of `listaddressgroupings`.
+/// List address item. Part of `listaddressgroupings`.
 // FIXME: The Core docs seem wrong, not sure what shape this should be?
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -533,7 +534,7 @@ pub struct ListAddressGroupingsItem {
 #[serde(deny_unknown_fields)]
 pub struct ListLockUnspent(pub Vec<ListLockUnspentItem>);
 
-/// List item returned as part of of `listlockunspent`.
+/// List lock unspent item. Part of of `listlockunspent`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ListLockUnspentItem {
@@ -548,7 +549,7 @@ pub struct ListLockUnspentItem {
 #[serde(deny_unknown_fields)]
 pub struct ListReceivedByAddress(pub Vec<ListReceivedByAddressItem>);
 
-/// List item returned as part of of `listreceivedbyaddress`.
+/// List received by address item. Part of of `listreceivedbyaddress`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ListReceivedByAddressItem {
@@ -571,7 +572,7 @@ pub struct ListReceivedByAddressItem {
 #[serde(deny_unknown_fields)]
 pub struct ListReceivedByLabel(pub Vec<ListReceivedByLabelItem>);
 
-/// Item returned as part of `listreceivedbylabel`.
+/// List received by label item. Part of of `listreceivedbyaddress`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ListReceivedByLabelItem {
@@ -604,7 +605,7 @@ pub struct ListSinceBlock {
     pub last_block: BlockHash,
 }
 
-/// Transaction item, part of `listsinceblock` and `listtransactions`.
+/// Transaction item. Part of `listsinceblock` and `listtransactions`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TransactionItem {
@@ -696,7 +697,7 @@ pub struct ListTransactions(pub Vec<TransactionItem>);
 #[serde(deny_unknown_fields)]
 pub struct ListUnspent(pub Vec<ListUnspentItem>);
 
-/// Unspent transaction output, returned as part of `listunspent`.
+/// Unspent transaction output. Part of `listunspent`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ListUnspentItem {
@@ -847,6 +848,7 @@ pub struct UnloadWallet {
     pub warnings: Vec<String>,
 }
 
+/// Models the result of JSON-RPC method `walletcreatefundedpsbt`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct WalletCreateFundedPsbt {

--- a/types/src/psbt/mod.rs
+++ b/types/src/psbt/mod.rs
@@ -19,7 +19,7 @@ use crate::{ScriptPubkey, ScriptSig};
 
 /// Represents a bitcoin transaction.
 ///
-/// Returned as part of `decoderawtransaction` and `decodepsbt`.
+/// Part of `decoderawtransaction` and `decodepsbt`.
 // This JSON data can be encapsulated by a `bitcoin::Transaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -163,7 +163,7 @@ impl WitnessUtxo {
     }
 }
 
-/// A script returned as part of a PSBT input or output.
+/// A script part of a PSBT input or output.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PsbtScript {

--- a/types/src/v17/blockchain/mod.rs
+++ b/types/src/v17/blockchain/mod.rs
@@ -146,7 +146,7 @@ pub struct GetBlockchainInfo {
     pub warnings: String,
 }
 
-/// Status of softfork.
+/// Softfork status. Part of `getblockchaininfo`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Softfork {
@@ -158,7 +158,7 @@ pub struct Softfork {
     pub reject: SoftforkReject,
 }
 
-/// Progress toward rejecting pre-softfork blocks.
+/// Progress toward rejecting pre-softfork blocks. Part of `getblockchaininfo`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SoftforkReject {
@@ -166,7 +166,7 @@ pub struct SoftforkReject {
     pub status: bool,
 }
 
-/// Status of BIP-9 softforksin progress.
+/// Status of BIP-9 softforks in progress. Part of `getblockchaininfo`.
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Bip9Softfork {
@@ -183,7 +183,7 @@ pub struct Bip9Softfork {
     pub since: i64,
 }
 
-/// BIP-9 softfork status: one of "defined", "started", "locked_in", "active", "failed".
+/// BIP-9 softfork status. Part of `getblockchaininfo`.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Bip9SoftforkStatus {
@@ -384,7 +384,7 @@ pub struct GetBlockStats {
 #[serde(deny_unknown_fields)]
 pub struct GetChainTips(pub Vec<ChainTips>);
 
-/// An individual list item from the result of JSON-RPC method `getchaintips`.
+/// Chain tip item. Part of `getchaintips`.
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ChainTips {
@@ -399,7 +399,7 @@ pub struct ChainTips {
     pub status: ChainTipsStatus,
 }
 
-/// The `status` field from an individual list item from the result of JSON-RPC method `getchaintips`.
+/// Chain tip status. Part of `getchaintips`.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum ChainTipsStatus {
@@ -503,7 +503,7 @@ pub struct GetMempoolDescendantsVerbose(pub BTreeMap<String, MempoolEntry>);
 #[serde(deny_unknown_fields)]
 pub struct GetMempoolEntry(pub MempoolEntry);
 
-/// A relative (ancestor or descendant) transaction of a transaction in the mempool.
+/// Mempool data. Part of `getmempoolentry`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MempoolEntry {
@@ -549,7 +549,7 @@ pub struct MempoolEntry {
     pub spent_by: Vec<String>,
 }
 
-/// (No docs in Core v0.17.)
+/// Fee object. Part of `getmempoolentry`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MempoolEntryFees {

--- a/types/src/v17/control.rs
+++ b/types/src/v17/control.rs
@@ -26,7 +26,7 @@ use serde::{Deserialize, Serialize};
 #[serde(deny_unknown_fields)]
 pub struct GetMemoryInfoStats(pub BTreeMap<String, Locked>);
 
-/// Information about locked memory manager.
+/// Information about locked memory manager. Part of `getmemoryinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Locked {

--- a/types/src/v17/mining/mod.rs
+++ b/types/src/v17/mining/mod.rs
@@ -111,9 +111,7 @@ pub struct GetBlockTemplate {
     pub default_witness_commitment: Option<String>,
 }
 
-/// Contents of non-coinbase transactions that should be included in the next block.
-///
-/// Returned as part of `getblocktemplate`.
+/// Transaction contents. Part of `getblocktemplate`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct BlockTemplateTransaction {

--- a/types/src/v17/network/mod.rs
+++ b/types/src/v17/network/mod.rs
@@ -27,7 +27,7 @@ pub use self::error::*;
 #[serde(deny_unknown_fields)]
 pub struct GetAddedNodeInfo(pub Vec<AddedNode>);
 
-/// An item from the list returned by the JSON-RPC method `getaddednodeinfo`.
+/// An added node item. Part of `getaddednodeinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AddedNode {
@@ -40,7 +40,7 @@ pub struct AddedNode {
     pub addresses: Vec<AddedNodeAddress>,
 }
 
-/// An address returned as part of the JSON-RPC method `getaddednodeinfo`.
+/// An added node address item. Part of `getaddednodeinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AddedNodeAddress {
@@ -82,7 +82,7 @@ pub struct GetNetTotals {
     pub upload_target: UploadTarget,
 }
 
-/// The `upload_target` field from the result of JSON-RPC method `getnettotals`.
+/// The upload target totals. Part of `getnettotals`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct UploadTarget {
@@ -144,7 +144,7 @@ pub struct GetNetworkInfo {
     pub warnings: String,
 }
 
-/// Part of the result of the JSON-RPC method `getnetworkinfo` (information per network).
+/// Information per network. Part of `getnetworkinfo`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GetNetworkInfoNetwork {
@@ -160,7 +160,7 @@ pub struct GetNetworkInfoNetwork {
     pub proxy_randomize_credentials: bool,
 }
 
-/// Part of the result of the JSON-RPC method `getnetworkinfo` (local address info).
+/// Local address info. Part of `getnetworkinfo`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GetNetworkInfoAddress {
@@ -181,7 +181,7 @@ pub struct GetNetworkInfoAddress {
 #[serde(deny_unknown_fields)]
 pub struct GetPeerInfo(pub Vec<PeerInfo>);
 
-/// An item from the list returned by the JSON-RPC method `getpeerinfo`.
+/// A peer info item. Part of `getpeerinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PeerInfo {
@@ -269,7 +269,7 @@ pub struct PeerInfo {
 #[serde(deny_unknown_fields)]
 pub struct ListBanned(pub Vec<Banned>);
 
-/// An item from the list returned by the JSON-RPC method `listbanned`.
+/// An banned item. Part of `listbanned`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Banned {

--- a/types/src/v17/raw_transactions/mod.rs
+++ b/types/src/v17/raw_transactions/mod.rs
@@ -146,7 +146,7 @@ pub struct DecodePsbt {
     pub fee: Option<u64>,
 }
 
-/// An input in a partially signed Bitcoin transaction.
+/// An input in a partially signed Bitcoin transaction. Part of `decodepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PsbtInput {
@@ -175,7 +175,7 @@ pub struct PsbtInput {
     pub unknown: Option<HashMap<String, String>>,
 }
 
-/// An output in a partially signed Bitcoin transaction.
+/// An output in a partially signed Bitcoin transaction. Part of `decodepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PsbtOutput {
@@ -234,6 +234,8 @@ pub struct DecodeScript {
     pub p2sh_segwit: Option<String>,
 }
 
+/// Segwit data. Part of `decodescript`.
+//
 /// Seemingly undocumented data returned in the `segwit` field of `DecodeScript`.
 // This seems to be the same as `DecodeScript` except the `p2sh` field is called `p2sh-segwit`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
@@ -418,7 +420,7 @@ pub struct SignRawTransaction {
     pub errors: Option<Vec<SignFail>>,
 }
 
-/// Represents a script verification error.
+/// A script verification error. Part of `signrawtransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SignFail {
@@ -453,7 +455,7 @@ pub struct SignFail {
 #[serde(deny_unknown_fields)]
 pub struct TestMempoolAccept(pub Vec<MempoolAcceptance>);
 
-/// Represents a single mempool acceptance test result, returned as part of `testmempoolaccept`.
+/// A single mempool acceptance test result. Part of `testmempoolaccept`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MempoolAcceptance {

--- a/types/src/v17/wallet/mod.rs
+++ b/types/src/v17/wallet/mod.rs
@@ -17,14 +17,7 @@ use serde::{Deserialize, Serialize};
 // TODO: Remove wildcard, use explicit types.
 pub use self::error::*;
 
-// # Notes
-//
-// The following structs are very similar but have slightly different fields and docs.
-// - GetTransaction
-// - TransactionItem
-// - TransactionItem
-
-/// Returned as part of `getaddressesbylabel` and `getaddressinfo`.
+/// The purpose of an address. Part of `getaddressesbylabel`.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum AddressPurpose {
@@ -34,7 +27,7 @@ pub enum AddressPurpose {
     Receive,
 }
 
-/// The category of a transaction.
+/// The category of a transaction. Part of `gettransaction`, `listsinceblock` and `listtransactions`.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum TransactionCategory {
@@ -50,7 +43,8 @@ pub enum TransactionCategory {
     Orphan,
 }
 
-/// Whether this transaction can be RBF'ed.
+/// Whether this transaction can be RBF'ed. Part of `gettransaction`, `listsinceblock` and
+/// `listtransactions`.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Bip125Replaceable {
@@ -215,7 +209,7 @@ pub struct EncryptWallet(pub String);
 #[serde(deny_unknown_fields)]
 pub struct GetAddressesByLabel(pub BTreeMap<String, AddressInformation>);
 
-/// Returned as part of `getaddressesbylabel`.
+/// Address information. Part of `getaddressesbylabel`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AddressInformation {
@@ -293,7 +287,7 @@ pub struct GetAddressInfo {
     pub labels: Vec<GetAddressInfoLabel>,
 }
 
-/// The `script` field of `GetAddressInfo` (and `GetAddressInfoEmbedded`).
+/// The script field. Part of `getaddressinfo` and `getaddressinfoembedded`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub enum ScriptType {
     /// Non-standard output script type.
@@ -325,7 +319,7 @@ pub enum ScriptType {
     WitnessUnknown,
 }
 
-/// The `embedded` field of `GetAddressInfo`.
+/// The `embedded` address info field. Part of `getaddressinfo`.
 ///
 /// It includes all getaddressinfo output fields for the embedded address, excluding metadata
 /// ("timestamp", "hdkeypath", "hdseedid") and relation to the wallet ("ismine", "iswatchonly",
@@ -368,7 +362,7 @@ pub struct GetAddressInfoEmbedded {
     pub labels: Option<Vec<GetAddressInfoLabel>>,
 }
 
-/// The `label` field of `GetAddressInfo` (and `GetAddressInfoEmbedded`).
+/// Address label field. Part of `getaddressinfo` and `getaddressinfoembedded`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GetAddressInfoLabel {
@@ -482,6 +476,7 @@ pub struct GetTransaction {
     pub hex: String,
 }
 
+/// Transaction detail. Part of the `gettransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GetTransactionDetail {
@@ -580,7 +575,7 @@ pub struct GetWalletInfo {
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ImportMulti(pub Vec<ImportMultiEntry>);
 
-/// Represents a single entry in the importmulti result array.
+/// A single import multi entry. Part of `importmulti`.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ImportMultiEntry {
     /// The success.
@@ -589,7 +584,7 @@ pub struct ImportMultiEntry {
     pub error: Option<JsonRpcError>,
 }
 
-/// Represents the error object in a JSON-RPC error response.
+/// A JSON-RPC error response. Part of `importmulti`.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct JsonRpcError {
     /// The error code.
@@ -611,7 +606,7 @@ pub struct JsonRpcError {
 #[serde(deny_unknown_fields)]
 pub struct ListAddressGroupings(pub Vec<Vec<ListAddressGroupingsItem>>);
 
-/// List item type returned as part of `listaddressgroupings`.
+/// List item type. Part of `listaddressgroupings`.
 ///
 /// Core encodes items as a JSON array with either 2 elements `[address, amount]` when there is no
 /// label or 3 elements `[address, amount, label]` when a label is present. Represent this as an
@@ -644,7 +639,7 @@ pub struct ListLabels(pub Vec<String>);
 #[serde(deny_unknown_fields)]
 pub struct ListLockUnspent(pub Vec<ListLockUnspentItem>);
 
-/// List item returned as part of of `listlockunspent`.
+/// List lock unspent item. Part of of `listlockunspent`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ListLockUnspentItem {
@@ -663,7 +658,7 @@ pub struct ListLockUnspentItem {
 #[serde(deny_unknown_fields)]
 pub struct ListReceivedByAddress(pub Vec<ListReceivedByAddressItem>);
 
-/// List item returned as part of of `listreceivedByaddress`.
+/// List received by address item. Part of of `listreceivedbyaddress`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ListReceivedByAddressItem {
@@ -710,7 +705,7 @@ pub struct ListSinceBlock {
     pub last_block: String,
 }
 
-/// Transaction item returned as part of `listsinceblock` and `listtransactions`.
+/// Transaction item. Part of `listsinceblock` and `listtransactions`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TransactionItem {
@@ -808,7 +803,7 @@ pub struct ListTransactions(pub Vec<TransactionItem>);
 #[serde(deny_unknown_fields)]
 pub struct ListUnspent(pub Vec<ListUnspentItem>);
 
-/// Unspent transaction output, returned as part of `listunspent`.
+/// Unspent transaction output. Part of `listunspent`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ListUnspentItem {

--- a/types/src/v18/blockchain/mod.rs
+++ b/types/src/v18/blockchain/mod.rs
@@ -62,7 +62,7 @@ pub struct GetMempoolDescendantsVerbose(pub BTreeMap<String, MempoolEntry>);
 #[serde(deny_unknown_fields)]
 pub struct GetMempoolEntry(pub MempoolEntry);
 
-/// A relative (ancestor or descendant) transaction of a transaction in the mempool.
+/// Mempool data. Part of `getmempoolentry`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MempoolEntry {

--- a/types/src/v18/control.rs
+++ b/types/src/v18/control.rs
@@ -17,7 +17,7 @@ pub struct GetRpcInfo {
     active_commands: Vec<ActiveCommand>,
 }
 
-/// Information about an active command - return as part of `getrpcinfo`.
+/// Information about an active command. Part of `getrpcinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ActiveCommand {

--- a/types/src/v18/network/mod.rs
+++ b/types/src/v18/network/mod.rs
@@ -40,7 +40,7 @@ pub struct NodeAddress {
 #[serde(deny_unknown_fields)]
 pub struct GetPeerInfo(pub Vec<PeerInfo>);
 
-/// An item from the list returned by the JSON-RPC method `getpeerinfo`.
+/// A peer info item. Part of `getpeerinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PeerInfo {

--- a/types/src/v18/raw_transactions/mod.rs
+++ b/types/src/v18/raw_transactions/mod.rs
@@ -37,7 +37,7 @@ pub struct AnalyzePsbt {
     pub next: String,
 }
 
-/// Represents an input in a PSBT operation.
+/// Represents an input in a PSBT operation. Part of `analyzepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AnalyzePsbtInput {
@@ -51,7 +51,7 @@ pub struct AnalyzePsbtInput {
     pub next: Option<String>,
 }
 
-/// Represents missing elements required to complete an input.
+/// Represents missing elements required to complete an input. Part of `analyzepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AnalyzePsbtInputMissing {

--- a/types/src/v18/wallet/mod.rs
+++ b/types/src/v18/wallet/mod.rs
@@ -91,7 +91,7 @@ pub struct GetAddressInfo {
     pub labels: Vec<GetAddressInfoLabel>,
 }
 
-/// The `embedded` field of `GetAddressInfo`.
+/// The `embedded` address info field. Part of `getaddressinfo`.
 ///
 /// It includes all getaddressinfo output fields for the embedded address, excluding metadata
 /// ("timestamp", "hdkeypath", "hdseedid") and relation to the wallet ("ismine", "iswatchonly").
@@ -214,7 +214,7 @@ pub struct GetWalletInfo {
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ImportMulti(pub Vec<ImportMultiEntry>);
 
-/// Represents a single entry in the importmulti result array.
+/// A single import multi entry. Part of `importmulti`.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ImportMultiEntry {
     /// The success.
@@ -225,7 +225,7 @@ pub struct ImportMultiEntry {
     pub error: Option<JsonRpcError>,
 }
 
-/// Represents the error object in a JSON-RPC error response.
+/// A JSON-RPC error response. Part of `importmulti`.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct JsonRpcError {
     /// The error code.
@@ -245,7 +245,7 @@ pub struct JsonRpcError {
 #[serde(deny_unknown_fields)]
 pub struct ListReceivedByAddress(pub Vec<ListReceivedByAddressItem>);
 
-/// List item returned as part of of `listreceivedByaddress`.
+/// List received by address item. Part of of `listreceivedbyaddress`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ListReceivedByAddressItem {
@@ -273,7 +273,7 @@ pub struct ListReceivedByAddressItem {
 #[serde(deny_unknown_fields)]
 pub struct ListReceivedByLabel(pub Vec<ListReceivedByLabelItem>);
 
-/// Item returned as part of `listreceivedbylabel`.
+/// List received by label item. Part of of `listreceivedbyaddress`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ListReceivedByLabelItem {
@@ -299,7 +299,7 @@ pub struct ListReceivedByLabelItem {
 #[serde(deny_unknown_fields)]
 pub struct ListUnspent(pub Vec<ListUnspentItem>);
 
-/// Unspent transaction output, returned as part of `listunspent`.
+/// Unspent transaction output. Part of `listunspent`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ListUnspentItem {
@@ -346,7 +346,7 @@ pub struct ListWalletDir {
     pub wallets: Vec<ListWalletDirWallet>,
 }
 
-/// Wallet entry returned as part of `listwalletdir`.
+/// Wallet entry. Part of `listwalletdir`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ListWalletDirWallet {

--- a/types/src/v19/blockchain/mod.rs
+++ b/types/src/v19/blockchain/mod.rs
@@ -64,7 +64,7 @@ pub struct GetBlockchainInfo {
     pub warnings: String,
 }
 
-/// Status of softfork.
+/// Softfork status. Part of `getblockchaininfo`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Softfork {
@@ -79,7 +79,7 @@ pub struct Softfork {
     pub active: bool,
 }
 
-/// The softfork type: one of "buried", "bip9".
+/// The softfork type. Part of `getblockchaininfo`.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum SoftforkType {
@@ -93,7 +93,7 @@ pub enum SoftforkType {
     Bip9,
 }
 
-/// Status of BIP-9 softforks.
+/// BIP-9 softfork info. Part of `getblockchaininfo`.
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Bip9SoftforkInfo {
@@ -111,7 +111,7 @@ pub struct Bip9SoftforkInfo {
     pub statistics: Option<Bip9SoftforkStatistics>,
 }
 
-/// BIP-9 softfork status: one of "defined", "started", "locked_in", "active", "failed".
+/// BIP-9 softfork status. Part of `getblockchaininfo`.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Bip9SoftforkStatus {
@@ -127,7 +127,7 @@ pub enum Bip9SoftforkStatus {
     Failed,
 }
 
-/// Statistics for a BIP-9 softfork.
+/// BIP-9 softfork statistics. Part of `getblockchaininfo`.
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Bip9SoftforkStatistics {
@@ -239,7 +239,7 @@ pub struct GetMempoolDescendantsVerbose(pub BTreeMap<String, MempoolEntry>);
 #[serde(deny_unknown_fields)]
 pub struct GetMempoolEntry(pub MempoolEntry);
 
-/// A relative (ancestor or descendant) transaction of a transaction in the mempool.
+/// Mempool data. Part of `getmempoolentry`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MempoolEntry {
@@ -294,7 +294,7 @@ pub struct MempoolEntry {
     pub bip125_replaceable: bool,
 }
 
-/// The `fees` field from the result of JSON-RPC method `getmempoolentry`.
+/// Fee object. Part of `getmempoolentry`.
 ///
 /// Contains the base fee, modified fee (with fee deltas), and ancestor/descendant fee totals,
 /// all in BTC.

--- a/types/src/v19/network/mod.rs
+++ b/types/src/v19/network/mod.rs
@@ -68,7 +68,7 @@ pub struct GetNetworkInfo {
 #[serde(deny_unknown_fields)]
 pub struct GetPeerInfo(pub Vec<PeerInfo>);
 
-/// An item from the list returned by the JSON-RPC method `getpeerinfo`.
+/// A peer info item. Part of `getpeerinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PeerInfo {

--- a/types/src/v19/wallet/mod.rs
+++ b/types/src/v19/wallet/mod.rs
@@ -27,7 +27,7 @@ pub struct GetBalances {
     pub watch_only: Option<GetBalancesWatchOnly>,
 }
 
-/// Balances from outputs that the wallet can sign.
+/// Balances from outputs that the wallet can sign. Part of `getbalances`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GetBalancesMine {
@@ -43,7 +43,7 @@ pub struct GetBalancesMine {
     pub used: Option<f64>,
 }
 
-/// Hash and height of the block this information was generated on.
+/// Hash and height of the block this information was generated on. Part of `getbalances`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GetBalancesWatchOnly {
@@ -156,7 +156,7 @@ pub struct GetWalletInfo {
     pub scanning: GetWalletInfoScanning,
 }
 
-/// The `scanning` field of `GetWalletInfo` in v19.
+/// Current scanning details. Part of `getwalletinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum GetWalletInfoScanning {

--- a/types/src/v20/network.rs
+++ b/types/src/v20/network.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 #[serde(deny_unknown_fields)]
 pub struct ListBanned(pub Vec<Banned>);
 
-/// An item from the list returned by the JSON-RPC method `listbanned`.
+/// An banned item. Part of `listbanned`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Banned {

--- a/types/src/v20/wallet/mod.rs
+++ b/types/src/v20/wallet/mod.rs
@@ -115,7 +115,7 @@ pub struct GetAddressInfo {
     pub labels: Vec<String>,
 }
 
-/// The `embedded` field of `GetAddressInfo`.
+/// The `embedded` address info field. Part of `getaddressinfo`.
 ///
 /// It includes all getaddressinfo output fields for the embedded address, excluding metadata
 /// ("timestamp", "hdkeypath", "hdseedid") and relation to the wallet ("ismine", "iswatchonly").
@@ -224,6 +224,7 @@ pub struct GetTransaction {
     pub decoded: Option<Transaction>,
 }
 
+/// Transaction detail. Part of the `gettransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GetTransactionDetail {
@@ -278,7 +279,7 @@ pub struct ListSinceBlock {
     pub last_block: String,
 }
 
-/// Transaction item returned as part of `listsinceblock`.
+/// Transaction item. Part of `listsinceblock`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TransactionItem {

--- a/types/src/v21/blockchain/mod.rs
+++ b/types/src/v21/blockchain/mod.rs
@@ -64,7 +64,7 @@ pub struct GetBlockchainInfo {
     pub warnings: String,
 }
 
-/// Status of softfork.
+/// Softfork status. Part of `getblockchaininfo`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Softfork {
@@ -79,7 +79,7 @@ pub struct Softfork {
     pub active: bool,
 }
 
-/// The softfork type: one of "buried", "bip9".
+/// The softfork type. Part of `getblockchaininfo`.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum SoftforkType {
@@ -93,7 +93,7 @@ pub enum SoftforkType {
     Bip9,
 }
 
-/// Status of BIP-9 softforks.
+/// BIP-9 softfork info. Part of `getblockchaininfo`.
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Bip9SoftforkInfo {
@@ -163,7 +163,7 @@ pub struct GetMempoolDescendantsVerbose(pub BTreeMap<String, MempoolEntry>);
 #[serde(deny_unknown_fields)]
 pub struct GetMempoolEntry(pub MempoolEntry);
 
-/// A relative (ancestor or descendant) transaction of a transaction in the mempool.
+/// Mempool data. Part of `getmempoolentry`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MempoolEntry {

--- a/types/src/v21/network/mod.rs
+++ b/types/src/v21/network/mod.rs
@@ -72,7 +72,7 @@ pub struct GetNetworkInfo {
 #[serde(deny_unknown_fields)]
 pub struct GetPeerInfo(pub Vec<PeerInfo>);
 
-/// An item from the list returned by the JSON-RPC method `getpeerinfo`.
+/// A peer info item. Part of `getpeerinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PeerInfo {

--- a/types/src/v21/raw_transactions/mod.rs
+++ b/types/src/v21/raw_transactions/mod.rs
@@ -29,7 +29,7 @@ pub use self::error::{MempoolAcceptanceError, TestMempoolAcceptError};
 #[serde(deny_unknown_fields)]
 pub struct TestMempoolAccept(pub Vec<MempoolAcceptance>);
 
-/// Represents a single mempool acceptance test result, returned as part of `testmempoolaccept`.
+/// A single mempool acceptance test result. Part of `testmempoolaccept`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MempoolAcceptance {
@@ -46,7 +46,7 @@ pub struct MempoolAcceptance {
     pub reject_reason: Option<String>,
 }
 
-/// Wrapper for the fees field. Returned as part of `testmempoolaccept`.
+/// Wrapper for the fees field. Part of `testmempoolaccept`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MempoolAcceptanceFees {

--- a/types/src/v21/util.rs
+++ b/types/src/v21/util.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 #[serde(deny_unknown_fields)]
 pub struct GetIndexInfo(pub BTreeMap<String, GetIndexInfoName>);
 
-/// `name` field of `getindexinfo`.
+/// Index info details. Part of `getindexinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GetIndexInfoName {

--- a/types/src/v21/wallet/mod.rs
+++ b/types/src/v21/wallet/mod.rs
@@ -53,7 +53,7 @@ pub struct ImportDescriptors(
     pub Vec<ImportDescriptorsResult>,
 );
 
-/// Result object for each descriptor import in `importdescriptors`.
+/// Result object for each descriptor import. Part of `importdescriptors`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ImportDescriptorsResult {
@@ -225,7 +225,7 @@ pub struct GetWalletInfo {
     pub descriptors: bool,
 }
 
-/// The `scanning` field of the `getwalletinfo` RPC in v21.
+/// Current scanning details. Part of `getwalletinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum GetWalletInfoScanning {

--- a/types/src/v22/network.rs
+++ b/types/src/v22/network.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 #[serde(deny_unknown_fields)]
 pub struct GetNodeAddresses(pub Vec<NodeAddress>);
 
-/// An item from the list returned by the JSON-RPC method `getnodeaddresses`.
+/// An node address item. Part of `getnodeaddresses`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct NodeAddress {
@@ -44,7 +44,7 @@ pub struct NodeAddress {
 #[serde(deny_unknown_fields)]
 pub struct ListBanned(pub Vec<Banned>);
 
-/// An item from the list returned by the JSON-RPC method `listbanned`.
+/// An banned item. Part of `listbanned`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Banned {
@@ -69,7 +69,7 @@ pub struct Banned {
 #[serde(deny_unknown_fields)]
 pub struct GetPeerInfo(pub Vec<PeerInfo>);
 
-/// An item from the list returned by the JSON-RPC method `getpeerinfo`.
+/// A peer info item. Part of `getpeerinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PeerInfo {

--- a/types/src/v22/raw_transactions/mod.rs
+++ b/types/src/v22/raw_transactions/mod.rs
@@ -44,7 +44,7 @@ pub struct DecodeScript {
     pub p2sh_segwit: Option<String>,
 }
 
-/// `segwit` item returned as part of `decodescript`.
+/// Segwit data. Part of `decodescript`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DecodeScriptSegwit {
@@ -85,7 +85,7 @@ pub struct DecodeScriptSegwit {
 #[serde(deny_unknown_fields)]
 pub struct TestMempoolAccept(pub Vec<MempoolAcceptance>);
 
-/// Represents a single mempool acceptance test result, returned as part of `testmempoolaccept`.
+/// A single mempool acceptance test result. Part of `testmempoolaccept`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MempoolAcceptance {
@@ -104,7 +104,7 @@ pub struct MempoolAcceptance {
     pub reject_reason: Option<String>,
 }
 
-/// Wrapper for the fees field. Returned as part of `testmempoolaccept`.
+/// Wrapper for the fees field. Part of `testmempoolaccept`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MempoolAcceptanceFees {

--- a/types/src/v22/signer.rs
+++ b/types/src/v22/signer.rs
@@ -16,7 +16,7 @@ pub struct EnumerateSigners {
     pub signers: Vec<Signers>,
 }
 
-/// An item from the list returned by the JSON-RPC method `enumeratesigners`
+/// An signer item. Part of `enumeratesigners`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Signers {

--- a/types/src/v22/wallet/mod.rs
+++ b/types/src/v22/wallet/mod.rs
@@ -87,7 +87,7 @@ pub struct GetAddressInfo {
     pub labels: Vec<String>,
 }
 
-/// The `embedded` field of `GetAddressInfo`.
+/// The `embedded` address info field. Part of `getaddressinfo`.
 ///
 /// It includes all getaddressinfo output fields for the embedded address, excluding metadata
 /// ("timestamp", "hdkeypath", "hdseedid") and relation to the wallet ("ismine", "iswatchonly").

--- a/types/src/v23/blockchain/into.rs
+++ b/types/src/v23/blockchain/into.rs
@@ -69,7 +69,7 @@ impl GetDeploymentInfo {
 }
 
 impl DeploymentInfo {
-    /// Returned as part of `getdeploymentinfo`.
+    /// Part of `getdeploymentinfo`.
     pub fn into_model(self) -> Result<model::DeploymentInfo, crate::NumericError> {
         Ok(model::DeploymentInfo {
             deployment_type: self.deployment_type,
@@ -81,7 +81,7 @@ impl DeploymentInfo {
 }
 
 impl Bip9Info {
-    /// Returned as part of `getdeploymentinfo`.
+    /// Part of `getdeploymentinfo`.
     pub fn into_model(self) -> Result<model::Bip9Info, crate::NumericError> {
         Ok(model::Bip9Info {
             bit: self.bit,
@@ -98,7 +98,7 @@ impl Bip9Info {
 }
 
 impl Bip9Statistics {
-    /// Returned as part of `getdeploymentinfo`.
+    /// Part of `getdeploymentinfo`.
     pub fn into_model(self) -> Result<model::Bip9Statistics, crate::NumericError> {
         Ok(model::Bip9Statistics {
             period: self.period,

--- a/types/src/v23/blockchain/mod.rs
+++ b/types/src/v23/blockchain/mod.rs
@@ -83,7 +83,7 @@ pub struct GetDeploymentInfo {
     pub deployments: std::collections::BTreeMap<String, DeploymentInfo>,
 }
 
-/// Deployment info. Returned as part of `getdeploymentinfo`.
+/// Deployment info. Part of `getdeploymentinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DeploymentInfo {
@@ -98,7 +98,7 @@ pub struct DeploymentInfo {
     pub bip9: Option<Bip9Info>,
 }
 
-/// Status of bip9 softforks. Returned as part of `getdeploymentinfo`.
+/// Status of bip9 softforks. Part of `getdeploymentinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Bip9Info {
@@ -122,7 +122,7 @@ pub struct Bip9Info {
     pub signalling: Option<String>,
 }
 
-/// Numeric statistics about signalling for a softfork. Returned as part of `getdeploymentinfo`.
+/// Numeric statistics about signalling for a softfork. Part of `getdeploymentinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Bip9Statistics {
@@ -188,7 +188,7 @@ pub struct GetMempoolDescendantsVerbose(pub BTreeMap<String, MempoolEntry>);
 #[serde(deny_unknown_fields)]
 pub struct GetMempoolEntry(pub MempoolEntry);
 
-/// A relative (ancestor or descendant) transaction of a transaction in the mempool.
+/// Mempool data. Part of `getmempoolentry`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MempoolEntry {

--- a/types/src/v23/network.rs
+++ b/types/src/v23/network.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 #[serde(deny_unknown_fields)]
 pub struct GetPeerInfo(pub Vec<PeerInfo>);
 
-/// An item from the list returned by the JSON-RPC method `getpeerinfo`.
+/// A peer info item. Part of `getpeerinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PeerInfo {

--- a/types/src/v23/raw_transactions/mod.rs
+++ b/types/src/v23/raw_transactions/mod.rs
@@ -47,7 +47,7 @@ pub struct DecodePsbt {
     pub fee: Option<u64>,
 }
 
-/// An item from the global xpubs list of `DecodePsbt`.
+/// An item from the global xpubs list. Part of `decodepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GlobalXpub {
@@ -59,7 +59,7 @@ pub struct GlobalXpub {
     pub path: String,
 }
 
-/// An item from the global proprietary list of `DecodePsbt`.
+/// An item from the global proprietary list. Part of `decodepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Proprietary {
@@ -73,7 +73,7 @@ pub struct Proprietary {
     value: String,
 }
 
-/// An input in a partially signed Bitcoin transaction.
+/// An input in a partially signed Bitcoin transaction. Part of `decodepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PsbtInput {
@@ -111,7 +111,7 @@ pub struct PsbtInput {
     pub unknown: Option<HashMap<String, String>>,
 }
 
-/// An output in a partially signed Bitcoin transaction.
+/// An output in a partially signed Bitcoin transaction. Part of `decodepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PsbtOutput {
@@ -163,7 +163,7 @@ pub struct DecodeScript {
     pub p2sh_segwit: Option<String>,
 }
 
-/// `segwit` item returned as part of `decodescript`.
+/// Segwit data. Part of `decodescript`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DecodeScriptSegwit {

--- a/types/src/v23/wallet/mod.rs
+++ b/types/src/v23/wallet/mod.rs
@@ -180,7 +180,7 @@ pub struct GetWalletInfo {
     pub external_signer: bool,
 }
 
-/// The `scanning` field of the `getwalletinfo` RPC in v23.
+/// Current scanning details. Part of `getwalletinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum GetWalletInfoScanning {
@@ -210,7 +210,7 @@ pub struct ListSinceBlock {
     pub last_block: String,
 }
 
-/// Transaction item returned as part of `listsinceblock`.
+/// Transaction item. Part of `listsinceblock`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TransactionItem {

--- a/types/src/v24/blockchain/mod.rs
+++ b/types/src/v24/blockchain/mod.rs
@@ -64,7 +64,7 @@ pub struct GetMempoolDescendantsVerbose(pub BTreeMap<String, MempoolEntry>);
 #[serde(deny_unknown_fields)]
 pub struct GetMempoolEntry(pub MempoolEntry);
 
-/// A relative (ancestor or descendant) transaction of a transaction in the mempool.
+/// Mempool data. Part of `getmempoolentry`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MempoolEntry {
@@ -165,7 +165,7 @@ pub struct GetMempoolInfo {
 #[serde(deny_unknown_fields)]
 pub struct GetTxSpendingPrevout(pub Vec<GetTxSpendingPrevoutItem>);
 
-/// An individual result item from `gettxspendingprevout`.
+/// A transaction item. Part of `gettxspendingprevout`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GetTxSpendingPrevoutItem {

--- a/types/src/v24/network.rs
+++ b/types/src/v24/network.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 #[serde(deny_unknown_fields)]
 pub struct GetPeerInfo(pub Vec<PeerInfo>);
 
-/// An item from the list returned by the JSON-RPC method `getpeerinfo`.
+/// A peer info item. Part of `getpeerinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PeerInfo {

--- a/types/src/v24/raw_transactions/mod.rs
+++ b/types/src/v24/raw_transactions/mod.rs
@@ -47,7 +47,7 @@ pub struct DecodePsbt {
     pub fee: Option<u64>,
 }
 
-/// An item from the global xpubs list of `DecodePsbt`.
+/// An item from the global xpubs list. Part of `decodepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GlobalXpub {
@@ -59,7 +59,7 @@ pub struct GlobalXpub {
     pub path: String,
 }
 
-/// An item from the global proprietary list of `DecodePsbt`.
+/// An item from the global proprietary list. Part of `decodepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Proprietary {
@@ -73,7 +73,7 @@ pub struct Proprietary {
     value: String,
 }
 
-/// An input in a partially signed Bitcoin transaction.
+/// An input in a partially signed Bitcoin transaction. Part of `decodepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PsbtInput {
@@ -123,7 +123,7 @@ pub struct PsbtInput {
     pub unknown: Option<HashMap<String, String>>,
 }
 
-/// An output in a partially signed Bitcoin transaction.
+/// An output in a partially signed Bitcoin transaction. Part of `decodepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PsbtOutput {
@@ -145,7 +145,7 @@ pub struct PsbtOutput {
     pub unknown: Option<HashMap<String, String>>,
 }
 
-/// An item from the `taproot_script_path_sigs` list of `PsbtInput`.
+/// An item from the `taproot_script_path_sigs` list. Part of `decodepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TaprootScriptPathSig {
@@ -157,7 +157,7 @@ pub struct TaprootScriptPathSig {
     pub sig: String,
 }
 
-/// An item from the `taproot_scripts` list of `PsbtInput`.
+/// An item from the `taproot_scripts` list. Part of `decodepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TaprootScript {
@@ -170,7 +170,7 @@ pub struct TaprootScript {
     pub control_blocks: Vec<String>,
 }
 
-/// An item from the `taproot_bip32_derivs` list of `PsbtInput`.
+/// An item from the `taproot_bip32_derivs` list. Part of `decodepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TaprootBip32Deriv {
@@ -184,7 +184,7 @@ pub struct TaprootBip32Deriv {
     pub leaf_hashes: Vec<String>,
 }
 
-/// A Taproot leaf script at depth with version.
+/// A Taproot leaf script at depth with version. Part of `decodepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TaprootLeaf {

--- a/types/src/v24/wallet/mod.rs
+++ b/types/src/v24/wallet/mod.rs
@@ -88,6 +88,7 @@ pub struct GetTransaction {
     pub decoded: Option<Transaction>,
 }
 
+/// Transaction detail. Part of the `gettransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GetTransactionDetail {
@@ -140,7 +141,7 @@ pub struct ListSinceBlock {
     pub last_block: String,
 }
 
-/// Transaction item returned as part of `listsinceblock`.
+/// Transaction item. Part of `listsinceblock`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TransactionItem {
@@ -238,7 +239,7 @@ pub struct ListTransactions(pub Vec<TransactionItem>);
 #[serde(deny_unknown_fields)]
 pub struct ListUnspent(pub Vec<ListUnspentItem>);
 
-/// Unspent transaction output, returned as part of `listunspent`.
+/// Unspent transaction output, part of `listunspent`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ListUnspentItem {

--- a/types/src/v25/raw_transactions/mod.rs
+++ b/types/src/v25/raw_transactions/mod.rs
@@ -29,7 +29,7 @@ pub use self::error::{MempoolAcceptanceError, TestMempoolAcceptError};
 #[serde(deny_unknown_fields)]
 pub struct TestMempoolAccept(pub Vec<MempoolAcceptance>);
 
-/// Represents a single mempool acceptance test result, returned as part of `testmempoolaccept`.
+/// A single mempool acceptance test result. Part of `testmempoolaccept`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MempoolAcceptance {
@@ -48,7 +48,7 @@ pub struct MempoolAcceptance {
     pub reject_reason: Option<String>,
 }
 
-/// Wrapper for the fees field. Returned as part of `testmempoolaccept`.
+/// Wrapper for the fees field. Part of `testmempoolaccept`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MempoolAcceptanceFees {

--- a/types/src/v25/wallet/mod.rs
+++ b/types/src/v25/wallet/mod.rs
@@ -51,7 +51,7 @@ pub struct ListDescriptors {
     pub descriptors: Vec<DescriptorInfo>,
 }
 
-/// A descriptor object from `listdescriptors`.
+/// A descriptor object. Part of `listdescriptors`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct DescriptorInfo {

--- a/types/src/v26/blockchain/mod.rs
+++ b/types/src/v26/blockchain/mod.rs
@@ -55,7 +55,7 @@ pub struct GetChainStates {
     pub chain_states: Vec<ChainState>,
 }
 
-/// A single chainstate returned as part of `getchainstates`.
+/// A single chainstate. Part of `getchainstates`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ChainState {

--- a/types/src/v26/mining.rs
+++ b/types/src/v26/mining.rs
@@ -23,6 +23,7 @@ pub struct GetPrioritisedTransactions(
     pub BTreeMap<String, PrioritisedTransaction>,
 );
 
+/// An individual prioritised transaction. Part of `getprioritisedtransactions`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PrioritisedTransaction {

--- a/types/src/v26/network.rs
+++ b/types/src/v26/network.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 #[serde(deny_unknown_fields)]
 pub struct GetAddrManInfo(pub BTreeMap<String, AddrManInfoNetwork>);
 
-/// Address manager information returned as part of `getaddrmaninfo`.
+/// Address manager information. Part of `getaddrmaninfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AddrManInfoNetwork {
@@ -38,7 +38,7 @@ pub struct AddrManInfoNetwork {
 #[serde(deny_unknown_fields)]
 pub struct GetPeerInfo(pub Vec<PeerInfo>);
 
-/// An item from the list returned by the JSON-RPC method `getpeerinfo`.
+/// A peer info item. Part of `getpeerinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PeerInfo {

--- a/types/src/v26/raw_transactions/mod.rs
+++ b/types/src/v26/raw_transactions/mod.rs
@@ -76,7 +76,7 @@ pub struct SubmitPackage {
     pub replaced_transactions: Vec<String>,
 }
 
-/// Models the per-transaction result included in the JSON-RPC method `submitpackage`.
+/// The per-transaction result. Part of `submitpackage`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SubmitPackageTxResult {
@@ -95,7 +95,7 @@ pub struct SubmitPackageTxResult {
     pub error: Option<String>,
 }
 
-/// Models the fees included in the per-transaction result of the JSON-RPC method `submitpackage`.
+/// The fees included in the per-transaction result. Part of `submitpackage`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SubmitPackageTxResultFees {

--- a/types/src/v26/wallet/mod.rs
+++ b/types/src/v26/wallet/mod.rs
@@ -136,7 +136,7 @@ pub struct GetTransaction {
     pub last_processed_block: Option<LastProcessedBlock>,
 }
 
-/// Item returned as part of of `gettransaction`. v26 and later only.
+/// Last processed block item. Part of of `gettransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LastProcessedBlock {
@@ -207,7 +207,7 @@ pub struct GetWalletInfo {
     pub last_processed_block: Option<LastProcessedBlock>,
 }
 
-/// The `scanning` field of the `getwalletinfo` RPC in v26.
+/// Current scanning details. Part of `getwalletinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum GetWalletInfoScanning {

--- a/types/src/v27/mining.rs
+++ b/types/src/v27/mining.rs
@@ -23,6 +23,7 @@ pub struct GetPrioritisedTransactions(
     pub BTreeMap<String, PrioritisedTransaction>,
 );
 
+/// An individual prioritised transaction. Part of `getprioritisedtransactions`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct PrioritisedTransaction {

--- a/types/src/v28/raw_transactions/mod.rs
+++ b/types/src/v28/raw_transactions/mod.rs
@@ -47,7 +47,7 @@ pub struct SubmitPackage {
     pub replaced_transactions: Vec<String>,
 }
 
-/// Models the per-transaction result included in the JSON-RPC method `submitpackage`.
+/// The per-transaction result. Part of `submitpackage`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SubmitPackageTxResult {
@@ -66,7 +66,7 @@ pub struct SubmitPackageTxResult {
     pub error: Option<String>,
 }
 
-/// Models the fees included in the per-transaction result of the JSON-RPC method `submitpackage`.
+/// The fees included in the per-transaction result. Part of `submitpackage`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SubmitPackageTxResultFees {

--- a/types/src/v28/wallet/mod.rs
+++ b/types/src/v28/wallet/mod.rs
@@ -93,7 +93,7 @@ pub struct GetAddressInfo {
     pub labels: Vec<String>,
 }
 
-/// The `embedded` field of `GetAddressInfo`.
+/// The `embedded` address info field. Part of `getaddressinfo`.
 ///
 /// It includes all getaddressinfo output fields for the embedded address, excluding metadata
 /// ("timestamp", "hdkeypath", "hdseedid") and relation to the wallet ("ismine", "iswatchonly").
@@ -172,7 +172,7 @@ pub struct CreateWalletDescriptor {
 #[serde(deny_unknown_fields)]
 pub struct GetHdKeys(pub Vec<HdKey>);
 
-/// HD key entry returned as part of `gethdkeys`.
+/// HD key entry. Part of `gethdkeys`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct HdKey {
@@ -187,7 +187,7 @@ pub struct HdKey {
     pub descriptors: Vec<HdKeyDescriptor>,
 }
 
-/// Descriptor object returned as part of `gethdkeys`.
+/// Descriptor object. Part of `gethdkeys`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct HdKeyDescriptor {
@@ -296,7 +296,7 @@ pub struct ListSinceBlock {
     pub last_block: String,
 }
 
-/// Transaction item returned as part of `listsinceblock`.
+/// Transaction item. Part of `listsinceblock`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct TransactionItem {

--- a/types/src/v29/blockchain/mod.rs
+++ b/types/src/v29/blockchain/mod.rs
@@ -198,7 +198,7 @@ pub struct GetChainStates {
     pub chain_states: Vec<ChainState>,
 }
 
-/// A single chainstate returned as part of `getchainstates`.
+/// A single chainstate. Part of `getchainstates`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ChainState {
@@ -241,7 +241,7 @@ pub struct GetDescriptorActivity {
     pub activity: Vec<ActivityEntry>,
 }
 
-/// Enum representing either a spend or receive activity entry.
+/// Enum representing either a spend or receive activity entry. Part of `getdescriptoractivity`.
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum ActivityEntry {
@@ -251,7 +251,7 @@ pub enum ActivityEntry {
     Receive(ReceiveActivity),
 }
 
-/// Represents a 'spend' activity event.
+/// Represents a 'spend' activity event. Part of `getdescriptoractivity`.
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct SpendActivity {
@@ -277,7 +277,7 @@ pub struct SpendActivity {
     pub prevout_spk: ScriptPubkey,
 }
 
-/// Represents a 'receive' activity event.
+/// Represents a 'receive' activity event. Part of `getdescriptoractivity`.
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ReceiveActivity {

--- a/types/src/v29/mining/mod.rs
+++ b/types/src/v29/mining/mod.rs
@@ -80,7 +80,7 @@ pub struct GetMiningInfo {
     pub warnings: Vec<String>,
 }
 
-/// Represents the `next` block information within the GetMiningInfo result.
+/// Represents the `next` block information. Part of `getmininginfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct NextBlockInfo {

--- a/types/src/v29/raw_transactions/mod.rs
+++ b/types/src/v29/raw_transactions/mod.rs
@@ -28,7 +28,7 @@ pub use super::{MempoolAcceptanceError, TestMempoolAcceptError};
 #[serde(deny_unknown_fields)]
 pub struct TestMempoolAccept(pub Vec<MempoolAcceptance>);
 
-/// Represents a single mempool acceptance test result, returned as part of `testmempoolaccept`.
+/// A single mempool acceptance test result. Part of `testmempoolaccept`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MempoolAcceptance {
@@ -50,7 +50,7 @@ pub struct MempoolAcceptance {
     pub reject_details: Option<String>,
 }
 
-/// Wrapper for the fees field. Returned as part of `testmempoolaccept`.
+/// Wrapper for the fees field. Part of `testmempoolaccept`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MempoolAcceptanceFees {


### PR DESCRIPTION
The rustdocs for the RPCs in types in inconsistent. In particular the sub structs and enums don't always mention which RPC they are part of. This makes it harder to understand which bit goes with which.

Use the same language throughout so that when scanning through the code it is easier to follow.

Make all the rustdocs consistent and mention which RPC they are part of.