### PR TITLE
Reorder types structs in alphabetical order

### DIFF
--- a/types/src/model/blockchain.rs
+++ b/types/src/model/blockchain.rs
@@ -520,7 +520,7 @@ pub struct GetMempoolAncestors(pub Vec<Txid>);
 #[serde(deny_unknown_fields)]
 pub struct GetMempoolAncestorsVerbose(pub BTreeMap<Txid, MempoolEntry>);
 
-/// Models the result of JSON-RPC method `getmempoolancestors` with verbose set to false.
+/// Models the result of JSON-RPC method `getmempooldescendants` with verbose set to false.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct GetMempoolDescendants(pub Vec<Txid>);

--- a/types/src/model/blockchain.rs
+++ b/types/src/model/blockchain.rs
@@ -505,6 +505,63 @@ pub struct Bip9Statistics {
     pub possible: Option<bool>,
 }
 
+/// Models the result of the JSON-RPC method `getdescriptoractivity`.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct GetDescriptorActivity {
+    /// A list of activity events related to the descriptors.
+    pub activity: Vec<ActivityEntry>,
+}
+
+/// A spend or receive activity entry. Part of `getdescriptoractivity`.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub enum ActivityEntry {
+    /// The spend activity using `model::SpendActivity`.
+    Spend(SpendActivity),
+    /// The receive activity using `model::ReceiveActivity`.
+    Receive(ReceiveActivity),
+}
+
+/// Models a 'spend' activity event. Part of `getdescriptoractivity`.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct SpendActivity {
+    /// The total amount of the spent output.
+    pub amount: Amount,
+    /// The blockhash (omitted if unconfirmed).
+    pub block_hash: Option<BlockHash>,
+    /// Height of the spend (omitted if unconfirmed).
+    pub height: Option<u32>,
+    /// The txid of the spending transaction.
+    pub spend_txid: Txid,
+    /// The vout of the spend.
+    pub spend_vout: u32,
+    /// The txid of the prevout.
+    pub prevout_txid: Txid,
+    /// The vout of the prevout.
+    pub prevout_vout: u32,
+    /// The prev scriptPubKey.
+    pub prevout_spk: ScriptPubkey,
+}
+
+/// Models a 'receive' activity event. Part of `getdescriptoractivity`
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReceiveActivity {
+    /// The total amount in BTC of the new output.
+    pub amount: Amount,
+    /// The block that this receive is in (omitted if unconfirmed).
+    pub block_hash: Option<BlockHash>,
+    /// The height of the receive (omitted if unconfirmed).
+    pub height: Option<u32>,
+    /// The txid of the receiving transaction.
+    pub txid: Txid,
+    /// The vout of the receiving output.
+    pub vout: u32,
+    /// The ScriptPubKey.
+    pub output_spk: ScriptPubkey,
+}
+
 /// Models the result of JSON-RPC method `getdifficulty`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -696,68 +753,6 @@ pub struct GetTxSpendingPrevoutItem {
     pub spending_txid: Option<Txid>,
 }
 
-/// Models the result of JSON-RPC method `verifytxoutproof`.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct VerifyTxOutProof(pub Vec<Txid>);
-
-/// Models the result of the JSON-RPC method `getdescriptoractivity`.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct GetDescriptorActivity {
-    /// A list of activity events related to the descriptors.
-    pub activity: Vec<ActivityEntry>,
-}
-
-/// A spend or receive activity entry. Part of `getdescriptoractivity`.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-pub enum ActivityEntry {
-    /// The spend activity using `model::SpendActivity`.
-    Spend(SpendActivity),
-    /// The receive activity using `model::ReceiveActivity`.
-    Receive(ReceiveActivity),
-}
-
-/// Models a 'spend' activity event. Part of `getdescriptoractivity`.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct SpendActivity {
-    /// The total amount of the spent output.
-    pub amount: Amount,
-    /// The blockhash (omitted if unconfirmed).
-    pub block_hash: Option<BlockHash>,
-    /// Height of the spend (omitted if unconfirmed).
-    pub height: Option<u32>,
-    /// The txid of the spending transaction.
-    pub spend_txid: Txid,
-    /// The vout of the spend.
-    pub spend_vout: u32,
-    /// The txid of the prevout.
-    pub prevout_txid: Txid,
-    /// The vout of the prevout.
-    pub prevout_vout: u32,
-    /// The prev scriptPubKey.
-    pub prevout_spk: ScriptPubkey,
-}
-
-/// Models a 'receive' activity event. Part of `getdescriptoractivity`
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ReceiveActivity {
-    /// The total amount in BTC of the new output.
-    pub amount: Amount,
-    /// The block that this receive is in (omitted if unconfirmed).
-    pub block_hash: Option<BlockHash>,
-    /// The height of the receive (omitted if unconfirmed).
-    pub height: Option<u32>,
-    /// The txid of the receiving transaction.
-    pub txid: Txid,
-    /// The vout of the receiving output.
-    pub vout: u32,
-    /// The ScriptPubKey.
-    pub output_spk: ScriptPubkey,
-}
-
 /// Models the result of JSON-RPC method `loadtxoutset`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -782,3 +777,8 @@ pub struct ScanBlocksStart {
     /// Blocks that may have matched a scanobject
     pub relevant_blocks: Vec<BlockHash>,
 }
+
+/// Models the result of JSON-RPC method `verifytxoutproof`.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct VerifyTxOutProof(pub Vec<Txid>);

--- a/types/src/model/util.rs
+++ b/types/src/model/util.rs
@@ -23,18 +23,6 @@ pub struct CreateMultisig {
     pub warnings: Option<Vec<String>>,
 }
 
-/// Models the result of JSON-RPC method `estimatesmartfee`.
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct EstimateSmartFee {
-    /// Estimate fee rate in BTC/kB.
-    pub fee_rate: Option<FeeRate>,
-    /// Errors encountered during processing.
-    pub errors: Option<Vec<String>>,
-    /// Block number where estimate was found.
-    pub blocks: u32,
-}
-
 /// Models the result of JSON-RPC method `deriveaddresses`.
 ///
 /// > deriveaddresses "descriptor" ( range )
@@ -54,6 +42,18 @@ pub struct DeriveAddresses {
 pub struct DeriveAddressesMultipath {
     /// The derived addresses for each of the multipath expansions of the descriptor, in multipath specifier order.
     pub addresses: Vec<DeriveAddresses>,
+}
+
+/// Models the result of JSON-RPC method `estimatesmartfee`.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct EstimateSmartFee {
+    /// Estimate fee rate in BTC/kB.
+    pub fee_rate: Option<FeeRate>,
+    /// Errors encountered during processing.
+    pub errors: Option<Vec<String>>,
+    /// Block number where estimate was found.
+    pub blocks: u32,
 }
 
 /// Models the result of JSON-RPC method `signmessagewithprivkey`.

--- a/types/src/model/wallet.rs
+++ b/types/src/model/wallet.rs
@@ -748,16 +748,6 @@ pub struct LoadWallet {
     pub warnings: Vec<String>,
 }
 
-/// Models the result of JSON-RPC method `rescanblockchain`.
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct RescanBlockchain {
-    /// The block height where the rescan has started.
-    pub start_height: u32,
-    /// The height of the last rescanned block.
-    pub stop_height: u32,
-}
-
 /// Models the result of JSON-RPC method `psbtbumpfee`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -770,6 +760,16 @@ pub struct PsbtBumpFee {
     pub fee: Amount,
     /// Errors encountered during processing (may be empty).
     pub errors: Vec<String>,
+}
+
+/// Models the result of JSON-RPC method `rescanblockchain`.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RescanBlockchain {
+    /// The block height where the rescan has started.
+    pub start_height: u32,
+    /// The height of the last rescanned block.
+    pub stop_height: u32,
 }
 
 /// Models the result of JSON-RPC method `send`.

--- a/types/src/v17/blockchain/mod.rs
+++ b/types/src/v17/blockchain/mod.rs
@@ -602,7 +602,7 @@ pub struct GetMempoolInfo {
 #[serde(deny_unknown_fields)]
 pub struct GetRawMempool(pub Vec<String>);
 
-/// Result of JSON-RPC method `getmempooldescendants` with verbose set to `true`.
+/// Result of JSON-RPC method `getrawmempool` with verbose set to `true`.
 ///
 /// Map of txid to [`MempoolEntry`].
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]

--- a/types/src/v17/wallet/mod.rs
+++ b/types/src/v17/wallet/mod.rs
@@ -17,45 +17,6 @@ use serde::{Deserialize, Serialize};
 // TODO: Remove wildcard, use explicit types.
 pub use self::error::*;
 
-/// The purpose of an address. Part of `getaddressesbylabel`.
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "lowercase")]
-pub enum AddressPurpose {
-    /// A send-to address.
-    Send,
-    /// A receive-from address.
-    Receive,
-}
-
-/// The category of a transaction. Part of `gettransaction`, `listsinceblock` and `listtransactions`.
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "lowercase")]
-pub enum TransactionCategory {
-    /// Transactions sent.
-    Send,
-    /// Non-coinbase transactions received.
-    Receive,
-    /// Coinbase transactions received with more than 100 confirmations.
-    Generate,
-    /// Coinbase transactions received with 100 or fewer confirmations.
-    Immature,
-    /// Orphaned coinbase transactions received.
-    Orphan,
-}
-
-/// Whether this transaction can be RBF'ed. Part of `gettransaction`, `listsinceblock` and
-/// `listtransactions`.
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "lowercase")]
-pub enum Bip125Replaceable {
-    /// Yes, can be replaced due to BIP-125 (RBF).
-    Yes,
-    /// No, cannot be replaced due to BIP-125 (RBF).
-    No,
-    /// RBF unknown.
-    Unknown,
-}
-
 /// Result of JSON-RPC method `abortrescan`.
 ///
 /// > abortrescan
@@ -215,6 +176,16 @@ pub struct GetAddressesByLabel(pub BTreeMap<String, AddressInformation>);
 pub struct AddressInformation {
     /// Purpose of address.
     pub purpose: AddressPurpose,
+}
+
+/// The purpose of an address. Part of `getaddressesbylabel`.
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AddressPurpose {
+    /// A send-to address.
+    Send,
+    /// A receive-from address.
+    Receive,
 }
 
 /// Result of the JSON-RPC method `getaddressinfo`.
@@ -500,6 +471,35 @@ pub struct GetTransactionDetail {
     ///
     /// Only available for the 'send' category of transactions.
     pub abandoned: Option<bool>,
+}
+
+/// The category of a transaction. Part of `gettransaction`, `listsinceblock` and `listtransactions`.
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TransactionCategory {
+    /// Transactions sent.
+    Send,
+    /// Non-coinbase transactions received.
+    Receive,
+    /// Coinbase transactions received with more than 100 confirmations.
+    Generate,
+    /// Coinbase transactions received with 100 or fewer confirmations.
+    Immature,
+    /// Orphaned coinbase transactions received.
+    Orphan,
+}
+
+/// Whether this transaction can be RBF'ed. Part of `gettransaction`, `listsinceblock` and
+/// `listtransactions`.
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Bip125Replaceable {
+    /// Yes, can be replaced due to BIP-125 (RBF).
+    Yes,
+    /// No, cannot be replaced due to BIP-125 (RBF).
+    No,
+    /// RBF unknown.
+    Unknown,
 }
 
 /// Result of the JSON-RPC method `getunconfirmedbalance`.

--- a/types/src/v21/wallet/mod.rs
+++ b/types/src/v21/wallet/mod.rs
@@ -12,6 +12,69 @@ use serde::{Deserialize, Serialize};
 pub use self::error::{PsbtBumpFeeError, SendError};
 pub use super::GetWalletInfoError;
 
+/// Result of the JSON-RPC method `getwalletinfo`.
+///
+/// > getwalletinfo
+/// > Returns an object containing various wallet state info.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct GetWalletInfo {
+    /// The wallet name.
+    #[serde(rename = "walletname")]
+    pub wallet_name: String,
+    /// The wallet version.
+    #[serde(rename = "walletversion")]
+    pub wallet_version: i64,
+    /// The database format (bdb or sqlite).
+    pub format: String,
+    /// The total confirmed balance of the wallet in BTC. (DEPRECATED)
+    pub balance: f64,
+    /// The total unconfirmed balance of the wallet in BTC. (DEPRECATED)
+    pub unconfirmed_balance: f64,
+    /// The total immature balance of the wallet in BTC. (DEPRECATED)
+    pub immature_balance: f64,
+    /// The total number of transactions in the wallet
+    #[serde(rename = "txcount")]
+    pub tx_count: i64,
+    /// The UNIX epoch time of the oldest pre-generated key in the key pool. Legacy wallets only.
+    #[serde(rename = "keypoololdest")]
+    pub keypool_oldest: i64,
+    /// How many new keys are pre-generated (only counts external keys).
+    #[serde(rename = "keypoolsize")]
+    pub keypool_size: i64,
+    /// How many new keys are pre-generated for internal use (used for change outputs, only appears
+    /// if the wallet is using this feature, otherwise external keys are used).
+    #[serde(rename = "keypoolsize_hd_internal")]
+    pub keypool_size_hd_internal: i64,
+    /// The UNIX epoch time until which the wallet is unlocked for transfers, or 0 if the wallet is locked.
+    /// Only present for passphrase-encrypted wallets.
+    pub unlocked_until: Option<u32>,
+    /// The transaction fee configuration, set in BTC/kvB.
+    #[serde(rename = "paytxfee")]
+    pub pay_tx_fee: f64,
+    /// The Hash160 of the HD seed (only present when HD is enabled).
+    #[serde(rename = "hdseedid")]
+    pub hd_seed_id: Option<String>,
+    /// If privatekeys are disabled for this wallet (enforced watch-only wallet).
+    pub private_keys_enabled: bool,
+    /// Whether this wallet tracks clean/dirty coins in terms of reuse.
+    pub avoid_reuse: bool,
+    /// Current scanning details, or false if no scan is in progress.
+    pub scanning: GetWalletInfoScanning,
+    /// Whether this wallet uses descriptors for scriptPubKey management.
+    pub descriptors: bool,
+}
+
+/// Current scanning details. Part of `getwalletinfo`.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum GetWalletInfoScanning {
+    /// Scanning details.
+    Details { duration: u64, progress: f64 },
+    /// Not scanning (false).
+    NotScanning(bool),
+}
+
 /// Result of JSON-RPC method `importdescriptors`.
 ///
 /// > Import descriptors. This will trigger a rescan of the blockchain based on the earliest
@@ -170,67 +233,4 @@ pub struct UpgradeWallet {
     pub result: Option<String>,
     /// Error message (if there is one)
     pub error: Option<String>,
-}
-
-/// Result of the JSON-RPC method `getwalletinfo`.
-///
-/// > getwalletinfo
-/// > Returns an object containing various wallet state info.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct GetWalletInfo {
-    /// The wallet name.
-    #[serde(rename = "walletname")]
-    pub wallet_name: String,
-    /// The wallet version.
-    #[serde(rename = "walletversion")]
-    pub wallet_version: i64,
-    /// The database format (bdb or sqlite).
-    pub format: String,
-    /// The total confirmed balance of the wallet in BTC. (DEPRECATED)
-    pub balance: f64,
-    /// The total unconfirmed balance of the wallet in BTC. (DEPRECATED)
-    pub unconfirmed_balance: f64,
-    /// The total immature balance of the wallet in BTC. (DEPRECATED)
-    pub immature_balance: f64,
-    /// The total number of transactions in the wallet
-    #[serde(rename = "txcount")]
-    pub tx_count: i64,
-    /// The UNIX epoch time of the oldest pre-generated key in the key pool. Legacy wallets only.
-    #[serde(rename = "keypoololdest")]
-    pub keypool_oldest: i64,
-    /// How many new keys are pre-generated (only counts external keys).
-    #[serde(rename = "keypoolsize")]
-    pub keypool_size: i64,
-    /// How many new keys are pre-generated for internal use (used for change outputs, only appears
-    /// if the wallet is using this feature, otherwise external keys are used).
-    #[serde(rename = "keypoolsize_hd_internal")]
-    pub keypool_size_hd_internal: i64,
-    /// The UNIX epoch time until which the wallet is unlocked for transfers, or 0 if the wallet is locked.
-    /// Only present for passphrase-encrypted wallets.
-    pub unlocked_until: Option<u32>,
-    /// The transaction fee configuration, set in BTC/kvB.
-    #[serde(rename = "paytxfee")]
-    pub pay_tx_fee: f64,
-    /// The Hash160 of the HD seed (only present when HD is enabled).
-    #[serde(rename = "hdseedid")]
-    pub hd_seed_id: Option<String>,
-    /// If privatekeys are disabled for this wallet (enforced watch-only wallet).
-    pub private_keys_enabled: bool,
-    /// Whether this wallet tracks clean/dirty coins in terms of reuse.
-    pub avoid_reuse: bool,
-    /// Current scanning details, or false if no scan is in progress.
-    pub scanning: GetWalletInfoScanning,
-    /// Whether this wallet uses descriptors for scriptPubKey management.
-    pub descriptors: bool,
-}
-
-/// Current scanning details. Part of `getwalletinfo`.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum GetWalletInfoScanning {
-    /// Scanning details.
-    Details { duration: u64, progress: f64 },
-    /// Not scanning (false).
-    NotScanning(bool),
 }

--- a/types/src/v22/network.rs
+++ b/types/src/v22/network.rs
@@ -35,31 +35,6 @@ pub struct NodeAddress {
     pub network: String,
 }
 
-/// Result of JSON-RPC method `listbanned`.
-///
-/// > listbanned
-///
-/// > List all banned IPs/Subnets.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct ListBanned(pub Vec<Banned>);
-
-/// An banned item. Part of `listbanned`.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct Banned {
-    /// The IP/Subnet of the banned node.
-    pub address: String,
-    /// The UNIX epoch time the ban was created.
-    pub ban_created: u32,
-    /// The UNIX epoch time the ban was expires.
-    pub banned_until: u32,
-    /// The ban duration, in seconds.
-    pub ban_duration: u32,
-    /// The time remaining until the ban expires, in seconds.
-    pub time_remaining: u32,
-}
-
 /// Result of JSON-RPC method `getpeerinfo`.
 ///
 /// > getpeerinfo
@@ -170,4 +145,29 @@ pub struct PeerInfo {
     pub bytes_received_per_message: BTreeMap<String, u64>,
     /// Type of connection.
     pub connection_type: Option<String>,
+}
+
+/// Result of JSON-RPC method `listbanned`.
+///
+/// > listbanned
+///
+/// > List all banned IPs/Subnets.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ListBanned(pub Vec<Banned>);
+
+/// An banned item. Part of `listbanned`.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Banned {
+    /// The IP/Subnet of the banned node.
+    pub address: String,
+    /// The UNIX epoch time the ban was created.
+    pub ban_created: u32,
+    /// The UNIX epoch time the ban was expires.
+    pub banned_until: u32,
+    /// The ban duration, in seconds.
+    pub ban_duration: u32,
+    /// The time remaining until the ban expires, in seconds.
+    pub time_remaining: u32,
 }

--- a/types/src/v23/wallet/mod.rs
+++ b/types/src/v23/wallet/mod.rs
@@ -108,24 +108,6 @@ pub struct GetTransaction {
     pub decoded: Option<Transaction>,
 }
 
-/// Result of the JSON-RPC method `restorewallet`.
-///
-/// > restorewallet "wallet_name" "backup_file" ( load_on_startup )
-/// >
-/// > Restore and loads a wallet from backup.
-/// >
-/// > Arguments:
-/// > 1. wallet_name        (string, required) The name that will be applied to the restored wallet
-/// > 2. backup_file        (string, required) The backup file that will be used to restore the wallet.
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct RestoreWallet {
-    /// The wallet name if restored successfully.
-    pub name: String,
-    /// Warning message if wallet was not loaded cleanly.
-    pub warning: Option<String>,
-}
-
 /// Result of the JSON-RPC method `getwalletinfo`.
 ///
 /// > getwalletinfo
@@ -291,3 +273,21 @@ pub struct TransactionItem {
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ListTransactions(pub Vec<TransactionItem>);
+
+/// Result of the JSON-RPC method `restorewallet`.
+///
+/// > restorewallet "wallet_name" "backup_file" ( load_on_startup )
+/// >
+/// > Restore and loads a wallet from backup.
+/// >
+/// > Arguments:
+/// > 1. wallet_name        (string, required) The name that will be applied to the restored wallet
+/// > 2. backup_file        (string, required) The backup file that will be used to restore the wallet.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RestoreWallet {
+    /// The wallet name if restored successfully.
+    pub name: String,
+    /// Warning message if wallet was not loaded cleanly.
+    pub warning: Option<String>,
+}

--- a/types/src/v28/wallet/mod.rs
+++ b/types/src/v28/wallet/mod.rs
@@ -16,6 +16,23 @@ pub use super::{
     GetTransactionError, LastProcessedBlock, ScriptType,
 };
 
+/// Result of the JSON-RPC method `createwalletdescriptor`.
+///
+/// > createwalletdescriptor "type" ( {"internal":bool,"hdkey":"str",...} )
+/// >
+/// > Creates the wallet's descriptor for the given address type. The address type must be one that the wallet does not already have a descriptor for.
+/// > Requires wallet passphrase to be set with walletpassphrase call if wallet is encrypted.
+/// >
+/// > Arguments:
+/// > 1. type       (string, required) The address type the descriptor will produce. Options are "legacy", "p2sh-segwit", "bech32", and "bech32m".
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CreateWalletDescriptor {
+    /// The public descriptors that were added to the wallet.
+    #[serde(rename = "descs")]
+    pub descriptors: Vec<String>,
+}
+
 /// Result of the JSON-RPC method `getaddressinfo`.
 ///
 /// > getaddressinfo "address"
@@ -144,23 +161,6 @@ pub struct GetAddressInfoEmbedded {
     pub is_compressed: Option<bool>,
     /// Array of labels associated with the address.
     pub labels: Option<Vec<String>>,
-}
-
-/// Result of the JSON-RPC method `createwalletdescriptor`.
-///
-/// > createwalletdescriptor "type" ( {"internal":bool,"hdkey":"str",...} )
-/// >
-/// > Creates the wallet's descriptor for the given address type. The address type must be one that the wallet does not already have a descriptor for.
-/// > Requires wallet passphrase to be set with walletpassphrase call if wallet is encrypted.
-/// >
-/// > Arguments:
-/// > 1. type       (string, required) The address type the descriptor will produce. Options are "legacy", "p2sh-segwit", "bech32", and "bech32m".
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct CreateWalletDescriptor {
-    /// The public descriptors that were added to the wallet.
-    #[serde(rename = "descs")]
-    pub descriptors: Vec<String>,
 }
 
 /// Result of the JSON-RPC method `gethdkeys`.


### PR DESCRIPTION
Some of the structs and enums are not in alphabetical order.

- Order them all by the RPC name, with sub structs directly below. Code moves only, no content changes.

Two structs had incorrect RPC names in their rustdocs.

- Correct the rustdocs.
