### PR TITLE
Add a feature for serde deny unknown fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,16 @@
 [workspace]
-members = ["client", "types", "node", "jsonrpc"]
+members = ["client", "jsonrpc", "node", "types"]
 exclude = ["integration_test", "verify"]
 resolver = "2"
 
 [patch.crates-io.corepc-client]
 path = "client"
 
-[patch.crates-io.corepc-types]
-path = "types"
+[patch.crates-io.jsonrpc]
+path = "jsonrpc"
 
 [patch.crates-io.corepc-node]
 path = "node"
 
-[patch.crates-io.jsonrpc]
-path = "jsonrpc"
+[patch.crates-io.corepc-types]
+path = "types"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -25,8 +25,8 @@ bitcoin = { version = "0.32.0", default-features = false, features = ["std", "se
 log = "0.4"
 serde = { version = "1.0.103", default-features = false, features = [ "derive", "alloc" ] }
 serde_json = { version = "1.0.117" }
-types = { package = "corepc-types", version = "0.9.0", default-features = false, features = ["std"] }
+types = { package = "corepc-types", path = "../types", default-features = false, features = ["std"] }
 
-jsonrpc = { version = "0.18.0", features = ["minreq_http"], optional = true }
+jsonrpc = { path = "../jsonrpc", features = ["minreq_http"], optional = true }
 
 [dev-dependencies]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -22,10 +22,10 @@ client-sync = ["jsonrpc"]
 
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false, features = ["std", "serde"] }
-types = { package = "corepc-types", version = "0.9.0", default-features = false, features = ["std"] }
 log = "0.4"
 serde = { version = "1.0.103", default-features = false, features = [ "derive", "alloc" ] }
 serde_json = { version = "1.0.117" }
+types = { package = "corepc-types", version = "0.9.0", default-features = false, features = ["std"] }
 
 jsonrpc = { version = "0.18.0", features = ["minreq_http"], optional = true }
 

--- a/client/src/client_sync/v21/mod.rs
+++ b/client/src/client_sync/v21/mod.rs
@@ -192,7 +192,6 @@ crate::impl_client_v17__get_zmq_notifications!();
 
 /// Request object for the `importdescriptors` method.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
 pub struct ImportDescriptorsRequest {
     /// Descriptor to import.
     #[serde(rename = "desc")]

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -57,16 +57,7 @@ TODO = []                       # This is a dirty hack while writing the tests.
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false, features = ["std", "serde"] }
 env_logger = "0.9.0"
-node = { package = "corepc-node", version = "0.9.0", default-features = false }
+node = { package = "corepc-node", path = "../node", default-features = false }
 rand = "0.8.5"
 
 [dev-dependencies]
-
-[patch.crates-io.corepc-client]
-path = "../client"
-
-[patch.crates-io.corepc-types]
-path = "../types"
-
-[patch.crates-io.corepc-node]
-path = "../node"

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -59,5 +59,7 @@ bitcoin = { version = "0.32.0", default-features = false, features = ["std", "se
 env_logger = "0.9.0"
 node = { package = "corepc-node", path = "../node", default-features = false }
 rand = "0.8.5"
+# Just so we can enable the feature.
+types = { package = "corepc-types", path = "../types", features = ["serde-deny-unknown-fields"] }
 
 [dev-dependencies]

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -56,9 +56,9 @@ TODO = []                       # This is a dirty hack while writing the tests.
 
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false, features = ["std", "serde"] }
+env_logger = "0.9.0"
 node = { package = "corepc-node", version = "0.9.0", default-features = false }
 rand = "0.8.5"
-env_logger = "0.9.0"
 
 [dev-dependencies]
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["tests", "contrib"]
 
 [dependencies]
 anyhow = { version = "1.0.66", default-features = false, features = ["std"] }
-corepc-client = { version = "0.9.0", features = ["client-sync"] }
+corepc-client = { path = "../client", features = ["client-sync"] }
 log = { version = "0.4", default-features = false }
 serde_json = { version = "1.0.117", default-features = false }
 tempfile = { version = "3", default-features = false }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -13,12 +13,12 @@ rust-version = "1.63.0"
 exclude = ["tests", "contrib"]
 
 [dependencies]
+anyhow = { version = "1.0.66", default-features = false, features = ["std"] }
 corepc-client = { version = "0.9.0", features = ["client-sync"] }
 log = { version = "0.4", default-features = false }
-which = { version = "3.1.1", default-features = false }
-anyhow = { version = "1.0.66", default-features = false, features = ["std"] }
-tempfile = {version = "3", default-features = false }
 serde_json = { version = "1.0.117", default-features = false }
+tempfile = { version = "3", default-features = false }
+which = { version = "3.1.1", default-features = false }
 
 [dev-dependencies]
 env_logger = { version = "0.9.3", default-features = false }
@@ -27,8 +27,8 @@ env_logger = { version = "0.9.3", default-features = false }
 anyhow = { version = "1.0.66", optional = true }
 bitcoin_hashes = { version = ">= 0.13, <= 0.14", optional = true }
 flate2 = { version = "1.0", optional = true }
-tar = { version = "0.4", optional = true }
 minreq = { version = "2.9.1", default-features = false, features = ["https"], optional = true }
+tar = { version = "0.4", optional = true }
 zip = { version = "0.6.6", default-features = false, features = ["bzip2", "deflate"], optional = true }
 
 # Please note, it is expected that a single version feature will be enabled however if you enable

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -15,6 +15,7 @@ exclude = ["tests", "contrib"]
 [features]
 default = ["std"]
 std = ["bitcoin/std"]
+serde-deny-unknown-fields = []
 
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false, features = ["serde", "base64", "secp-recovery"] }

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -180,7 +180,7 @@ pub fn compact_size_decode(slice: &mut &[u8]) -> u64 {
 /// backwards compatible so we only provide it not a v0.17 specific type. The `mtype::ScriptPubkey`
 /// mirrors this design (but with concrete `rust-bitcoin` types).
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ScriptPubkey {
     /// Script assembly.
     pub asm: String,
@@ -219,7 +219,7 @@ impl ScriptPubkey {
 
 /// Data returned by Core for a script signature.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ScriptSig {
     /// Assembly representation of the script.
     pub asm: String,

--- a/types/src/model/blockchain.rs
+++ b/types/src/model/blockchain.rs
@@ -19,7 +19,7 @@ use crate::ScriptPubkey;
 
 /// Models the result of JSON-RPC method `dumptxoutset`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DumpTxOutSet {
     /// The number of coins written in the snapshot.
     pub coins_written: Amount,
@@ -37,17 +37,17 @@ pub struct DumpTxOutSet {
 
 /// Models the result of JSON-RPC method `getbestblockhash`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBestBlockHash(pub BlockHash);
 
 /// Models the result of JSON-RPC method `getblock` with verbosity set to 0.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockVerboseZero(pub Block);
 
 /// Models the result of JSON-RPC method `getblock` with verbosity set to 1.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockVerboseOne {
     /// The block hash (same as provided) in RPC call.
     pub hash: BlockHash,
@@ -91,7 +91,7 @@ pub struct GetBlockVerboseOne {
 
 /// Models the result of JSON-RPC method `getblockchaininfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockchainInfo {
     /// Current network name as defined in BIP70 (main, test, signet, regtest).
     pub chain: Network,
@@ -137,7 +137,7 @@ pub struct GetBlockchainInfo {
 
 /// Softfork status. Part of `getblockchaininfo`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Softfork {
     /// The [`SoftforkType`]: one of "buried", "bip9".
     #[serde(rename = "type")]
@@ -166,7 +166,7 @@ pub enum SoftforkType {
 
 /// BIP-9 softfork info. Part of `getblockchaininfo`.
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Bip9SoftforkInfo {
     /// One of "defined", "started", "locked_in", "active", "failed".
     pub status: Bip9SoftforkStatus,
@@ -201,7 +201,7 @@ pub enum Bip9SoftforkStatus {
 
 /// BIP-9 softfork statistics. Part of `getblockchaininfo`.
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Bip9SoftforkStatistics {
     /// The length in blocks of the BIP9 signalling period.
     pub period: u32,
@@ -217,12 +217,12 @@ pub struct Bip9SoftforkStatistics {
 
 /// Models the result of JSON-RPC method `getblockcount`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockCount(pub u64);
 
 /// Models the result of JSON-RPC method `getblockfilter`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockFilter {
     /// The filter data.
     pub filter: Vec<u8>,
@@ -232,17 +232,17 @@ pub struct GetBlockFilter {
 
 /// Models the result of JSON-RPC method `getblockhash`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockHash(pub BlockHash);
 
 /// Models the result of JSON-RPC method `getblockheader`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockHeader(pub block::Header);
 
 /// Models the result of JSON-RPC method `getblockheader`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockHeaderVerbose {
     /// the block hash (same as provided).
     pub hash: BlockHash,
@@ -278,7 +278,7 @@ pub struct GetBlockHeaderVerbose {
 
 /// Models the result of JSON-RPC method `getblockstats`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockStats {
     /// Average fee in the block.
     pub average_fee: Amount,
@@ -348,7 +348,7 @@ pub struct GetBlockStats {
 
 /// Models the result of JSON-RPC method `getchainstates`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetChainStates {
     /// The number of headers seen so far.
     pub headers: u32,
@@ -358,7 +358,7 @@ pub struct GetChainStates {
 
 /// A single chainstate. Part of `getchainstates`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ChainState {
     /// Number of blocks in this chainstate.
     pub blocks: u32,
@@ -384,12 +384,12 @@ pub struct ChainState {
 
 /// Models the result of JSON-RPC method `getchaintips`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetChainTips(pub Vec<ChainTips>);
 
 /// An individual list item from the result of JSON-RPC method `getchaintips`.
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ChainTips {
     /// Height of the chain tip.
     pub height: u32,
@@ -419,7 +419,7 @@ pub enum ChainTipsStatus {
 
 /// Models the result of JSON-RPC method `getchaintxstats`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetChainTxStats {
     /// The timestamp for the final block in the window in UNIX format.
     pub time: u32,
@@ -441,7 +441,7 @@ pub struct GetChainTxStats {
 
 /// Models the result of JSON-RPC method `getdeploymentinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetDeploymentInfo {
     /// Requested block hash (or tip).
     pub hash: BlockHash,
@@ -453,7 +453,7 @@ pub struct GetDeploymentInfo {
 
 /// Deployment info. Part of `getdeploymentinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DeploymentInfo {
     /// One of "buried", "bip9".
     pub deployment_type: String,
@@ -467,7 +467,7 @@ pub struct DeploymentInfo {
 
 /// Status of bip9 softforks. Part of `getdeploymentinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Bip9Info {
     /// The bit (0-28) in the block version field used to signal this softfork (only for "started" and "locked_in" status).
     pub bit: Option<u8>,
@@ -491,7 +491,7 @@ pub struct Bip9Info {
 
 /// Numeric statistics about signalling for a softfork. Part of `getdeploymentinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Bip9Statistics {
     /// The length in blocks of the signalling period.
     pub period: u32,
@@ -507,7 +507,7 @@ pub struct Bip9Statistics {
 
 /// Models the result of the JSON-RPC method `getdescriptoractivity`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetDescriptorActivity {
     /// A list of activity events related to the descriptors.
     pub activity: Vec<ActivityEntry>,
@@ -524,7 +524,7 @@ pub enum ActivityEntry {
 
 /// Models a 'spend' activity event. Part of `getdescriptoractivity`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SpendActivity {
     /// The total amount of the spent output.
     pub amount: Amount,
@@ -546,7 +546,7 @@ pub struct SpendActivity {
 
 /// Models a 'receive' activity event. Part of `getdescriptoractivity`
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ReceiveActivity {
     /// The total amount in BTC of the new output.
     pub amount: Amount,
@@ -564,37 +564,37 @@ pub struct ReceiveActivity {
 
 /// Models the result of JSON-RPC method `getdifficulty`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetDifficulty(pub f64);
 
 /// Models the result of JSON-RPC method `getmempoolancestors` with verbose set to false.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolAncestors(pub Vec<Txid>);
 
 /// Models the result of JSON-RPC method `getmempoolancestors` with verbose set to true.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolAncestorsVerbose(pub BTreeMap<Txid, MempoolEntry>);
 
 /// Models the result of JSON-RPC method `getmempooldescendants` with verbose set to false.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolDescendants(pub Vec<Txid>);
 
 /// Models the result of JSON-RPC method `getmempooldescendants` with verbose set to true.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolDescendantsVerbose(pub BTreeMap<Txid, MempoolEntry>);
 
 /// Models the result of JSON-RPC method `getmempoolentry`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolEntry(pub MempoolEntry);
 
 /// Mempool data. Part of `getmempoolentry`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct MempoolEntry {
     /// Virtual transaction size as defined in BIP 141. v0.19 and later only.
     ///
@@ -637,7 +637,7 @@ pub struct MempoolEntry {
 
 /// Fee object. Part of `getmempoolentry`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct MempoolEntryFees {
     /// Transaction fee in BTC.
     pub base: Amount,
@@ -651,7 +651,7 @@ pub struct MempoolEntryFees {
 
 /// Models the result of JSON-RPC method `getmempoolinfo` with verbose set to true.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolInfo {
     /// True if the mempool is fully loaded. v0.19 and later only.
     pub loaded: Option<bool>,
@@ -685,17 +685,17 @@ pub struct GetMempoolInfo {
 
 /// Models the result of JSON-RPC method `getrawmempool` with verbose set to false.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetRawMempool(pub Vec<Txid>);
 
 /// Models the result of JSON-RPC method `getrawmempool` with verbose set to true.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetRawMempoolVerbose(pub BTreeMap<Txid, MempoolEntry>);
 
 /// Models the result of JSON-RPC method `gettxout`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetTxOut {
     /// The hash of the block at the tip of the chain.
     pub best_block: BlockHash,
@@ -713,7 +713,7 @@ pub struct GetTxOut {
 
 /// Models the result of JSON-RPC method `gettxoutsetinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetTxOutSetInfo {
     /// The current block height (index).
     pub height: u32,
@@ -740,12 +740,12 @@ pub struct GetTxOutSetInfo {
 
 /// Models the result of JSON-RPC method `gettxspendingprevout`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetTxSpendingPrevout(pub Vec<GetTxSpendingPrevoutItem>);
 
 /// A transaction item. Part of `gettxspendingprevout`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetTxSpendingPrevoutItem {
     /// The outpoint containing the transaction id and vout value of the checked output.
     pub outpoint: OutPoint,
@@ -755,7 +755,7 @@ pub struct GetTxSpendingPrevoutItem {
 
 /// Models the result of JSON-RPC method `loadtxoutset`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct LoadTxOutSet {
     /// The number of coins loaded from the snapshot.
     pub coins_loaded: Amount,
@@ -780,5 +780,5 @@ pub struct ScanBlocksStart {
 
 /// Models the result of JSON-RPC method `verifytxoutproof`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct VerifyTxOutProof(pub Vec<Txid>);

--- a/types/src/model/generating.rs
+++ b/types/src/model/generating.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 /// Models the result of JSON-RPC method `generate`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Generate(pub Vec<BlockHash>);
 
 impl Generate {
@@ -23,7 +23,7 @@ impl Generate {
 
 /// Models the result of JSON-RPC method `generateblock`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GenerateBlock {
     /// Hash of generated block.
     pub hash: BlockHash,
@@ -33,7 +33,7 @@ pub struct GenerateBlock {
 
 /// Models the result of JSON-RPC method `generatetoaddress`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GenerateToAddress(pub Vec<BlockHash>);
 
 impl GenerateToAddress {
@@ -46,7 +46,7 @@ impl GenerateToAddress {
 
 /// Models the result of JSON-RPC method `generatetodescriptor`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GenerateToDescriptor(pub Vec<BlockHash>);
 
 impl GenerateToDescriptor {

--- a/types/src/model/mining.rs
+++ b/types/src/model/mining.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 
 /// Models the result of JSON-RPC method `getblocktemplate`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockTemplate {
     /// The preferred block version.
     pub version: block::Version,
@@ -72,7 +72,7 @@ pub struct GetBlockTemplate {
 
 /// Non-coinbase transaction contents. Part of `getblocktemplate`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct BlockTemplateTransaction {
     /// The transaction.
     pub data: Transaction,
@@ -99,7 +99,7 @@ pub struct BlockTemplateTransaction {
 
 /// Models the result of JSON-RPC method `getmininginfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMiningInfo {
     /// The current block.
     pub blocks: u64,
@@ -132,7 +132,7 @@ pub struct GetMiningInfo {
 
 /// Represents the `next` block information. Part of `getmininginfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct NextBlockInfo {
     /// The next height.
     pub height: u64,
@@ -146,12 +146,12 @@ pub struct NextBlockInfo {
 
 /// Models the result of JSON-RPC method `getprioritisedtransactions`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetPrioritisedTransactions(pub BTreeMap<Txid, PrioritisedTransaction>);
 
 /// An individual prioritised transaction. Part of `getprioritisedtransactions`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct PrioritisedTransaction {
     /// Transaction fee delta in satoshis.
     pub fee_delta: Amount,

--- a/types/src/model/network.rs
+++ b/types/src/model/network.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 /// Models the result of JSON-RPC method `getnetworkinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetNetworkInfo {
     /// The server version.
     pub version: usize,
@@ -48,7 +48,7 @@ pub struct GetNetworkInfo {
 
 /// Information per network. Part of `getnetworkinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetNetworkInfoNetwork {
     /// Network (ipv4, ipv6, onion, i2p, cjdns).
     pub name: String,
@@ -64,7 +64,7 @@ pub struct GetNetworkInfoNetwork {
 
 /// Local address info. Part of `getnetworkinfo`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetNetworkInfoAddress {
     /// Network address.
     pub address: String,

--- a/types/src/model/raw_transactions.rs
+++ b/types/src/model/raw_transactions.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 
 /// Models the result of JSON-RPC method `analyzepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct AnalyzePsbt {
     /// Array of input objects.
     pub inputs: Vec<AnalyzePsbtInput>,
@@ -32,7 +32,7 @@ pub struct AnalyzePsbt {
 
 /// An input in a PSBT operation. Part of `analyzepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct AnalyzePsbtInput {
     /// Whether a UTXO is provided.
     pub has_utxo: bool,
@@ -46,7 +46,7 @@ pub struct AnalyzePsbtInput {
 
 /// Missing elements required to complete an input. Part of `analyzepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct AnalyzePsbtInputMissing {
     /// Public key IDs of public keys whose BIP 32 derivation paths are missing.
     pub pubkeys: Vec<hash160::Hash>,
@@ -60,32 +60,32 @@ pub struct AnalyzePsbtInputMissing {
 
 /// Models the result of JSON-RPC method `combinepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct CombinePsbt(pub Psbt);
 
 /// Models the result of JSON-RPC method `combinerawtransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct CombineRawTransaction(pub Transaction);
 
 /// Models the result of JSON-RPC method `converttopsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ConvertToPsbt(pub Psbt);
 
 /// Models the result of JSON-RPC method `createpsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct CreatePsbt(pub Psbt);
 
 /// Models the result of JSON-RPC method `createrawtransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct CreateRawTransaction(pub Transaction);
 
 /// Models the result of JSON-RPC method `decodepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DecodePsbt {
     /// The decoded PSBT.
     pub psbt: Psbt,
@@ -95,12 +95,12 @@ pub struct DecodePsbt {
 
 /// Models the result of JSON-RPC method `decoderawtransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DecodeRawTransaction(pub Transaction);
 
 /// Models the result of JSON-RPC method `decodescript`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DecodeScript {
     /// The `scriptPubkey`.
     pub script_pubkey: Option<ScriptBuf>,
@@ -122,7 +122,7 @@ pub struct DecodeScript {
 
 /// Models the result of JSON-RPC method `descriptorprocesspsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DescriptorProcessPsbt {
     /// The decoded PSBT.
     pub psbt: Psbt,
@@ -134,7 +134,7 @@ pub struct DescriptorProcessPsbt {
 
 /// Models the result of JSON-RPC method `finalizepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct FinalizePsbt {
     /// The partially signed transaction if not extracted.
     pub psbt: Option<Psbt>,
@@ -146,7 +146,7 @@ pub struct FinalizePsbt {
 
 /// Models the result of JSON-RPC method `fundrawtransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct FundRawTransaction {
     /// The resulting raw transaction.
     pub tx: Transaction,
@@ -158,13 +158,13 @@ pub struct FundRawTransaction {
 
 /// Models the result of JSON-RPC method `getrawtransaction` with verbose set to `false`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetRawTransaction(pub Transaction);
 
 /// Models the result of JSON-RPC method `getrawtransaction` with verbose set to `true`.
 /// Result of JSON-RPC method `getrawtransaction`
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetRawTransactionVerbose {
     /// Whether specified block is in the active chain or not (only present with explicit "blockhash" argument).
     pub in_active_chain: Option<bool>,
@@ -182,17 +182,17 @@ pub struct GetRawTransactionVerbose {
 
 /// Models the result of JSON-RPC method `joinpsbts`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct JoinPsbts(pub Psbt);
 
 /// Models the result of JSON-RPC method `sendrawtransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SendRawTransaction(pub Txid);
 
 /// Models the result of JSON-RPC method `signrawtransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SignRawTransaction {
     /// The raw transaction with signature(s).
     pub tx: Transaction,
@@ -210,7 +210,7 @@ pub type SignRawTransactionWithKey = SignRawTransaction;
 
 /// A script verification error. Part of `signrawtransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SignFail {
     /// The referenced, previous transaction.
     pub txid: Txid,
@@ -226,7 +226,7 @@ pub struct SignFail {
 
 /// Models the result of JSON-RPC method `submitpackage`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SubmitPackage {
     /// The transaction package result message. "success" indicates all transactions were accepted into or are already in the mempool.
     pub package_msg: String,
@@ -238,7 +238,7 @@ pub struct SubmitPackage {
 
 /// Models the per-transaction result included in the JSON-RPC method `submitpackage`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SubmitPackageTxResult {
     /// The transaction id.
     pub txid: Txid,
@@ -256,7 +256,7 @@ pub struct SubmitPackageTxResult {
 
 /// Models the fees included in the per-transaction result of the JSON-RPC method `submitpackage`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SubmitPackageTxResultFees {
     /// Transaction fee.
     pub base_fee: Amount,
@@ -272,7 +272,7 @@ pub struct SubmitPackageTxResultFees {
 
 /// Models the result of JSON-RPC method `testmempoolaccept`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct TestMempoolAccept {
     /// Test results for each raw transaction in the input array.
     pub results: Vec<MempoolAcceptance>,
@@ -280,7 +280,7 @@ pub struct TestMempoolAccept {
 
 /// Models a single mempool acceptance test result. Part of `testmempoolaccept`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct MempoolAcceptance {
     /// The transaction ID.
     pub txid: Txid,
@@ -300,7 +300,7 @@ pub struct MempoolAcceptance {
 
 /// Models the fees field. Part of `testmempoolaccept`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct MempoolAcceptanceFees {
     /// Transaction fee in BTC.
     pub base: Amount,
@@ -313,5 +313,5 @@ pub struct MempoolAcceptanceFees {
 
 /// Models the result of JSON-RPC method `utxoupdatepsbt;`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct UtxoUpdatePsbt(pub Psbt);

--- a/types/src/model/util.rs
+++ b/types/src/model/util.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 /// Models the result of JSON-RPC method `createmultisig`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct CreateMultisig {
     /// The value of the new multisig address.
     pub address: Address<NetworkUnchecked>,
@@ -30,7 +30,7 @@ pub struct CreateMultisig {
 /// > Derives one or more addresses corresponding to an output descriptor.
 /// > Returns an array of derived addresses.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DeriveAddresses {
     /// The derived addresses.
     pub addresses: Vec<Address<NetworkUnchecked>>,
@@ -38,7 +38,7 @@ pub struct DeriveAddresses {
 
 /// Models the result of JSON-RPC method `deriveaddresses` for multipath descriptors.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DeriveAddressesMultipath {
     /// The derived addresses for each of the multipath expansions of the descriptor, in multipath specifier order.
     pub addresses: Vec<DeriveAddresses>,
@@ -46,7 +46,7 @@ pub struct DeriveAddressesMultipath {
 
 /// Models the result of JSON-RPC method `estimatesmartfee`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct EstimateSmartFee {
     /// Estimate fee rate in BTC/kB.
     pub fee_rate: Option<FeeRate>,

--- a/types/src/model/wallet.rs
+++ b/types/src/model/wallet.rs
@@ -56,7 +56,7 @@ pub enum Bip125Replaceable {
 
 /// Models the result of JSON-RPC method `addmultisigaddress`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct AddMultisigAddress {
     /// The new multisig address.
     pub address: Address<NetworkUnchecked>,
@@ -70,7 +70,7 @@ pub struct AddMultisigAddress {
 
 /// Models the result of JSON-RPC method `bumpfee`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct BumpFee {
     /// The id of the new transaction.
     pub txid: Txid,
@@ -84,7 +84,7 @@ pub struct BumpFee {
 
 /// Models the result of JSON-RPC method `createwallet`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct CreateWallet {
     /// The wallet name if created successfully.
     ///
@@ -96,17 +96,17 @@ pub struct CreateWallet {
 
 /// Models the result of JSON-RPC method `dumpprivkey`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DumpPrivKey(pub PrivateKey);
 
 /// Models the result of JSON-RPC method `getaddressesbylabel`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetAddressesByLabel(pub BTreeMap<Address<NetworkUnchecked>, AddressInformation>);
 
 /// Address information. Part of `getaddressesbylabel`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct AddressInformation {
     /// Purpose of address.
     pub purpose: AddressPurpose,
@@ -246,14 +246,14 @@ pub struct GetAddressInfoEmbedded {
 
 /// Models the result of JSON-RPC method `getbalance`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBalance(pub Amount);
 
 /// Models the result of JSON-RPC method `getbalances`.
 ///
 /// Core version 0.19 onwards.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBalances {
     /// Balances from outputs that the wallet can sign.
     pub mine: GetBalancesMine,
@@ -266,7 +266,7 @@ pub struct GetBalances {
 
 /// Balances from outputs that the wallet can sign. Part of `getbalances`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBalancesMine {
     /// Trusted balance (outputs created by the wallet or confirmed outputs).
     pub trusted: Amount,
@@ -282,7 +282,7 @@ pub struct GetBalancesMine {
 
 /// Hash and height of the block this information was generated on. Part of `getbalances`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBalancesWatchOnly {
     /// Trusted balance (outputs created by the wallet or confirmed outputs).
     pub trusted: Amount,
@@ -294,12 +294,12 @@ pub struct GetBalancesWatchOnly {
 
 /// Models the result of JSON-RPC method `gethdkeys`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetHdKeys(pub Vec<HdKey>);
 
 /// An HD key entry. Part of `gethdkeys`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct HdKey {
     /// The extended public key.
     pub xpub: Xpub,
@@ -313,7 +313,7 @@ pub struct HdKey {
 
 /// Descriptor object. Part of `gethdkeys`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct HdKeyDescriptor {
     /// Descriptor string representation.
     pub descriptor: String,
@@ -323,27 +323,27 @@ pub struct HdKeyDescriptor {
 
 /// Models the result of JSON-RPC method `getnewaddress`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetNewAddress(pub Address<NetworkUnchecked>);
 
 /// Models the result of JSON-RPC method `getrawchangeaddress`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetRawChangeAddress(pub Address<NetworkUnchecked>);
 
 /// Models the result of JSON-RPC method `getreceivedbyaddress`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetReceivedByAddress(pub Amount);
 
 /// Models the result of JSON-RPC method `getreceivedbylabel`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetReceivedByLabel(pub Amount);
 
 /// Models the result of JSON-RPC method `gettransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetTransaction {
     /// The transaction amount.
     #[serde(default, with = "bitcoin::amount::serde::as_btc")]
@@ -404,7 +404,7 @@ pub struct GetTransaction {
 
 /// Transaction detail. Part of the `gettransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetTransactionDetail {
     /// Only returns true if imported addresses were involved in transaction. v20 and later only.
     pub involves_watch_only: Option<bool>,
@@ -437,7 +437,7 @@ pub struct GetTransactionDetail {
 
 /// Last processed block item. Part of of `gettransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct LastProcessedBlock {
     /// Hash of the block this information was generated on.
     pub hash: BlockHash,
@@ -447,12 +447,12 @@ pub struct LastProcessedBlock {
 
 /// Models the result of JSON-RPC method `getunconfirmedbalance`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetUnconfirmedBalance(pub Amount);
 
 /// Models the result of JSON-RPC method `getwalletinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetWalletInfo {
     /// The wallet name.
     pub wallet_name: String,
@@ -515,13 +515,13 @@ pub enum GetWalletInfoScanning {
 
 /// Models the result of JSON-RPC method `listaddressgroupings`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListAddressGroupings(pub Vec<Vec<ListAddressGroupingsItem>>);
 
 /// List address item. Part of `listaddressgroupings`.
 // FIXME: The Core docs seem wrong, not sure what shape this should be?
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListAddressGroupingsItem {
     /// The bitcoin address.
     pub address: Address<NetworkUnchecked>,
@@ -533,12 +533,12 @@ pub struct ListAddressGroupingsItem {
 
 /// Models the result of JSON-RPC method `listlockunspent`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListLockUnspent(pub Vec<ListLockUnspentItem>);
 
 /// List lock unspent item. Part of of `listlockunspent`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListLockUnspentItem {
     /// The transaction id locked.
     pub txid: Txid,
@@ -548,12 +548,12 @@ pub struct ListLockUnspentItem {
 
 /// Models the result of JSON-RPC method `listreceivedbyaddress`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListReceivedByAddress(pub Vec<ListReceivedByAddressItem>);
 
 /// List received by address item. Part of of `listreceivedbyaddress`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListReceivedByAddressItem {
     /// Only returned if imported addresses were involved in transaction.
     pub involves_watch_only: Option<bool>,
@@ -571,12 +571,12 @@ pub struct ListReceivedByAddressItem {
 
 /// Models the result of JSON-RPC method `listreceivedbylabel`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListReceivedByLabel(pub Vec<ListReceivedByLabelItem>);
 
 /// List received by label item. Part of of `listreceivedbyaddress`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListReceivedByLabelItem {
     /// Only returned if imported addresses were involved in transaction.
     pub involves_watch_only: Option<bool>,
@@ -590,7 +590,7 @@ pub struct ListReceivedByLabelItem {
 
 /// Models the result of JSON-RPC method `listsinceblock`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListSinceBlock {
     /// All the transactions.
     pub transactions: Vec<TransactionItem>,
@@ -609,7 +609,7 @@ pub struct ListSinceBlock {
 
 /// Transaction item. Part of `listsinceblock` and `listtransactions`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct TransactionItem {
     /// Only returns true if imported addresses were involved in transaction.
     pub involves_watch_only: Option<bool>,
@@ -691,17 +691,17 @@ pub struct TransactionItem {
 
 /// Models the result of JSON-RPC method `listtransactions`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListTransactions(pub Vec<TransactionItem>);
 
 /// Models the result of JSON-RPC method `listunspent`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListUnspent(pub Vec<ListUnspentItem>);
 
 /// Unspent transaction output. Part of `listunspent`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListUnspentItem {
     /// The transaction id.
     pub txid: Txid,
@@ -737,12 +737,12 @@ pub struct ListUnspentItem {
 
 /// Models the result of JSON-RPC method `listwallets`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListWallets(pub Vec<String>);
 
 /// Models the result of JSON-RPC method `loadwallet`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct LoadWallet {
     /// The wallet name if loaded successfully.
     pub name: String,
@@ -752,7 +752,7 @@ pub struct LoadWallet {
 
 /// Models the result of JSON-RPC method `psbtbumpfee`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct PsbtBumpFee {
     /// The base64-encoded unsigned PSBT of the new transaction.
     pub psbt: Psbt,
@@ -766,7 +766,7 @@ pub struct PsbtBumpFee {
 
 /// Models the result of JSON-RPC method `rescanblockchain`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct RescanBlockchain {
     /// The block height where the rescan has started.
     pub start_height: u32,
@@ -776,7 +776,7 @@ pub struct RescanBlockchain {
 
 /// Models the result of JSON-RPC method `send`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Send {
     /// If the transaction has a complete set of signatures.
     pub complete: bool,
@@ -791,7 +791,7 @@ pub struct Send {
 
 /// Models the result of JSON-RPC method `sendall`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SendAll {
     /// If the transaction has a complete set of signatures.
     pub complete: bool,
@@ -806,12 +806,12 @@ pub struct SendAll {
 
 /// Models the result of JSON-RPC method `sendmany`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SendMany(pub Txid);
 
 /// Models the verbose result of JSON-RPC method `sendmany` when `verbose=true`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SendManyVerbose {
     /// The transaction id for the send. Only 1 transaction is created regardless of the number of addresses.
     pub txid: Txid,
@@ -821,7 +821,7 @@ pub struct SendManyVerbose {
 
 /// Models the result of JSON-RPC method `sendtoaddress`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SendToAddress {
     pub txid: Txid,
 }
@@ -838,7 +838,7 @@ pub type SignRawTransactionWithWallet = SignRawTransaction;
 
 /// Models the result of JSON-RPC method `simulaterawtransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SimulateRawTransaction {
     /// The wallet balance change (negative means decrease).
     #[serde(default, with = "bitcoin::amount::serde::as_btc")]
@@ -849,7 +849,7 @@ pub struct SimulateRawTransaction {
 ///
 /// Core version v0.21 onwards.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct UnloadWallet {
     /// Warning messages, if any, related to unloading the wallet.
     // Changes from single string to vector in Core v25
@@ -858,7 +858,7 @@ pub struct UnloadWallet {
 
 /// Models the result of JSON-RPC method `walletcreatefundedpsbt`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct WalletCreateFundedPsbt {
     /// The resulting PSBT.
     pub psbt: Psbt,
@@ -871,7 +871,7 @@ pub struct WalletCreateFundedPsbt {
 
 /// Models the result of JSON-RPC method `walletdisplayaddress`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct WalletDisplayAddress {
     /// The address as confirmed by the signer
     pub address: Address<NetworkUnchecked>,
@@ -879,7 +879,7 @@ pub struct WalletDisplayAddress {
 
 /// Models the result of JSON-RPC method `walletprocesspsbt`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct WalletProcessPsbt {
     /// The partially signed transaction.
     pub psbt: Psbt,

--- a/types/src/psbt/mod.rs
+++ b/types/src/psbt/mod.rs
@@ -22,7 +22,7 @@ use crate::{ScriptPubkey, ScriptSig};
 /// Part of `decoderawtransaction` and `decodepsbt`.
 // This JSON data can be encapsulated by a `bitcoin::Transaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct RawTransaction {
     /// The transaction id.
     pub txid: String,
@@ -74,7 +74,7 @@ impl RawTransaction {
 /// Represents a transaction input.
 // This JSON data can be encapsulated by a `bitcoin::TxIn`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct RawTransactionInput {
     /// The transaction id.
     pub txid: String,
@@ -115,7 +115,7 @@ impl RawTransactionInput {
 /// Represents a transaction output.
 // This JSON data can be encapsulated by a `bitcoin::TxOut` + index.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct RawTransactionOutput {
     /// The value in BTC.
     pub value: f64,
@@ -142,7 +142,7 @@ impl RawTransactionOutput {
 /// Transaction output for witness UTXOs.
 // This JSON data can be encapsulated by a `bitcoin::TxOut`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct WitnessUtxo {
     /// The value in BTC.
     pub amount: f64,
@@ -165,7 +165,7 @@ impl WitnessUtxo {
 
 /// A script part of a PSBT input or output.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct PsbtScript {
     /// The asm.
     pub asm: String,
@@ -191,7 +191,7 @@ impl PsbtScript {
 // bip32_derivation: BTreeMap<secp256k1::PublicKey, KeySource>,
 // KeySource = (Fingerprint, DerivationPath);
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Bip32Deriv {
     /// The public key this path corresponds to.
     pub pubkey: String,
@@ -204,7 +204,7 @@ pub struct Bip32Deriv {
 /// The key source data for a BIP-32 derivation.
 // In v0.17 the BIP-32 derivation for inputs is a map of pubkey to this type.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct InputKeySource {
     /// The fingerprint of the master key.
     pub master_fingerprint: String,
@@ -214,7 +214,7 @@ pub struct InputKeySource {
 
 /// Final script data.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct FinalScript {
     /// The asm.
     pub asm: String,

--- a/types/src/v17/blockchain/mod.rs
+++ b/types/src/v17/blockchain/mod.rs
@@ -23,7 +23,7 @@ use crate::{model, ScriptPubkey};
 /// >
 /// > Returns the hash of the best (tip) block in the most-work fully-validated chain.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBestBlockHash(pub String);
 
 /// Result of JSON-RPC method `getblock` with verbosity set to 0.
@@ -38,7 +38,7 @@ pub struct GetBestBlockHash(pub String);
 /// > 1. "blockhash"          (string, required) The block hash
 /// > 2. verbosity              (numeric, optional, default=1) 0 for hex encoded data, 1 for a json object, and 2 for json object with transaction data
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockVerboseZero(
     /// A string that is serialized, hex-encoded data for block 'hash'.
     pub String,
@@ -46,7 +46,7 @@ pub struct GetBlockVerboseZero(
 
 /// Result of JSON-RPC method `getblock` with verbosity set to 1.
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockVerboseOne {
     /// The block hash (same as provided) in RPC call.
     pub hash: String,
@@ -102,7 +102,7 @@ pub struct GetBlockVerboseOne {
 /// >
 /// > Returns an object containing various state info regarding blockchain processing.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockchainInfo {
     /// Current network name as defined in BIP70 (main, test, signet, regtest).
     pub chain: String,
@@ -148,7 +148,7 @@ pub struct GetBlockchainInfo {
 
 /// Softfork status. Part of `getblockchaininfo`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Softfork {
     /// Name of softfork.
     pub id: String,
@@ -160,7 +160,7 @@ pub struct Softfork {
 
 /// Progress toward rejecting pre-softfork blocks. Part of `getblockchaininfo`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SoftforkReject {
     /// `true` if threshold reached.
     pub status: bool,
@@ -168,7 +168,7 @@ pub struct SoftforkReject {
 
 /// Status of BIP-9 softforks in progress. Part of `getblockchaininfo`.
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Bip9Softfork {
     /// One of "defined", "started", "locked_in", "active", "failed".
     pub status: Bip9SoftforkStatus,
@@ -205,7 +205,7 @@ pub enum Bip9SoftforkStatus {
 /// >
 /// > Returns the number of blocks in the longest blockchain.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockCount(pub u64);
 
 /// Result of JSON-RPC method `getblockhash`.
@@ -215,7 +215,7 @@ pub struct GetBlockCount(pub u64);
 /// > Arguments:
 /// > 1. height         (numeric, required) The height index
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockHash(pub String);
 
 /// Result of JSON-RPC method `getblockheader` with verbosity set to `false`.
@@ -226,7 +226,7 @@ pub struct GetBlockHash(pub String);
 /// > Arguments:
 /// > 1. "hash"          (string, required) The block hash
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockHeader(pub String);
 
 /// Result of JSON-RPC method `getblockheader` with verbosity set to `true`.
@@ -237,7 +237,7 @@ pub struct GetBlockHeader(pub String);
 /// > Arguments:
 /// > 1. "hash"          (string, required) The block hash
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockHeaderVerbose {
     /// The block hash (same as provided).
     pub hash: String,
@@ -292,7 +292,7 @@ pub struct GetBlockHeaderVerbose {
 /// > Arguments:
 /// > 1. "hash_or_height"     (string or numeric, required) The block hash or height of the target block
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockStats {
     /// Average fee in the block.
     #[serde(rename = "avgfee")]
@@ -381,12 +381,12 @@ pub struct GetBlockStats {
 ///
 /// > Return information about all known tips in the block tree, including the main chain as well as orphaned branches.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetChainTips(pub Vec<ChainTips>);
 
 /// Chain tip item. Part of `getchaintips`.
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ChainTips {
     /// Height of the chain tip.
     pub height: i64,
@@ -421,7 +421,7 @@ pub enum ChainTipsStatus {
 /// >
 /// > Compute statistics about the total number and rate of transactions in the chain.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetChainTxStats {
     /// The timestamp for the final block in the window in UNIX format.
     pub time: i64,
@@ -450,7 +450,7 @@ pub struct GetChainTxStats {
 /// > Result:
 /// > n.nnn       (numeric) the proof-of-work difficulty as a multiple of the minimum difficulty.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetDifficulty(pub f64);
 
 /// Result of JSON-RPC method `getmempoolancestors` with verbose set to `false`.
@@ -462,14 +462,14 @@ pub struct GetDifficulty(pub f64);
 /// > Arguments:
 /// > 1. "txid"                 (string, required) The transaction id (must be in mempool)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolAncestors(pub Vec<String>);
 
 /// Result of JSON-RPC method `getmempoolancestors` with verbose set to true.
 ///
 /// Map of txid to [`MempoolEntry`] i.e., an ancestor.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolAncestorsVerbose(pub BTreeMap<String, MempoolEntry>);
 
 /// Result of JSON-RPC method `getmempooldescendants` with verbose set to `false`.
@@ -481,14 +481,14 @@ pub struct GetMempoolAncestorsVerbose(pub BTreeMap<String, MempoolEntry>);
 /// > Arguments:
 /// > 1. "txid"                 (string, required) The transaction id (must be in mempool)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolDescendants(pub Vec<String>);
 
 /// Result of JSON-RPC method `getmempooldescendants` with verbose set to true.
 ///
 /// Map of txid to [`MempoolEntry`] i.e., a descendant.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolDescendantsVerbose(pub BTreeMap<String, MempoolEntry>);
 
 /// Result of JSON-RPC method `getmempoolentry`.
@@ -500,12 +500,12 @@ pub struct GetMempoolDescendantsVerbose(pub BTreeMap<String, MempoolEntry>);
 /// > Arguments:
 /// > 1. "txid"                 (string, required) The transaction id (must be in mempool)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolEntry(pub MempoolEntry);
 
 /// Mempool data. Part of `getmempoolentry`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct MempoolEntry {
     /// Virtual transaction size as defined in BIP 141.
     ///
@@ -551,7 +551,7 @@ pub struct MempoolEntry {
 
 /// Fee object. Part of `getmempoolentry`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct MempoolEntryFees {
     /// Transaction fee in BTC.
     pub base: f64,
@@ -569,7 +569,7 @@ pub struct MempoolEntryFees {
 /// >
 /// > Returns details on the active state of the TX memory pool.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolInfo {
     /// Current transaction count.
     pub size: i64,
@@ -599,14 +599,14 @@ pub struct GetMempoolInfo {
 /// >
 /// > Hint: use getmempoolentry to fetch a specific transaction from the mempool.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetRawMempool(pub Vec<String>);
 
 /// Result of JSON-RPC method `getrawmempool` with verbose set to `true`.
 ///
 /// Map of txid to [`MempoolEntry`].
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetRawMempoolVerbose(pub BTreeMap<String, MempoolEntry>);
 
 /// Result of JSON-RPC method `gettxout`.
@@ -619,7 +619,7 @@ pub struct GetRawMempoolVerbose(pub BTreeMap<String, MempoolEntry>);
 /// > 1. txid               (string, required) The transaction id
 /// > 2. n                  (numeric, required) vout number
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetTxOut {
     /// The hash of the block at the tip of the chain.
     #[serde(rename = "bestblock")]
@@ -642,7 +642,7 @@ pub struct GetTxOut {
 /// > Returns statistics about the unspent transaction output set.
 /// > Note this call may take some time.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetTxOutSetInfo {
     /// The current block height (index).
     pub height: i64,
@@ -673,7 +673,7 @@ pub struct GetTxOutSetInfo {
 /// > 1. "height"       (numeric, required) The block height to prune up to. May be set to a discrete height, or a unix timestamp
 /// >                   to prune blocks whose block time is at least 2 hours older than the provided timestamp.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct PruneBlockchain(
     /// The height of the last block pruned.
     pub i64,
@@ -681,7 +681,7 @@ pub struct PruneBlockchain(
 
 /// Result of JSON-RPC method `verifychain`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct VerifyChain(pub bool);
 
 /// Result of JSON-RPC method `verifytxoutproof`.
@@ -696,5 +696,5 @@ pub struct VerifyChain(pub bool);
 ///
 /// Inner field is the txid(s) which the proof commits to, or empty array if the proof can not be validated.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct VerifyTxOutProof(pub Vec<String>);

--- a/types/src/v17/control.rs
+++ b/types/src/v17/control.rs
@@ -23,12 +23,12 @@ use serde::{Deserialize, Serialize};
 // This just mimics the map returned by my instance of Core `v0.17`, I don't know how
 // to handle other map values or if they exist?
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMemoryInfoStats(pub BTreeMap<String, Locked>);
 
 /// Information about locked memory manager. Part of `getmemoryinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Locked {
     /// Number of bytes used.
     pub used: u64,
@@ -53,7 +53,7 @@ pub struct Locked {
 ///
 /// > Gets and sets the logging configuration.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Logging {
     pub addrman: bool,
     pub bench: bool,

--- a/types/src/v17/generating.rs
+++ b/types/src/v17/generating.rs
@@ -18,7 +18,7 @@ use crate::model;
 /// > Arguments:
 /// > 1. nblocks      (numeric, required) How many blocks are generated immediately.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Generate(
     /// Hashes of blocks generated.
     pub Vec<String>,
@@ -42,7 +42,7 @@ impl Generate {
 /// > 1. nblocks     (numeric, required) How many blocks are generated immediately.
 /// > 2. address     (string, required) The address to send the newly generated bitcoin to.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GenerateToAddress(
     /// Hashes of blocks generated.
     pub Vec<String>,

--- a/types/src/v17/mining/mod.rs
+++ b/types/src/v17/mining/mod.rs
@@ -42,7 +42,7 @@ pub use self::error::{BlockTemplateTransactionError, GetBlockTemplateError};
 /// >        "data": "hex",          (string, optional) proposed block data to check, encoded in hexadecimal; valid only for mode="proposal"
 /// >      }
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockTemplate {
     /// The preferred block version.
     pub version: i32,
@@ -113,7 +113,7 @@ pub struct GetBlockTemplate {
 
 /// Transaction contents. Part of `getblocktemplate`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct BlockTemplateTransaction {
     /// Transaction data encoded in hexadecimal (byte-for-byte).
     pub data: String,
@@ -143,7 +143,7 @@ pub struct BlockTemplateTransaction {
 /// >
 /// > Returns a json object containing mining-related information.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMiningInfo {
     /// The current block.
     pub blocks: u64,

--- a/types/src/v17/network/mod.rs
+++ b/types/src/v17/network/mod.rs
@@ -24,12 +24,12 @@ pub use self::error::*;
 /// > Arguments:
 /// > 1. "node"   (string, optional) If provided, return information about this specific node, otherwise all nodes are returned.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetAddedNodeInfo(pub Vec<AddedNode>);
 
 /// An added node item. Part of `getaddednodeinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct AddedNode {
     /// The node IP address or name (as provided to addnode).
     #[serde(rename = "addednode")]
@@ -42,7 +42,7 @@ pub struct AddedNode {
 
 /// An added node address item. Part of `getaddednodeinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct AddedNodeAddress {
     /// The bitcoin server IP and port we're connected to.
     pub address: String,
@@ -56,7 +56,7 @@ pub struct AddedNodeAddress {
 /// >
 /// > Returns n (numeric) The connection count
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetConnectionCount(pub u64);
 
 /// Result of JSON-RPC method `getnettotals`.
@@ -66,7 +66,7 @@ pub struct GetConnectionCount(pub u64);
 /// > Returns information about network traffic, including bytes in, bytes out,
 /// > and current time.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetNetTotals {
     /// Total bytes received.
     #[serde(rename = "totalbytesrecv")]
@@ -84,7 +84,7 @@ pub struct GetNetTotals {
 
 /// The upload target totals. Part of `getnettotals`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct UploadTarget {
     /// Length of the measuring timeframe in seconds.
     pub timeframe: u64,
@@ -106,7 +106,7 @@ pub struct UploadTarget {
 ///
 /// > Returns an object containing various state info regarding P2P networking.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetNetworkInfo {
     /// The server version.
     pub version: usize,
@@ -146,7 +146,7 @@ pub struct GetNetworkInfo {
 
 /// Information per network. Part of `getnetworkinfo`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetNetworkInfoNetwork {
     /// Network (ipv4, ipv6, onion, i2p, cjdns).
     pub name: String,
@@ -162,7 +162,7 @@ pub struct GetNetworkInfoNetwork {
 
 /// Local address info. Part of `getnetworkinfo`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetNetworkInfoAddress {
     /// Network address.
     pub address: String,
@@ -178,12 +178,12 @@ pub struct GetNetworkInfoAddress {
 /// >
 /// > Returns data about each connected network node as a json array of objects.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetPeerInfo(pub Vec<PeerInfo>);
 
 /// A peer info item. Part of `getpeerinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct PeerInfo {
     /// Peer index.
     pub id: u32,
@@ -266,12 +266,12 @@ pub struct PeerInfo {
 ///
 /// > List all banned IPs/Subnets.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListBanned(pub Vec<Banned>);
 
 /// An banned item. Part of `listbanned`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Banned {
     // NOTE: Shape taken from Core source code,as method is undocumented in the Bitcoin RPC CLI for version 17 to 20.
     /// The IP/Subnet of the banned node.
@@ -290,5 +290,5 @@ pub struct Banned {
 /// >
 /// > Disable/enable all p2p network activity.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SetNetworkActive(pub bool);

--- a/types/src/v17/raw_transactions/mod.rs
+++ b/types/src/v17/raw_transactions/mod.rs
@@ -38,7 +38,7 @@ pub use crate::psbt::{
 /// >       ,...
 /// >     ]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct CombinePsbt(
     /// The base64-encoded partially signed transaction.
     pub String,
@@ -58,7 +58,7 @@ pub struct CombinePsbt(
 /// >       ,...
 /// >     ]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct CombineRawTransaction(
     /// The hex-encoded raw transaction with signature(s).
     pub String,
@@ -74,7 +74,7 @@ pub struct CombineRawTransaction(
 /// > Arguments:
 /// > 1. "hexstring"              (string, required) The hex string of a raw transaction
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ConvertToPsbt(
     /// The resulting raw transaction (base64-encoded string).
     pub String,
@@ -94,7 +94,7 @@ pub struct ConvertToPsbt(
 /// >          "txid":"id",      (string, required) The transaction id
 /// >          "vout":n,         (numeric, required) The output number
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct CreatePsbt(
     /// The resulting raw transaction (base64-encoded string).
     pub String,
@@ -117,7 +117,7 @@ pub struct CreatePsbt(
 /// >          "txid":"id",      (string, required) The transaction id
 /// >          "vout":n,         (numeric, required) The output number
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct CreateRawTransaction(
     /// hex string of the transaction.
     pub String,
@@ -132,7 +132,7 @@ pub struct CreateRawTransaction(
 /// > Arguments:
 /// > 1. "psbt"            (string, required) The PSBT base64 string
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DecodePsbt {
     /// The decoded network-serialized unsigned transaction.
     pub tx: RawTransaction,
@@ -148,7 +148,7 @@ pub struct DecodePsbt {
 
 /// An input in a partially signed Bitcoin transaction. Part of `decodepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct PsbtInput {
     /// Decoded network transaction for non-witness UTXOs.
     pub non_witness_utxo: Option<RawTransaction>,
@@ -177,7 +177,7 @@ pub struct PsbtInput {
 
 /// An output in a partially signed Bitcoin transaction. Part of `decodepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct PsbtOutput {
     /// The redeem script.
     pub redeem_script: Option<PsbtScript>,
@@ -198,7 +198,7 @@ pub struct PsbtOutput {
 /// > Arguments:
 /// > 1. "hexstring"      (string, required) The transaction hex string
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DecodeRawTransaction(pub RawTransaction);
 
 /// Result of JSON-RPC method `decodescript`.
@@ -211,7 +211,7 @@ pub struct DecodeRawTransaction(pub RawTransaction);
 /// > 1. "hexstring"     (string) the hex encoded script
 // The docs on Core v0.17 appear to be way off what is actually returned.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DecodeScript {
     /// Script public key.
     pub asm: String,
@@ -239,7 +239,7 @@ pub struct DecodeScript {
 /// Seemingly undocumented data returned in the `segwit` field of `DecodeScript`.
 // This seems to be the same as `DecodeScript` except the `p2sh` field is called `p2sh-segwit`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DecodeScriptSegwit {
     /// Script public key.
     pub asm: String,
@@ -269,7 +269,7 @@ pub struct DecodeScriptSegwit {
 /// > Arguments:
 /// > 1. "psbt"                 (string) A base64 string of a PSBT
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct FinalizePsbt {
     /// The base64-encoded partially signed transaction if not extracted.
     pub psbt: Option<String>,
@@ -297,7 +297,7 @@ pub struct FinalizePsbt {
 /// > Arguments:
 /// > 1. "hexstring"           (string, required) The hex string of the raw transaction
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct FundRawTransaction {
     /// The resulting raw transaction (hex-encoded string).
     pub hex: String,
@@ -329,7 +329,7 @@ pub struct FundRawTransaction {
 /// > 2. verbose     (bool, optional, default=false) If false, return a string, otherwise return a json object
 /// > 3. "blockhash" (string, optional) The block in which to look for the transaction
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetRawTransaction(
     /// The serialized, hex-encoded data for 'txid'.
     pub String,
@@ -337,7 +337,7 @@ pub struct GetRawTransaction(
 
 /// Result of JSON-RPC method `getrawtransaction` with verbose set to `true`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetRawTransactionVerbose {
     /// Whether specified block is in the active chain or not (only present with explicit "blockhash" argument).
     pub in_active_chain: Option<bool>,
@@ -390,7 +390,7 @@ pub struct GetRawTransactionVerbose {
 /// > 1. hexstring        (string, required) The hex string of the raw transaction
 /// > 2. allowhighfees    (boolean, optional, default=false) Allow high fees
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SendRawTransaction(
     /// The transaction hash in hex.
     pub String,
@@ -410,7 +410,7 @@ pub struct SendRawTransaction(
 /// > Arguments:
 /// > 1. "hexstring"     (string, required) The transaction hex string
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SignRawTransaction {
     /// The hex-encoded raw transaction with signature(s).
     pub hex: String,
@@ -440,7 +440,7 @@ pub type SignRawTransactionWithKey = SignRawTransaction;
 
 /// A script verification error. Part of `signrawtransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SignFail {
     /// The hash of the referenced, previous transaction.
     pub txid: String,
@@ -470,12 +470,12 @@ pub struct SignFail {
 /// >                                         Length must be one for now.
 /// > 2. allowhighfees    (boolean, optional, default=false) Allow high fees
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct TestMempoolAccept(pub Vec<MempoolAcceptance>);
 
 /// A single mempool acceptance test result. Part of `testmempoolaccept`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct MempoolAcceptance {
     /// The transaction hash in hex.
     pub txid: String,

--- a/types/src/v17/util/mod.rs
+++ b/types/src/v17/util/mod.rs
@@ -27,7 +27,7 @@ pub use self::error::{CreateMultisigError, ValidateAddressError};
 /// >        ,...
 /// >      ]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct CreateMultisig {
     /// The value of the new multisig address.
     pub address: String,
@@ -57,7 +57,7 @@ pub struct CreateMultisig {
 /// >        "ECONOMICAL"
 /// >        "CONSERVATIVE"
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct EstimateSmartFee {
     /// Estimate fee rate in BTC/kB.
     #[serde(rename = "feerate")]
@@ -78,7 +78,7 @@ pub struct EstimateSmartFee {
 /// > 1. "privkey"         (string, required) The private key to sign the message with.
 /// > 2. "message"         (string, required) The message to create a signature of.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SignMessageWithPrivKey(pub String);
 
 /// Result of JSON-RPC method `validateaddress`.
@@ -94,7 +94,7 @@ pub struct SignMessageWithPrivKey(pub String);
 /// > Arguments:
 /// > 1. "address"                    (string, required) The bitcoin address to validate
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ValidateAddress {
     /// If the address is valid or not. If not, this is the only property returned.
     #[serde(rename = "isvalid")]
@@ -127,5 +127,5 @@ pub struct ValidateAddress {
 /// > 2. "signature"       (string, required) The signature provided by the signer in base 64 encoding (see signmessage).
 /// > 3. "message"         (string, required) The message that was signed.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct VerifyMessage(pub bool);

--- a/types/src/v17/wallet/mod.rs
+++ b/types/src/v17/wallet/mod.rs
@@ -24,7 +24,7 @@ use super::SignRawTransaction;
 /// >
 /// > Stops current wallet rescan triggered by an RPC call, e.g. by an importprivkey call.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct AbortRescan(pub bool);
 
 /// Result of the JSON-RPC method `addmultisigaddress`.
@@ -41,7 +41,7 @@ pub struct AbortRescan(pub bool);
 /// > 1. nrequired                      (numeric, required) The number of required signatures out of the n keys or addresses.
 /// > 2. "keys"                         (string, required) A json array of bitcoin addresses or hex-encoded public keys
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct AddMultisigAddress {
     /// The value of the new multisig address.
     pub address: String,
@@ -69,7 +69,7 @@ pub struct AddMultisigAddress {
 /// > Arguments:
 /// > 1. txid                  (string, required) The txid to be bumped
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct BumpFee {
     /// The id of the new transaction.
     pub txid: String,
@@ -91,7 +91,7 @@ pub struct BumpFee {
 /// > Arguments:
 /// > 1. "wallet_name"          (string, required) The name for the new wallet. If this is a path, the wallet will be created at the path location.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct CreateWallet {
     /// The wallet name if created successfully.
     ///
@@ -116,7 +116,7 @@ impl CreateWallet {
 /// > Arguments:
 /// > 1. "address"   (string, required) The bitcoin address for the private key
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DumpPrivKey(pub String); // The private key.
 
 impl DumpPrivKey {
@@ -136,7 +136,7 @@ impl DumpPrivKey {
 /// > Arguments:
 /// > 1. "filename"    (string, required) The filename with path (either absolute or relative to bitcoind)
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DumpWallet {
     /// The filename with full absolute path.
     #[serde(rename = "filename")]
@@ -156,7 +156,7 @@ pub struct DumpWallet {
 /// > Arguments:
 /// > 1. passphrase    (string, required) The pass phrase to encrypt the wallet with. It must be at least 1 character, but should be long.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct EncryptWallet(pub String);
 
 /// Result of the JSON-RPC method `getaddressesbylabel`.
@@ -168,12 +168,12 @@ pub struct EncryptWallet(pub String);
 /// > Arguments:
 /// > 1. "label"  (string, required) The label.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetAddressesByLabel(pub BTreeMap<String, AddressInformation>);
 
 /// Address information. Part of `getaddressesbylabel`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct AddressInformation {
     /// Purpose of address.
     pub purpose: AddressPurpose,
@@ -199,7 +199,7 @@ pub enum AddressPurpose {
 /// > Arguments:
 /// > 1. "address"                    (string, required) The bitcoin address to get the information of.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetAddressInfo {
     /// The bitcoin address validated.
     pub address: String,
@@ -297,7 +297,7 @@ pub enum ScriptType {
 /// ("timestamp", "hdkeypath", "hdseedid") and relation to the wallet ("ismine", "iswatchonly",
 /// "account").
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetAddressInfoEmbedded {
     /// The bitcoin address validated.
     pub address: String,
@@ -336,7 +336,7 @@ pub struct GetAddressInfoEmbedded {
 
 /// Address label field. Part of `getaddressinfo` and `getaddressinfoembedded`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetAddressInfoLabel {
     /// The label.
     pub name: String,
@@ -352,7 +352,7 @@ pub struct GetAddressInfoLabel {
 /// > The available balance is what the wallet considers currently spendable, and is
 /// > thus affected by options which limit spendability such as -spendzeroconfchange.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBalance(pub f64);
 
 impl GetBalance {
@@ -371,7 +371,7 @@ impl GetBalance {
 /// > If 'label' is specified, it is added to the address book
 /// > so payments received with the address will be associated with 'label'.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetNewAddress(pub String);
 
 /// Result of the JSON-RPC method `getrawchangeaddress`.
@@ -381,7 +381,7 @@ pub struct GetNewAddress(pub String);
 /// > Returns a new Bitcoin address, for receiving change.
 /// > This is for use with raw transactions, NOT normal use.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetRawChangeAddress(pub String);
 
 /// Result of the JSON-RPC method `getreceivedbyaddress`.
@@ -393,7 +393,7 @@ pub struct GetRawChangeAddress(pub String);
 /// > Arguments:
 /// > 1. "address"         (string, required) The bitcoin address for transactions.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetReceivedByAddress(pub f64); // Amount in BTC.
 
 /// Result of the JSON-RPC method `gettransaction`.
@@ -405,7 +405,7 @@ pub struct GetReceivedByAddress(pub f64); // Amount in BTC.
 /// > Arguments:
 /// > 1. txid                 (string, required) The transaction id
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetTransaction {
     /// The transaction amount in BTC.
     pub amount: f64,
@@ -450,7 +450,7 @@ pub struct GetTransaction {
 
 /// Transaction detail. Part of the `gettransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetTransactionDetail {
     /// DEPRECATED. The account name involved in the transaction, can be "" for the default account.
     pub account: Option<String>, // Docs are wrong, this is not documented as optional.
@@ -508,7 +508,7 @@ pub enum Bip125Replaceable {
 /// > getunconfirmedbalance
 /// > Returns the server's total unconfirmed balance
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetUnconfirmedBalance(pub f64); // Core docs are missing so this is just a guess.
 
 /// Result of the JSON-RPC method `getwalletinfo`.
@@ -516,7 +516,7 @@ pub struct GetUnconfirmedBalance(pub f64); // Core docs are missing so this is j
 /// > getwalletinfo
 /// > Returns an object containing various wallet state info.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetWalletInfo {
     /// The wallet name.
     #[serde(rename = "walletname")]
@@ -604,7 +604,7 @@ pub struct JsonRpcError {
 /// > made public by common use as inputs or as the resulting change
 /// > in past transactions
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListAddressGroupings(pub Vec<Vec<ListAddressGroupingsItem>>);
 
 /// List item type. Part of `listaddressgroupings`.
@@ -627,7 +627,7 @@ pub enum ListAddressGroupingsItem {
 /// >
 /// > Returns the list of all labels, or labels that are assigned to addresses with a specific purpose.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListLabels(pub Vec<String>);
 
 /// Result of the JSON-RPC method `listlockunspent`.
@@ -637,12 +637,12 @@ pub struct ListLabels(pub Vec<String>);
 /// > Returns list of temporarily unspendable outputs.
 /// > See the lockunspent call to lock and unlock transactions for spending.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListLockUnspent(pub Vec<ListLockUnspentItem>);
 
 /// List lock unspent item. Part of of `listlockunspent`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListLockUnspentItem {
     /// The transaction id locked.
     pub txid: String,
@@ -656,12 +656,12 @@ pub struct ListLockUnspentItem {
 /// >
 /// > List balances by receiving address.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListReceivedByAddress(pub Vec<ListReceivedByAddressItem>);
 
 /// List received by address item. Part of of `listreceivedbyaddress`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListReceivedByAddressItem {
     /// Only returned if imported addresses were involved in transaction.
     #[serde(rename = "involvesWatchonly")]
@@ -688,7 +688,7 @@ pub struct ListReceivedByAddressItem {
 /// > If "blockhash" is no longer a part of the main chain, transactions from the fork point onward are included.
 /// > Additionally, if include_removed is set, transactions affecting the wallet which were removed are returned in the "removed" array.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListSinceBlock {
     /// All the transactions.
     pub transactions: Vec<TransactionItem>,
@@ -708,7 +708,7 @@ pub struct ListSinceBlock {
 
 /// Transaction item. Part of `listsinceblock` and `listtransactions`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct TransactionItem {
     /// DEPRECATED. The account name associated with the transaction. Will be "" for the default account.
     pub account: Option<String>,
@@ -790,7 +790,7 @@ pub struct TransactionItem {
 /// > Note that the "account" argument and "otheraccount" return value have been removed in V0.17. To use this RPC with an "account" argument, restart
 /// > bitcoind with -deprecatedrpc=accounts
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListTransactions(pub Vec<TransactionItem>);
 
 /// Result of the JSON-RPC method `listunspent`.
@@ -801,12 +801,12 @@ pub struct ListTransactions(pub Vec<TransactionItem>);
 /// > with between minconf and maxconf (inclusive) confirmations.
 /// > Optionally filter to only include txouts paid to specified addresses.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListUnspent(pub Vec<ListUnspentItem>);
 
 /// Unspent transaction output. Part of `listunspent`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListUnspentItem {
     /// The transaction id.
     pub txid: String,
@@ -844,7 +844,7 @@ pub struct ListUnspentItem {
 /// > Returns a list of currently loaded wallets.
 /// > For full information on the wallet, use "getwalletinfo"
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListWallets(pub Vec<String>);
 
 /// Result of the JSON-RPC method `loadwallet`.
@@ -858,7 +858,7 @@ pub struct ListWallets(pub Vec<String>);
 /// > Arguments:
 /// > 1. "filename"    (string, required) The wallet directory or .dat file.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct LoadWallet {
     /// The wallet name if loaded successfully.
     pub name: String,
@@ -886,7 +886,7 @@ pub struct LockUnspent(pub bool);
 /// >
 /// > Rescan the local blockchain for wallet related transactions.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct RescanBlockchain {
     /// The block height where the rescan has started.
     pub start_height: i64,
@@ -911,7 +911,7 @@ pub struct RescanBlockchain {
 /// >       ,...
 /// >     }
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SendMany(
     /// The transaction id for the send.
     ///
@@ -929,7 +929,7 @@ pub struct SendMany(
 /// > 1. "address"            (string, required) The bitcoin address to send to.
 /// > 2. "amount"             (numeric or string, required) The amount in BTC to send. eg 0.1
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SendToAddress(pub String);
 
 impl SendToAddress {
@@ -956,7 +956,7 @@ pub struct SetTxFee(pub bool);
 /// > 1. "address"         (string, required) The bitcoin address to use for the private key.
 /// > 2. "message"         (string, required) The message to create a signature of.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SignMessage(
     /// The signature of the message encoded in base 64.
     pub String,
@@ -1006,7 +1006,7 @@ pub type SignRawTransactionWithWallet = SignRawTransaction;
 /// >                              accepted as second parameter.
 /// >    ]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct WalletCreateFundedPsbt {
     /// The resulting raw transaction (base64-encoded string).
     pub psbt: String,
@@ -1028,7 +1028,7 @@ pub struct WalletCreateFundedPsbt {
 /// > Arguments:
 /// > 1. "psbt"                      (string, required) The transaction base64 string
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct WalletProcessPsbt {
     /// The base64-encoded partially signed transaction.
     pub psbt: String,

--- a/types/src/v17/zmq.rs
+++ b/types/src/v17/zmq.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 ///>
 ///> Returns information about the active ZeroMQ notifications.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetZmqNotifications {
     /// Type of notification.
     #[serde(rename = "type")]

--- a/types/src/v18/blockchain/mod.rs
+++ b/types/src/v18/blockchain/mod.rs
@@ -21,14 +21,14 @@ use super::{MapMempoolEntryError, MempoolEntryError, MempoolEntryFees};
 /// > Arguments:
 /// > 1. "txid"                 (string, required) The transaction id (must be in mempool)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolAncestors(pub Vec<String>);
 
 /// Result of JSON-RPC method `getmempoolancestors` with verbose set to true.
 ///
 /// Map of txid to `MempoolEntry` i.e., an ancestor.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolAncestorsVerbose(pub BTreeMap<String, MempoolEntry>);
 
 /// Result of JSON-RPC method `getmempooldescendants` with verbose set to `false`.
@@ -40,14 +40,14 @@ pub struct GetMempoolAncestorsVerbose(pub BTreeMap<String, MempoolEntry>);
 /// > Arguments:
 /// > 1. "txid"                 (string, required) The transaction id (must be in mempool)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolDescendants(pub Vec<String>);
 
 /// Result of JSON-RPC method `getmempooldescendants` with verbose set to true.
 ///
 /// Map of txid to [`MempoolEntry`] i.e., a descendant.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolDescendantsVerbose(pub BTreeMap<String, MempoolEntry>);
 
 /// Result of JSON-RPC method `getmempoolentry`.
@@ -59,12 +59,12 @@ pub struct GetMempoolDescendantsVerbose(pub BTreeMap<String, MempoolEntry>);
 /// > Arguments:
 /// > 1. "txid"                 (string, required) The transaction id (must be in mempool)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolEntry(pub MempoolEntry);
 
 /// Mempool data. Part of `getmempoolentry`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct MempoolEntry {
     /// Virtual transaction size as defined in BIP 141.
     ///

--- a/types/src/v18/control.rs
+++ b/types/src/v18/control.rs
@@ -12,14 +12,14 @@ use serde::{Deserialize, Serialize};
 /// >
 /// > Returns details of the RPC server.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetRpcInfo {
     active_commands: Vec<ActiveCommand>,
 }
 
 /// Information about an active command. Part of `getrpcinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ActiveCommand {
     /// The name of the RPC command.
     pub method: String,

--- a/types/src/v18/network/mod.rs
+++ b/types/src/v18/network/mod.rs
@@ -14,12 +14,12 @@ use serde::{Deserialize, Serialize};
 /// >
 /// > Return known addresses which can potentially be used to find new nodes in the network.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetNodeAddresses(pub Vec<NodeAddress>);
 
 /// An item from the list returned by the JSON-RPC method `getnodeaddresses`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct NodeAddress {
     /// Timestamp in seconds since epoch (Jan 1 1970 GMT) when the node was last seen.
     pub time: u64,
@@ -37,12 +37,12 @@ pub struct NodeAddress {
 /// >
 /// > Returns data about each connected network node as a json array of objects.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetPeerInfo(pub Vec<PeerInfo>);
 
 /// A peer info item. Part of `getpeerinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct PeerInfo {
     /// Peer index.
     pub id: u32,

--- a/types/src/v18/raw_transactions/mod.rs
+++ b/types/src/v18/raw_transactions/mod.rs
@@ -20,7 +20,7 @@ pub use self::error::{AnalyzePsbtError, AnalyzePsbtInputMissingError};
 /// Arguments:
 /// 1. psbt    (string, required) A base64 string of a PSBT
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct AnalyzePsbt {
     /// Array of input objects.
     pub inputs: Vec<AnalyzePsbtInput>,
@@ -39,7 +39,7 @@ pub struct AnalyzePsbt {
 
 /// Represents an input in a PSBT operation. Part of `analyzepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct AnalyzePsbtInput {
     /// Whether a UTXO is provided.
     pub has_utxo: bool,
@@ -53,7 +53,7 @@ pub struct AnalyzePsbtInput {
 
 /// Represents missing elements required to complete an input. Part of `analyzepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct AnalyzePsbtInputMissing {
     /// Public key ID, hash160 of the public key, of a public key whose BIP 32 derivation path is missing.
     pub pubkeys: Option<Vec<String>>,
@@ -81,7 +81,7 @@ pub struct AnalyzePsbtInputMissing {
 /// >        ...
 /// >      ]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct JoinPsbts(
     /// The base64-encoded partially signed transaction.
     pub String,
@@ -96,7 +96,7 @@ pub struct JoinPsbts(
 /// > Arguments:
 /// > 1. psbt    (string, required) A base64 string of a PSBT
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct UtxoUpdatePsbt(
     /// The base64-encoded partially signed transaction with inputs updated.
     pub String,

--- a/types/src/v18/util/mod.rs
+++ b/types/src/v18/util/mod.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 /// > Derives one or more addresses corresponding to an output descriptor.
 /// > Returns an array of derived addresses.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DeriveAddresses(pub Vec<String>);
 
 /// Result of JSON-RPC method `getdescriptorinfo`.
@@ -25,7 +25,7 @@ pub struct DeriveAddresses(pub Vec<String>);
 /// > Analyses a descriptor.
 /// > Returns information about the descriptor.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetDescriptorInfo {
     /// The descriptor in canonical form, without private keys.
     pub descriptor: String,

--- a/types/src/v18/wallet/mod.rs
+++ b/types/src/v18/wallet/mod.rs
@@ -25,7 +25,7 @@ pub use super::{
 /// > Arguments:
 /// > 1. "address"                    (string, required) The bitcoin address to get the information of.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetAddressInfo {
     /// The bitcoin address validated.
     pub address: String,
@@ -96,7 +96,7 @@ pub struct GetAddressInfo {
 /// It includes all getaddressinfo output fields for the embedded address, excluding metadata
 /// ("timestamp", "hdkeypath", "hdseedid") and relation to the wallet ("ismine", "iswatchonly").
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetAddressInfoEmbedded {
     /// The bitcoin address validated.
     pub address: String,
@@ -149,7 +149,7 @@ pub struct GetAddressInfoEmbedded {
 /// >
 /// > Returns the total amount received by addresses with `<label>` in transactions with at least `[minconf]` confirmations.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetReceivedByLabel(pub f64);
 
 /// Result of the JSON-RPC method `getwalletinfo`.
@@ -157,7 +157,7 @@ pub struct GetReceivedByLabel(pub f64);
 /// > getwalletinfo
 /// > Returns an object containing various wallet state info.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetWalletInfo {
     /// The wallet name.
     #[serde(rename = "walletname")]
@@ -242,12 +242,12 @@ pub struct JsonRpcError {
 /// >
 /// > List balances by receiving address.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListReceivedByAddress(pub Vec<ListReceivedByAddressItem>);
 
 /// List received by address item. Part of of `listreceivedbyaddress`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListReceivedByAddressItem {
     /// Only returned if imported addresses were involved in transaction.
     #[serde(rename = "involvesWatchonly")]
@@ -270,12 +270,12 @@ pub struct ListReceivedByAddressItem {
 /// >
 /// > List received transactions by label.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListReceivedByLabel(pub Vec<ListReceivedByLabelItem>);
 
 /// List received by label item. Part of of `listreceivedbyaddress`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListReceivedByLabelItem {
     /// Only returned if imported addresses were involved in transaction.
     #[serde(rename = "involvesWatchonly")]
@@ -296,12 +296,12 @@ pub struct ListReceivedByLabelItem {
 /// > with between minconf and maxconf (inclusive) confirmations.
 /// > Optionally filter to only include txouts paid to specified addresses.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListUnspent(pub Vec<ListUnspentItem>);
 
 /// Unspent transaction output. Part of `listunspent`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListUnspentItem {
     /// The transaction id.
     pub txid: String,
@@ -340,7 +340,7 @@ pub struct ListUnspentItem {
 /// >
 /// > Returns a list of wallets in the wallet directory.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListWalletDir {
     /// The list of wallets in the wallet directory.
     pub wallets: Vec<ListWalletDirWallet>,
@@ -348,7 +348,7 @@ pub struct ListWalletDir {
 
 /// Wallet entry. Part of `listwalletdir`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListWalletDirWallet {
     /// The wallet name.
     pub name: String,

--- a/types/src/v18/zmq.rs
+++ b/types/src/v18/zmq.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 ///>
 ///> Returns information about the active ZeroMQ notifications.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetZmqNotifications {
     /// Type of notification.
     #[serde(rename = "type")]

--- a/types/src/v19/blockchain/mod.rs
+++ b/types/src/v19/blockchain/mod.rs
@@ -21,7 +21,7 @@ use super::{GetChainTxStatsError, GetMempoolInfoError};
 /// >
 /// > Returns an object containing various state info regarding blockchain processing.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockchainInfo {
     /// Current network name as defined in BIP70 (main, test, signet, regtest).
     pub chain: String,
@@ -66,7 +66,7 @@ pub struct GetBlockchainInfo {
 
 /// Softfork status. Part of `getblockchaininfo`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Softfork {
     /// The [`SoftforkType`]: one of "buried", "bip9".
     #[serde(rename = "type")]
@@ -95,7 +95,7 @@ pub enum SoftforkType {
 
 /// BIP-9 softfork info. Part of `getblockchaininfo`.
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Bip9SoftforkInfo {
     /// One of "defined", "started", "locked_in", "active", "failed".
     pub status: Bip9SoftforkStatus,
@@ -129,7 +129,7 @@ pub enum Bip9SoftforkStatus {
 
 /// BIP-9 softfork statistics. Part of `getblockchaininfo`.
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Bip9SoftforkStatistics {
     /// The length in blocks of the BIP9 signalling period.
     pub period: i64,
@@ -153,7 +153,7 @@ pub struct Bip9SoftforkStatistics {
 /// > 1. blockhash     (string, required) The hash of the block
 /// > 2. filtertype    (string, optional, default=basic) The type name of the filter
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockFilter {
     /// The hex-encoded filter data.
     pub filter: String,
@@ -167,7 +167,7 @@ pub struct GetBlockFilter {
 /// >
 /// > Compute statistics about the total number and rate of transactions in the chain.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetChainTxStats {
     /// The timestamp for the final block in the window in UNIX format.
     pub time: i64,
@@ -198,14 +198,14 @@ pub struct GetChainTxStats {
 /// > Arguments:
 /// > 1. "txid"                 (string, required) The transaction id (must be in mempool)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolAncestors(pub Vec<String>);
 
 /// Result of JSON-RPC method `getmempoolancestors` with verbose set to true.
 ///
 /// Map of txid to `MempoolEntry` i.e., an ancestor.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolAncestorsVerbose(pub BTreeMap<String, MempoolEntry>);
 
 /// Result of JSON-RPC method `getmempooldescendants` with verbose set to `false`.
@@ -217,14 +217,14 @@ pub struct GetMempoolAncestorsVerbose(pub BTreeMap<String, MempoolEntry>);
 /// > Arguments:
 /// > 1. "txid"                 (string, required) The transaction id (must be in mempool)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolDescendants(pub Vec<String>);
 
 /// Result of JSON-RPC method `getmempooldescendants` with verbose set to true.
 ///
 /// Map of txid to [`MempoolEntry`] i.e., a descendant.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolDescendantsVerbose(pub BTreeMap<String, MempoolEntry>);
 
 /// Result of JSON-RPC method `getmempoolentry`.
@@ -236,12 +236,12 @@ pub struct GetMempoolDescendantsVerbose(pub BTreeMap<String, MempoolEntry>);
 /// > Arguments:
 /// > 1. "txid"                 (string, required) The transaction id (must be in mempool)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolEntry(pub MempoolEntry);
 
 /// Mempool data. Part of `getmempoolentry`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct MempoolEntry {
     /// Virtual transaction size as defined in BIP 141.
     ///
@@ -299,7 +299,7 @@ pub struct MempoolEntry {
 /// Contains the base fee, modified fee (with fee deltas), and ancestor/descendant fee totals,
 /// all in BTC.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct MempoolEntryFees {
     /// Transaction fee in BTC.
     pub base: f64,
@@ -317,7 +317,7 @@ pub struct MempoolEntryFees {
 /// >
 /// > Returns details on the active state of the TX memory pool.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolInfo {
     /// True if the mempool is fully loaded. v0.19 and later only.
     pub loaded: bool,

--- a/types/src/v19/control.rs
+++ b/types/src/v19/control.rs
@@ -14,7 +14,7 @@ use super::ActiveCommand;
 /// >
 /// > Returns details of the RPC server.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetRpcInfo {
     /// All active commands
     pub active_commands: Vec<ActiveCommand>,

--- a/types/src/v19/network/mod.rs
+++ b/types/src/v19/network/mod.rs
@@ -18,7 +18,7 @@ use super::{GetNetworkInfoAddress, GetNetworkInfoError, GetNetworkInfoNetwork};
 ///
 /// > Returns an object containing various state info regarding P2P networking.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetNetworkInfo {
     /// The server version.
     pub version: usize,
@@ -65,12 +65,12 @@ pub struct GetNetworkInfo {
 /// >
 /// > Returns data about each connected network node as a json array of objects.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetPeerInfo(pub Vec<PeerInfo>);
 
 /// A peer info item. Part of `getpeerinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct PeerInfo {
     /// Peer index.
     pub id: u32,

--- a/types/src/v19/util.rs
+++ b/types/src/v19/util.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 /// > Analyses a descriptor.
 /// > Returns information about the descriptor.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetDescriptorInfo {
     /// The descriptor in canonical form, without private keys.
     pub descriptor: String,

--- a/types/src/v19/wallet/mod.rs
+++ b/types/src/v19/wallet/mod.rs
@@ -19,7 +19,7 @@ use super::{Bip125Replaceable, GetTransactionDetail, GetTransactionError, GetWal
 /// >
 /// > Returns an object with all balances in BTC.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBalances {
     /// Balances from outputs that the wallet can sign.
     pub mine: GetBalancesMine,
@@ -29,7 +29,7 @@ pub struct GetBalances {
 
 /// Balances from outputs that the wallet can sign. Part of `getbalances`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBalancesMine {
     /// Trusted balance (outputs created by the wallet or confirmed outputs).
     pub trusted: f64,
@@ -45,7 +45,7 @@ pub struct GetBalancesMine {
 
 /// Hash and height of the block this information was generated on. Part of `getbalances`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBalancesWatchOnly {
     /// Trusted balance (outputs created by the wallet or confirmed outputs).
     pub trusted: f64,
@@ -64,7 +64,7 @@ pub struct GetBalancesWatchOnly {
 /// > Arguments:
 /// > 1. txid                 (string, required) The transaction id
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetTransaction {
     /// The transaction amount in BTC.
     pub amount: f64,
@@ -112,7 +112,7 @@ pub struct GetTransaction {
 /// > getwalletinfo
 /// > Returns an object containing various wallet state info.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetWalletInfo {
     /// The wallet name.
     #[serde(rename = "walletname")]
@@ -176,7 +176,7 @@ pub enum GetWalletInfoScanning {
 /// > 1. flag     (string, required) The name of the flag to change. Current available flags: avoid_reuse
 /// > 2. value    (boolean, optional, default=true) The new state.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SetWalletFlag {
     /// The name of the flag that was modified.
     pub flag_name: String,

--- a/types/src/v20/control.rs
+++ b/types/src/v20/control.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// > Gets and sets the logging configuration.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Logging {
     pub addrman: bool,
     pub bench: bool,

--- a/types/src/v20/generating.rs
+++ b/types/src/v20/generating.rs
@@ -20,7 +20,7 @@ use crate::model;
 /// > 2. descriptor    (string, required) The descriptor to send the newly generated bitcoin to.
 /// > 3. maxtries      (numeric, optional, default=1000000) How many iterations to try.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GenerateToDescriptor(
     /// Hashes of blocks generated.
     pub Vec<String>,

--- a/types/src/v20/network.rs
+++ b/types/src/v20/network.rs
@@ -12,12 +12,12 @@ use serde::{Deserialize, Serialize};
 ///
 /// > List all banned IPs/Subnets.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListBanned(pub Vec<Banned>);
 
 /// An banned item. Part of `listbanned`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Banned {
     /// The IP/Subnet of the banned node.
     pub address: String,

--- a/types/src/v20/util/mod.rs
+++ b/types/src/v20/util/mod.rs
@@ -25,7 +25,7 @@ pub use super::CreateMultisigError;
 /// >        ,...
 /// >      ]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct CreateMultisig {
     /// The value of the new multisig address.
     pub address: String,

--- a/types/src/v20/wallet/mod.rs
+++ b/types/src/v20/wallet/mod.rs
@@ -30,7 +30,7 @@ pub use super::{
 /// > 1. nrequired                      (numeric, required) The number of required signatures out of the n keys or addresses.
 /// > 2. "keys"                         (string, required) A json array of bitcoin addresses or hex-encoded public keys
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct AddMultisigAddress {
     /// The value of the new multisig address.
     pub address: String,
@@ -51,7 +51,7 @@ pub struct AddMultisigAddress {
 /// > Arguments:
 /// > 1. "address"                    (string, required) The bitcoin address to get the information of.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetAddressInfo {
     /// The bitcoin address validated.
     pub address: String,
@@ -120,7 +120,7 @@ pub struct GetAddressInfo {
 /// It includes all getaddressinfo output fields for the embedded address, excluding metadata
 /// ("timestamp", "hdkeypath", "hdseedid") and relation to the wallet ("ismine", "iswatchonly").
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetAddressInfoEmbedded {
     /// The bitcoin address validated.
     pub address: String,
@@ -174,7 +174,7 @@ pub struct GetAddressInfoEmbedded {
 /// > Arguments:
 /// > 1. txid                 (string, required) The transaction id
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetTransaction {
     /// The transaction amount in BTC.
     pub amount: f64,
@@ -226,7 +226,7 @@ pub struct GetTransaction {
 
 /// Transaction detail. Part of the `gettransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetTransactionDetail {
     /// Only returns true if imported addresses were involved in transaction. v20 and later only.
     #[serde(rename = "involvesWatchonly")]
@@ -261,7 +261,7 @@ pub struct GetTransactionDetail {
 /// > If "blockhash" is no longer a part of the main chain, transactions from the fork point onward are included.
 /// > Additionally, if include_removed is set, transactions affecting the wallet which were removed are returned in the "removed" array.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListSinceBlock {
     /// All the transactions.
     pub transactions: Vec<TransactionItem>,
@@ -281,7 +281,7 @@ pub struct ListSinceBlock {
 
 /// Transaction item. Part of `listsinceblock`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct TransactionItem {
     /// Only returns true if imported addresses were involved in transaction.
     #[serde(rename = "involvesWatchonly")]
@@ -354,5 +354,5 @@ pub struct TransactionItem {
 /// > Note that the "account" argument and "otheraccount" return value have been removed in V0.17. To use this RPC with an "account" argument, restart
 /// > bitcoind with -deprecatedrpc=accounts
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListTransactions(pub Vec<TransactionItem>);

--- a/types/src/v21/blockchain/mod.rs
+++ b/types/src/v21/blockchain/mod.rs
@@ -21,7 +21,7 @@ pub use super::{
 /// >
 /// > Returns an object containing various state info regarding blockchain processing.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockchainInfo {
     /// Current network name as defined in BIP70 (main, test, signet, regtest).
     pub chain: String,
@@ -66,7 +66,7 @@ pub struct GetBlockchainInfo {
 
 /// Softfork status. Part of `getblockchaininfo`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Softfork {
     /// The [`SoftforkType`]: one of "buried", "bip9".
     #[serde(rename = "type")]
@@ -95,7 +95,7 @@ pub enum SoftforkType {
 
 /// BIP-9 softfork info. Part of `getblockchaininfo`.
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Bip9SoftforkInfo {
     /// One of "defined", "started", "locked_in", "active", "failed".
     pub status: Bip9SoftforkStatus,
@@ -122,14 +122,14 @@ pub struct Bip9SoftforkInfo {
 /// > Arguments:
 /// > 1. "txid"                 (string, required) The transaction id (must be in mempool)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolAncestors(pub Vec<String>);
 
 /// Result of JSON-RPC method `getmempoolancestors` with verbose set to true.
 ///
 /// Map of txid to `MempoolEntry` i.e., an ancestor.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolAncestorsVerbose(pub BTreeMap<String, MempoolEntry>);
 
 /// Result of JSON-RPC method `getmempooldescendants` with verbose set to `false`.
@@ -141,14 +141,14 @@ pub struct GetMempoolAncestorsVerbose(pub BTreeMap<String, MempoolEntry>);
 /// > Arguments:
 /// > 1. "txid"                 (string, required) The transaction id (must be in mempool)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolDescendants(pub Vec<String>);
 
 /// Result of JSON-RPC method `getmempooldescendants` with verbose set to true.
 ///
 /// Map of txid to [`MempoolEntry`] i.e., a descendant.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolDescendantsVerbose(pub BTreeMap<String, MempoolEntry>);
 
 /// Result of JSON-RPC method `getmempoolentry`.
@@ -160,12 +160,12 @@ pub struct GetMempoolDescendantsVerbose(pub BTreeMap<String, MempoolEntry>);
 /// > Arguments:
 /// > 1. "txid"                 (string, required) The transaction id (must be in mempool)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolEntry(pub MempoolEntry);
 
 /// Mempool data. Part of `getmempoolentry`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct MempoolEntry {
     /// Virtual transaction size as defined in BIP 141.
     ///
@@ -223,7 +223,7 @@ pub struct MempoolEntry {
 /// >
 /// > Returns details on the active state of the TX memory pool.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolInfo {
     /// True if the mempool is fully loaded. v0.19 and later only.
     pub loaded: bool,

--- a/types/src/v21/generating/mod.rs
+++ b/types/src/v21/generating/mod.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 /// >        ...
 /// >      ]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GenerateBlock {
     /// Hash of generated block
     pub hash: String,

--- a/types/src/v21/hidden.rs
+++ b/types/src/v21/hidden.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 /// > 1. address    (string, required) The IP address of the peer
 /// > 2. port       (numeric, required) The port of the peer
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct AddPeerAddress {
     /// Whether the peer address was successfully added to the address manager.
     pub success: bool,

--- a/types/src/v21/network/mod.rs
+++ b/types/src/v21/network/mod.rs
@@ -18,7 +18,7 @@ use super::{GetNetworkInfoAddress, GetNetworkInfoError, GetNetworkInfoNetwork};
 ///
 /// > Returns an object containing various state info regarding P2P networking.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetNetworkInfo {
     /// The server version.
     pub version: usize,
@@ -69,12 +69,12 @@ pub struct GetNetworkInfo {
 /// >
 /// > Returns data about each connected network node as a json array of objects.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetPeerInfo(pub Vec<PeerInfo>);
 
 /// A peer info item. Part of `getpeerinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct PeerInfo {
     /// Peer index.
     pub id: u32,

--- a/types/src/v21/raw_transactions/mod.rs
+++ b/types/src/v21/raw_transactions/mod.rs
@@ -26,12 +26,12 @@ pub use self::error::{MempoolAcceptanceError, TestMempoolAcceptError};
 /// >                                         Length must be one for now.
 /// > 2. allowhighfees    (boolean, optional, default=false) Allow high fees
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct TestMempoolAccept(pub Vec<MempoolAcceptance>);
 
 /// A single mempool acceptance test result. Part of `testmempoolaccept`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct MempoolAcceptance {
     /// The transaction hash in hex.
     pub txid: String,
@@ -48,7 +48,7 @@ pub struct MempoolAcceptance {
 
 /// Wrapper for the fees field. Part of `testmempoolaccept`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct MempoolAcceptanceFees {
     /// Transaction fee in BTC.
     pub base: f64,

--- a/types/src/v21/util.rs
+++ b/types/src/v21/util.rs
@@ -12,12 +12,12 @@ use serde::{Deserialize, Serialize};
 ///
 /// > Returns the status of one or all available indices currently running in the node.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetIndexInfo(pub BTreeMap<String, GetIndexInfoName>);
 
 /// Index info details. Part of `getindexinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetIndexInfoName {
     /// Whether the index is synced or not.
     pub synced: bool,

--- a/types/src/v21/wallet/mod.rs
+++ b/types/src/v21/wallet/mod.rs
@@ -17,7 +17,7 @@ pub use super::GetWalletInfoError;
 /// > getwalletinfo
 /// > Returns an object containing various wallet state info.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetWalletInfo {
     /// The wallet name.
     #[serde(rename = "walletname")]
@@ -110,7 +110,7 @@ pub enum GetWalletInfoScanning {
 /// >      ...
 /// >    ]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ImportDescriptors(
     /// Response is an array with the same size as the input that has the execution result.
     pub Vec<ImportDescriptorsResult>,
@@ -118,7 +118,7 @@ pub struct ImportDescriptors(
 
 /// Result object for each descriptor import. Part of `importdescriptors`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ImportDescriptorsResult {
     /// Whether the import was successful.
     pub success: bool,
@@ -137,7 +137,7 @@ pub struct ImportDescriptorsResult {
 /// Arguments:
 /// 1. txid    (string, required) The txid to be bumped
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct PsbtBumpFee {
     /// The base64-encoded unsigned PSBT of the new transaction.
     pub psbt: String,
@@ -161,7 +161,7 @@ pub struct PsbtBumpFee {
 /// >    That is, each address can only appear once and there can only be one 'data' object.
 /// >    For convenience, a dictionary, which holds the key-value pairs directly, is also accepted.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Send {
     /// If the transaction has a complete set of signatures.
     pub complete: bool,
@@ -187,7 +187,7 @@ pub struct Send {
 /// > ...
 /// > 10. verbose (boolean, optional, default=false) If true, return extra infomration about the transaction.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SendMany(
     /// The transaction id for the send.
     pub String,
@@ -195,7 +195,7 @@ pub struct SendMany(
 
 /// Result of JSON-RPC method `sendmany` when `verbose=true`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SendManyVerbose {
     /// The transaction id for the send. Only 1 transaction is created regardless of the number of addresses.
     pub txid: String,
@@ -210,7 +210,7 @@ pub struct SendManyVerbose {
 /// > Unloads the wallet referenced by the request endpoint, otherwise unloads the wallet specified in the argument.
 /// > Specifying the wallet name on a wallet endpoint is invalid.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct UnloadWallet {
     /// Warning messages, if any, related to unloading the wallet.
     pub warning: String,
@@ -221,7 +221,7 @@ pub struct UnloadWallet {
 /// > Upgrade the wallet. Upgrades to the latest version if no version number is specified.
 /// > New keys may be generated and a new wallet backup will need to be made.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct UpgradeWallet {
     /// Name of wallet this operation was performed on
     pub wallet_name: String,

--- a/types/src/v22/blockchain/mod.rs
+++ b/types/src/v22/blockchain/mod.rs
@@ -16,7 +16,7 @@ pub use super::GetMempoolInfoError;
 /// >
 /// > Returns details on the active state of the TX memory pool.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolInfo {
     /// True if the mempool is fully loaded. v0.19 and later only.
     pub loaded: bool,

--- a/types/src/v22/control.rs
+++ b/types/src/v22/control.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// > Gets and sets the logging configuration.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Logging {
     pub addrman: bool,
     pub bench: bool,

--- a/types/src/v22/network.rs
+++ b/types/src/v22/network.rs
@@ -16,12 +16,12 @@ use serde::{Deserialize, Serialize};
 /// > These can potentially be used to find new peers in the network.
 /// > The total number of addresses known to the node may be higher.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetNodeAddresses(pub Vec<NodeAddress>);
 
 /// An node address item. Part of `getnodeaddresses`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct NodeAddress {
     /// Timestamp in seconds since epoch (Jan 1 1970 GMT) when the node was last seen.
     pub time: u64,
@@ -41,12 +41,12 @@ pub struct NodeAddress {
 /// >
 /// > Returns data about each connected network node as a json array of objects.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetPeerInfo(pub Vec<PeerInfo>);
 
 /// A peer info item. Part of `getpeerinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct PeerInfo {
     /// Peer index.
     pub id: u32,
@@ -153,12 +153,12 @@ pub struct PeerInfo {
 ///
 /// > List all banned IPs/Subnets.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListBanned(pub Vec<Banned>);
 
 /// An banned item. Part of `listbanned`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Banned {
     /// The IP/Subnet of the banned node.
     pub address: String,

--- a/types/src/v22/raw_transactions/mod.rs
+++ b/types/src/v22/raw_transactions/mod.rs
@@ -21,7 +21,7 @@ pub use self::error::{DecodeScriptError, MempoolAcceptanceError, TestMempoolAcce
 /// > 1. "hexstring"     (string) the hex encoded script
 // The docs on Core v0.17 appear to be way off what is actually returned.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DecodeScript {
     /// Script public key.
     pub asm: String,
@@ -46,7 +46,7 @@ pub struct DecodeScript {
 
 /// Segwit data. Part of `decodescript`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DecodeScriptSegwit {
     /// Script public key.
     pub asm: String,
@@ -82,12 +82,12 @@ pub struct DecodeScriptSegwit {
 /// >                                         Length must be one for now.
 /// > 2. allowhighfees    (boolean, optional, default=false) Allow high fees
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct TestMempoolAccept(pub Vec<MempoolAcceptance>);
 
 /// A single mempool acceptance test result. Part of `testmempoolaccept`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct MempoolAcceptance {
     /// The transaction hash in hex.
     pub txid: String,
@@ -106,7 +106,7 @@ pub struct MempoolAcceptance {
 
 /// Wrapper for the fees field. Part of `testmempoolaccept`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct MempoolAcceptanceFees {
     /// Transaction fee in BTC.
     pub base: f64,

--- a/types/src/v22/signer.rs
+++ b/types/src/v22/signer.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// > Returns a list of external signers from -signer.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct EnumerateSigners {
     /// List of external signers.
     pub signers: Vec<Signers>,
@@ -18,7 +18,7 @@ pub struct EnumerateSigners {
 
 /// An signer item. Part of `enumeratesigners`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Signers {
     /// Master key fingerprint.
     pub fingerprint: String,

--- a/types/src/v22/wallet/mod.rs
+++ b/types/src/v22/wallet/mod.rs
@@ -20,7 +20,7 @@ pub use super::{GetAddressInfoEmbeddedError, GetAddressInfoError, ScriptType};
 /// > Arguments:
 /// > 1. "address"                    (string, required) The bitcoin address to get the information of.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetAddressInfo {
     /// The bitcoin address validated.
     pub address: String,
@@ -92,7 +92,7 @@ pub struct GetAddressInfo {
 /// It includes all getaddressinfo output fields for the embedded address, excluding metadata
 /// ("timestamp", "hdkeypath", "hdseedid") and relation to the wallet ("ismine", "iswatchonly").
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetAddressInfoEmbedded {
     /// The bitcoin address validated.
     pub address: String,
@@ -144,7 +144,7 @@ pub struct GetAddressInfoEmbedded {
 ///
 /// > List descriptors imported into a descriptor-enabled wallet.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListDescriptors {
     /// Name of wallet this operation was performed on.
     pub wallet_name: String,
@@ -154,7 +154,7 @@ pub struct ListDescriptors {
 
 /// A descriptor object from `listdescriptors`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DescriptorInfo {
     /// Descriptor string representation.
     #[serde(rename = "desc")]
@@ -175,7 +175,7 @@ pub struct DescriptorInfo {
 ///
 /// > Display address on an external signer for verification.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct WalletDisplayAddress {
     /// The address as confirmed by the signer
     pub address: String,

--- a/types/src/v23/blockchain/mod.rs
+++ b/types/src/v23/blockchain/mod.rs
@@ -22,7 +22,7 @@ pub use super::{
 /// >
 /// > Returns an object containing various state info regarding blockchain processing.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockchainInfo {
     /// Current network name as defined in BIP70 (main, test, signet, regtest).
     pub chain: String,
@@ -73,7 +73,7 @@ pub struct GetBlockchainInfo {
 /// >
 /// > Returns an object containing various state info regarding deployments of consensus changes.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetDeploymentInfo {
     /// Requested block hash (or tip).
     pub hash: String,
@@ -85,7 +85,7 @@ pub struct GetDeploymentInfo {
 
 /// Deployment info. Part of `getdeploymentinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DeploymentInfo {
     /// One of "buried", "bip9".
     #[serde(rename = "type")]
@@ -100,7 +100,7 @@ pub struct DeploymentInfo {
 
 /// Status of bip9 softforks. Part of `getdeploymentinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Bip9Info {
     /// The bit (0-28) in the block version field used to signal this softfork (only for "started" and "locked_in" status).
     pub bit: Option<u8>,
@@ -124,7 +124,7 @@ pub struct Bip9Info {
 
 /// Numeric statistics about signalling for a softfork. Part of `getdeploymentinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Bip9Statistics {
     /// The length in blocks of the signalling period.
     pub period: u32,
@@ -147,14 +147,14 @@ pub struct Bip9Statistics {
 /// > Arguments:
 /// > 1. "txid"                 (string, required) The transaction id (must be in mempool)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolAncestors(pub Vec<String>);
 
 /// Result of JSON-RPC method `getmempoolancestors` with verbose set to true.
 ///
 /// Map of txid to `MempoolEntry` i.e., an ancestor.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolAncestorsVerbose(pub BTreeMap<String, MempoolEntry>);
 
 /// Result of JSON-RPC method `getmempooldescendants` with verbose set to `false`.
@@ -166,14 +166,14 @@ pub struct GetMempoolAncestorsVerbose(pub BTreeMap<String, MempoolEntry>);
 /// > Arguments:
 /// > 1. "txid"                 (string, required) The transaction id (must be in mempool)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolDescendants(pub Vec<String>);
 
 /// Result of JSON-RPC method `getmempooldescendants` with verbose set to true.
 ///
 /// Map of txid to [`MempoolEntry`] i.e., a descendant.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolDescendantsVerbose(pub BTreeMap<String, MempoolEntry>);
 
 /// Result of JSON-RPC method `getmempoolentry`.
@@ -185,12 +185,12 @@ pub struct GetMempoolDescendantsVerbose(pub BTreeMap<String, MempoolEntry>);
 /// > Arguments:
 /// > 1. "txid"                 (string, required) The transaction id (must be in mempool)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolEntry(pub MempoolEntry);
 
 /// Mempool data. Part of `getmempoolentry`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct MempoolEntry {
     /// Virtual transaction size as defined in BIP 141.
     ///
@@ -255,7 +255,7 @@ pub struct MempoolEntry {
 ///
 /// > Dumps the mempool to disk. It will fail until the previous dump is fully loaded.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SaveMempool {
     /// The directory and file where the mempool was saved.
     pub filename: String,

--- a/types/src/v23/control.rs
+++ b/types/src/v23/control.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// > Gets and sets the logging configuration.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Logging {
     pub addrman: bool,
     pub bench: bool,

--- a/types/src/v23/network.rs
+++ b/types/src/v23/network.rs
@@ -14,12 +14,12 @@ use serde::{Deserialize, Serialize};
 /// >
 /// > Returns data about each connected network node as a json array of objects.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetPeerInfo(pub Vec<PeerInfo>);
 
 /// A peer info item. Part of `getpeerinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct PeerInfo {
     /// Peer index.
     pub id: u32,

--- a/types/src/v23/raw_transactions/mod.rs
+++ b/types/src/v23/raw_transactions/mod.rs
@@ -27,7 +27,7 @@ pub use crate::psbt::{Bip32Deriv, PsbtScript, RawTransaction, WitnessUtxo};
 /// > Arguments:
 /// > 1. "psbt"            (string, required) The PSBT base64 string
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DecodePsbt {
     /// The decoded network-serialized unsigned transaction.
     pub tx: RawTransaction,
@@ -49,7 +49,7 @@ pub struct DecodePsbt {
 
 /// An item from the global xpubs list. Part of `decodepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GlobalXpub {
     /// The extended public key this path corresponds to.
     pub xpub: String,
@@ -61,7 +61,7 @@ pub struct GlobalXpub {
 
 /// An item from the global proprietary list. Part of `decodepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Proprietary {
     /// The hex string for the proprietary identifier.
     identifier: String,
@@ -75,7 +75,7 @@ pub struct Proprietary {
 
 /// An input in a partially signed Bitcoin transaction. Part of `decodepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct PsbtInput {
     /// Decoded network transaction for non-witness UTXOs.
     pub non_witness_utxo: Option<RawTransaction>,
@@ -113,7 +113,7 @@ pub struct PsbtInput {
 
 /// An output in a partially signed Bitcoin transaction. Part of `decodepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct PsbtOutput {
     /// The redeem script.
     pub redeem_script: Option<PsbtScript>,
@@ -137,7 +137,7 @@ pub struct PsbtOutput {
 /// > 1. "hexstring"     (string) the hex encoded script
 // The docs on Core v0.17 appear to be way off what is actually returned.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DecodeScript {
     /// Script public key.
     pub asm: String,
@@ -165,7 +165,7 @@ pub struct DecodeScript {
 
 /// Segwit data. Part of `decodescript`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DecodeScriptSegwit {
     /// Script public key.
     pub asm: String,

--- a/types/src/v23/util/mod.rs
+++ b/types/src/v23/util/mod.rs
@@ -25,7 +25,7 @@ pub use super::CreateMultisigError;
 /// >        ,...
 /// >      ]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct CreateMultisig {
     /// The value of the new multisig address.
     pub address: String,

--- a/types/src/v23/wallet/mod.rs
+++ b/types/src/v23/wallet/mod.rs
@@ -30,7 +30,7 @@ pub use super::{
 /// > 1. nrequired                      (numeric, required) The number of required signatures out of the n keys or addresses.
 /// > 2. "keys"                         (string, required) A json array of bitcoin addresses or hex-encoded public keys
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct AddMultisigAddress {
     /// The value of the new multisig address.
     pub address: String,
@@ -52,7 +52,7 @@ pub struct AddMultisigAddress {
 /// > Arguments:
 /// > 1. txid                 (string, required) The transaction id
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetTransaction {
     /// The transaction amount in BTC.
     pub amount: f64,
@@ -114,7 +114,7 @@ pub struct GetTransaction {
 /// >
 /// > Returns an object containing various wallet state info.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetWalletInfo {
     /// the wallet name
     #[serde(rename = "walletname")]
@@ -174,7 +174,7 @@ pub enum GetWalletInfoScanning {
 
 /// Result of the JSON-RPC method `listsinceblock`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListSinceBlock {
     /// All the transactions.
     pub transactions: Vec<TransactionItem>,
@@ -194,7 +194,7 @@ pub struct ListSinceBlock {
 
 /// Transaction item. Part of `listsinceblock`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct TransactionItem {
     /// Only returns true if imported addresses were involved in transaction.
     #[serde(rename = "involvesWatchonly")]
@@ -271,7 +271,7 @@ pub struct TransactionItem {
 /// > Note that the "account" argument and "otheraccount" return value have been removed in V0.17. To use this RPC with an "account" argument, restart
 /// > bitcoind with -deprecatedrpc=accounts
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListTransactions(pub Vec<TransactionItem>);
 
 /// Result of the JSON-RPC method `restorewallet`.
@@ -284,7 +284,7 @@ pub struct ListTransactions(pub Vec<TransactionItem>);
 /// > 1. wallet_name        (string, required) The name that will be applied to the restored wallet
 /// > 2. backup_file        (string, required) The backup file that will be used to restore the wallet.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct RestoreWallet {
     /// The wallet name if restored successfully.
     pub name: String,

--- a/types/src/v24/blockchain/mod.rs
+++ b/types/src/v24/blockchain/mod.rs
@@ -23,14 +23,14 @@ pub use super::{GetMempoolInfoError, MapMempoolEntryError, MempoolEntryError, Me
 /// > Arguments:
 /// > 1. "txid"                 (string, required) The transaction id (must be in mempool)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolAncestors(pub Vec<String>);
 
 /// Result of JSON-RPC method `getmempoolancestors` with verbose set to true.
 ///
 /// Map of txid to `MempoolEntry` i.e., an ancestor.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolAncestorsVerbose(pub BTreeMap<String, MempoolEntry>);
 
 /// Result of JSON-RPC method `getmempooldescendants` with verbose set to `false`.
@@ -42,14 +42,14 @@ pub struct GetMempoolAncestorsVerbose(pub BTreeMap<String, MempoolEntry>);
 /// > Arguments:
 /// > 1. "txid"                 (string, required) The transaction id (must be in mempool)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolDescendants(pub Vec<String>);
 
 /// Result of JSON-RPC method `getmempooldescendants` with verbose set to true.
 ///
 /// Map of txid to [`MempoolEntry`] i.e., a descendant.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolDescendantsVerbose(pub BTreeMap<String, MempoolEntry>);
 
 /// Result of JSON-RPC method `getmempoolentry`.
@@ -61,12 +61,12 @@ pub struct GetMempoolDescendantsVerbose(pub BTreeMap<String, MempoolEntry>);
 /// > Arguments:
 /// > 1. "txid"                 (string, required) The transaction id (must be in mempool)
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolEntry(pub MempoolEntry);
 
 /// Mempool data. Part of `getmempoolentry`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct MempoolEntry {
     /// Virtual transaction size as defined in BIP 141.
     ///
@@ -115,7 +115,7 @@ pub struct MempoolEntry {
 /// >
 /// > Returns details on the active state of the TX memory pool.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolInfo {
     /// True if the mempool is fully loaded. v0.19 and later only.
     pub loaded: bool,
@@ -162,12 +162,12 @@ pub struct GetMempoolInfo {
 /// > Arguments:
 /// > 1. outputs                 (json array, required) The transaction outputs that we want to check, and within each, the txid (string) vout (numeric).
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetTxSpendingPrevout(pub Vec<GetTxSpendingPrevoutItem>);
 
 /// A transaction item. Part of `gettxspendingprevout`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetTxSpendingPrevoutItem {
     /// The transaction id of the checked output
     pub txid: String,

--- a/types/src/v24/network.rs
+++ b/types/src/v24/network.rs
@@ -14,12 +14,12 @@ use serde::{Deserialize, Serialize};
 /// >
 /// > Returns data about each connected network node as a json array of objects.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetPeerInfo(pub Vec<PeerInfo>);
 
 /// A peer info item. Part of `getpeerinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct PeerInfo {
     /// Peer index.
     pub id: u32,

--- a/types/src/v24/raw_transactions/mod.rs
+++ b/types/src/v24/raw_transactions/mod.rs
@@ -27,7 +27,7 @@ pub use crate::psbt::{Bip32Deriv, PsbtScript, RawTransaction, WitnessUtxo};
 /// > Arguments:
 /// > 1. "psbt"            (string, required) The PSBT base64 string
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DecodePsbt {
     /// The decoded network-serialized unsigned transaction.
     pub tx: RawTransaction,
@@ -49,7 +49,7 @@ pub struct DecodePsbt {
 
 /// An item from the global xpubs list. Part of `decodepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GlobalXpub {
     /// The extended public key this path corresponds to.
     pub xpub: String,
@@ -61,7 +61,7 @@ pub struct GlobalXpub {
 
 /// An item from the global proprietary list. Part of `decodepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Proprietary {
     /// The hex string for the proprietary identifier.
     identifier: String,
@@ -75,7 +75,7 @@ pub struct Proprietary {
 
 /// An input in a partially signed Bitcoin transaction. Part of `decodepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct PsbtInput {
     /// Decoded network transaction for non-witness UTXOs.
     pub non_witness_utxo: Option<RawTransaction>,
@@ -125,7 +125,7 @@ pub struct PsbtInput {
 
 /// An output in a partially signed Bitcoin transaction. Part of `decodepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct PsbtOutput {
     /// The redeem script.
     pub redeem_script: Option<PsbtScript>,
@@ -147,7 +147,7 @@ pub struct PsbtOutput {
 
 /// An item from the `taproot_script_path_sigs` list. Part of `decodepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct TaprootScriptPathSig {
     /// The x-only pubkey for this signature.
     pub pubkey: String,
@@ -159,7 +159,7 @@ pub struct TaprootScriptPathSig {
 
 /// An item from the `taproot_scripts` list. Part of `decodepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct TaprootScript {
     /// A leaf script.
     pub script: String,
@@ -172,7 +172,7 @@ pub struct TaprootScript {
 
 /// An item from the `taproot_bip32_derivs` list. Part of `decodepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct TaprootBip32Deriv {
     /// The x-only public key this path corresponds to.
     pub pubkey: String,
@@ -186,7 +186,7 @@ pub struct TaprootBip32Deriv {
 
 /// A Taproot leaf script at depth with version. Part of `decodepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct TaprootLeaf {
     /// The depth of this element in the tree.
     pub depth: u32,

--- a/types/src/v24/wallet/mod.rs
+++ b/types/src/v24/wallet/mod.rs
@@ -26,7 +26,7 @@ pub use super::{
 /// > Arguments:
 /// > 1. txid                 (string, required) The transaction id
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetTransaction {
     /// The transaction amount in BTC.
     pub amount: f64,
@@ -90,7 +90,7 @@ pub struct GetTransaction {
 
 /// Transaction detail. Part of the `gettransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetTransactionDetail {
     /// Only returns true if imported addresses were involved in transaction. v20 and later only.
     #[serde(rename = "involvesWatchonly")]
@@ -123,7 +123,7 @@ pub struct GetTransactionDetail {
 
 /// Result of the JSON-RPC method `listsinceblock`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListSinceBlock {
     /// All the transactions.
     pub transactions: Vec<TransactionItem>,
@@ -143,7 +143,7 @@ pub struct ListSinceBlock {
 
 /// Transaction item. Part of `listsinceblock`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct TransactionItem {
     /// Only returns true if imported addresses were involved in transaction.
     #[serde(rename = "involvesWatchonly")]
@@ -225,7 +225,7 @@ pub struct TransactionItem {
 /// > Note that the "account" argument and "otheraccount" return value have been removed in V0.17. To use this RPC with an "account" argument, restart
 /// > bitcoind with -deprecatedrpc=accounts
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListTransactions(pub Vec<TransactionItem>);
 
 /// Result of the JSON-RPC method `listunspent`.
@@ -236,12 +236,12 @@ pub struct ListTransactions(pub Vec<TransactionItem>);
 /// > with between minconf and maxconf (inclusive) confirmations.
 /// > Optionally filter to only include txouts paid to specified addresses.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListUnspent(pub Vec<ListUnspentItem>);
 
 /// Unspent transaction output, part of `listunspent`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListUnspentItem {
     /// The transaction id.
     pub txid: String,
@@ -295,7 +295,7 @@ pub struct ListUnspentItem {
 /// > 1. wallet_name    (string, optional, default=the wallet name from the RPC endpoint) The name of the wallet to migrate. If provided both here and in the RPC endpoint, the two must be identical.
 /// > 2. passphrase     (string) The wallet passphrase
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct MigrateWallet {
     /// The name of the primary migrated wallet
     pub wallet_name: String,
@@ -321,7 +321,7 @@ pub struct MigrateWallet {
 /// > 1. recipients                       (json array, required) The sendall destinations. Each address may only appear once.
 /// >                                     Optionally some recipients can be specified with an amount to perform payments, but at least one address must appear without a specified amount.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SendAll {
     /// If the transaction has a complete set of signatures.
     pub complete: bool,
@@ -342,7 +342,7 @@ pub struct SendAll {
 /// > Arguments:
 /// > 1. rawtxs                            (json array, optional) An array of hex strings of raw transactions.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SimulateRawTransaction {
     /// The wallet balance change (negative means decrease).
     pub balance_change: f64,

--- a/types/src/v25/blockchain/mod.rs
+++ b/types/src/v25/blockchain/mod.rs
@@ -26,7 +26,7 @@ pub use super::GetBlockStatsError;
 /// > Arguments:
 /// > 1. "hash_or_height"     (string or numeric, required) The block hash or height of the target block
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockStats {
     /// Average fee in the block.
     #[serde(rename = "avgfee")]

--- a/types/src/v25/control.rs
+++ b/types/src/v25/control.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// > Gets and sets the logging configuration.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Logging {
     pub addrman: bool,
     pub bench: bool,

--- a/types/src/v25/generating/mod.rs
+++ b/types/src/v25/generating/mod.rs
@@ -25,7 +25,7 @@ pub use self::error::GenerateBlockError;
 /// >        ...
 /// >      ]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GenerateBlock {
     /// Hash of generated block
     pub hash: String,

--- a/types/src/v25/raw_transactions/mod.rs
+++ b/types/src/v25/raw_transactions/mod.rs
@@ -26,12 +26,12 @@ pub use self::error::{MempoolAcceptanceError, TestMempoolAcceptError};
 /// >                                         Length must be one for now.
 /// > 2. allowhighfees    (boolean, optional, default=false) Allow high fees
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct TestMempoolAccept(pub Vec<MempoolAcceptance>);
 
 /// A single mempool acceptance test result. Part of `testmempoolaccept`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct MempoolAcceptance {
     /// The transaction hash in hex.
     pub txid: String,
@@ -50,7 +50,7 @@ pub struct MempoolAcceptance {
 
 /// Wrapper for the fees field. Part of `testmempoolaccept`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct MempoolAcceptanceFees {
     /// Transaction fee in BTC.
     pub base: f64,

--- a/types/src/v25/wallet/mod.rs
+++ b/types/src/v25/wallet/mod.rs
@@ -24,7 +24,7 @@ use serde::{Deserialize, Serialize};
 /// > 7. load_on_startup         (boolean, optional) Save wallet name to persistent settings and load on startup. True to add wallet to startup list, false to remove, null to leave unchanged.
 /// > 8. external_signer         (boolean, optional, default=false) Use an external signer such as a hardware wallet. Requires -signer to be configured. Wallet creation will fail if keys cannot be fetched. Requires disable_private_keys and descriptors set to true.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct CreateWallet {
     /// The wallet name if created successfully.
     ///
@@ -43,7 +43,7 @@ pub struct CreateWallet {
 ///
 /// > List descriptors imported into a descriptor-enabled wallet.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListDescriptors {
     /// Name of wallet this operation was performed on.
     pub wallet_name: String,
@@ -53,7 +53,7 @@ pub struct ListDescriptors {
 
 /// A descriptor object. Part of `listdescriptors`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DescriptorInfo {
     /// Descriptor string representation.
     #[serde(rename = "desc")]
@@ -84,7 +84,7 @@ pub struct DescriptorInfo {
 /// > 1. filename           (string, required) The wallet directory or .dat file.
 /// > 2. load_on_startup    (boolean, optional) Save wallet name to persistent settings and load on startup. True to add wallet to startup list, false to remove, null to leave unchanged.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct LoadWallet {
     /// The wallet name if loaded successfully.
     pub name: String,
@@ -108,7 +108,7 @@ pub struct LoadWallet {
 /// > 1. wallet_name        (string, optional, default=the wallet name from the RPC endpoint) The name of the wallet to unload. If provided both here and in the RPC endpoint, the two must be identical.
 /// > 2. load_on_startup    (boolean, optional) Save wallet name to persistent settings and load on startup. True to add wallet to startup list, false to remove, null to leave unchanged.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct UnloadWallet {
     /// Warning messages, if any, related to unloading the wallet. Multiple messages will be delimited by newlines.
     ///

--- a/types/src/v26/blockchain/mod.rs
+++ b/types/src/v26/blockchain/mod.rs
@@ -22,7 +22,7 @@ pub use self::error::{
 /// > Arguments:
 /// > 1. path    (string, required) Path to the output file. If relative, will be prefixed by datadir.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DumpTxOutSet {
     /// The number of coins written in the snapshot.
     pub coins_written: f64,
@@ -46,7 +46,7 @@ pub struct DumpTxOutSet {
 /// >
 /// > Return information about chainstates.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetChainStates {
     /// The number of headers seen so far.
     pub headers: i64,
@@ -57,7 +57,7 @@ pub struct GetChainStates {
 
 /// A single chainstate. Part of `getchainstates`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ChainState {
     /// Number of blocks in this chainstate.
     pub blocks: i64,
@@ -87,7 +87,7 @@ pub struct ChainState {
 /// > Returns statistics about the unspent transaction output set.
 /// > Note this call may take some time.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetTxOutSetInfo {
     /// The current block height (index).
     pub height: i64,
@@ -121,7 +121,7 @@ pub struct GetTxOutSetInfo {
 /// > Arguments:
 /// > 1. path    (string, required) path to the snapshot file. If relative, will be prefixed by datadir.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct LoadTxOutSet {
     /// The number of coins loaded from the snapshot.
     pub coins_loaded: f64,

--- a/types/src/v26/control.rs
+++ b/types/src/v26/control.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// > Gets and sets the logging configuration.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Logging {
     pub addrman: bool,
     pub bench: bool,

--- a/types/src/v26/mining.rs
+++ b/types/src/v26/mining.rs
@@ -17,7 +17,7 @@ use crate::model;
 /// >
 /// > Returns a map of all user-created (see prioritisetransaction) fee deltas by txid, and whether the tx is present in mempool.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetPrioritisedTransactions(
     /// prioritisation keyed by txid.
     pub BTreeMap<String, PrioritisedTransaction>,
@@ -25,7 +25,7 @@ pub struct GetPrioritisedTransactions(
 
 /// An individual prioritised transaction. Part of `getprioritisedtransactions`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct PrioritisedTransaction {
     /// Transaction fee delta in satoshis.
     pub fee_delta: i64,

--- a/types/src/v26/network.rs
+++ b/types/src/v26/network.rs
@@ -14,12 +14,12 @@ use serde::{Deserialize, Serialize};
 /// >
 /// > Provides information about the node's address manager by returning the number of addresses in the `new` and `tried` tables and their sum for all networks.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetAddrManInfo(pub BTreeMap<String, AddrManInfoNetwork>);
 
 /// Address manager information. Part of `getaddrmaninfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct AddrManInfoNetwork {
     /// Number of addresses in the new table, which represent potential peers the node has discovered but hasn't yet successfully connected to.
     pub new: u64,
@@ -35,12 +35,12 @@ pub struct AddrManInfoNetwork {
 /// >
 /// > Returns data about each connected network node as a json array of objects.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetPeerInfo(pub Vec<PeerInfo>);
 
 /// A peer info item. Part of `getpeerinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct PeerInfo {
     /// Peer index.
     pub id: u32,

--- a/types/src/v26/raw_transactions/mod.rs
+++ b/types/src/v26/raw_transactions/mod.rs
@@ -34,7 +34,7 @@ use crate::model;
 /// >        ...
 /// >      ]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DescriptorProcessPsbt {
     /// The base64-encoded partially signed transaction.
     pub psbt: String,
@@ -62,7 +62,7 @@ pub struct DescriptorProcessPsbt {
 /// >        ...
 /// >      ]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SubmitPackage {
     /// The transaction package result message.
     ///
@@ -78,7 +78,7 @@ pub struct SubmitPackage {
 
 /// The per-transaction result. Part of `submitpackage`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SubmitPackageTxResult {
     /// The transaction id.
     pub txid: String,
@@ -97,7 +97,7 @@ pub struct SubmitPackageTxResult {
 
 /// The fees included in the per-transaction result. Part of `submitpackage`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SubmitPackageTxResultFees {
     /// Transaction fee.
     #[serde(rename = "base")]

--- a/types/src/v26/wallet/mod.rs
+++ b/types/src/v26/wallet/mod.rs
@@ -35,7 +35,7 @@ pub use super::{
 /// > 7. load_on_startup         (boolean, optional) Save wallet name to persistent settings and load on startup. True to add wallet to startup list, false to remove, null to leave unchanged.
 /// > 8. external_signer         (boolean, optional, default=false) Use an external signer such as a hardware wallet. Requires -signer to be configured. Wallet creation will fail if keys cannot be fetched. Requires disable_private_keys and descriptors set to true.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct CreateWallet {
     /// The wallet name if created successfully.
     ///
@@ -51,7 +51,7 @@ pub struct CreateWallet {
 /// >
 /// > Returns an object with all balances in BTC.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBalances {
     /// Balances from outputs that the wallet can sign.
     pub mine: GetBalancesMine,
@@ -71,7 +71,7 @@ pub struct GetBalances {
 /// > Arguments:
 /// > 1. txid                 (string, required) The transaction id
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetTransaction {
     /// The transaction amount in BTC.
     pub amount: f64,
@@ -138,7 +138,7 @@ pub struct GetTransaction {
 
 /// Last processed block item. Part of of `gettransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct LastProcessedBlock {
     /// Hash of the block this information was generated on.
     pub hash: String,
@@ -152,7 +152,7 @@ pub struct LastProcessedBlock {
 /// >
 /// > Returns an object containing various wallet state info.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetWalletInfo {
     /// the wallet name
     #[serde(rename = "walletname")]
@@ -229,7 +229,7 @@ pub enum GetWalletInfoScanning {
 /// > 1. filename           (string, required) The wallet directory or .dat file.
 /// > 2. load_on_startup    (boolean, optional) Save wallet name to persistent settings and load on startup. True to add wallet to startup list, false to remove, null to leave unchanged.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct LoadWallet {
     /// The wallet name if loaded successfully.
     pub name: String,
@@ -248,7 +248,7 @@ pub struct LoadWallet {
 /// > 1. wallet_name        (string, optional, default=the wallet name from the RPC endpoint) The name of the wallet to unload. If provided both here and in the RPC endpoint, the two must be identical.
 /// > 2. load_on_startup    (boolean, optional) Save wallet name to persistent settings and load on startup. True to add wallet to startup list, false to remove, null to leave unchanged.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct UnloadWallet {
     /// Warning messages, if any, related to loading the wallet.
     pub warnings: Option<Vec<String>>,
@@ -265,7 +265,7 @@ pub struct UnloadWallet {
 /// > Arguments:
 /// > 1. "psbt"                      (string, required) The transaction base64 string
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct WalletProcessPsbt {
     /// The base64-encoded partially signed transaction.
     pub psbt: String,

--- a/types/src/v27/mining.rs
+++ b/types/src/v27/mining.rs
@@ -17,7 +17,7 @@ use crate::model;
 /// >
 /// > Returns a map of all user-created (see prioritisetransaction) fee deltas by txid, and whether the tx is present in mempool.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetPrioritisedTransactions(
     /// prioritisation keyed by txid.
     pub BTreeMap<String, PrioritisedTransaction>,
@@ -25,7 +25,7 @@ pub struct GetPrioritisedTransactions(
 
 /// An individual prioritised transaction. Part of `getprioritisedtransactions`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct PrioritisedTransaction {
     /// Transaction fee delta in satoshis.
     pub fee_delta: i64,

--- a/types/src/v28/blockchain.rs
+++ b/types/src/v28/blockchain.rs
@@ -18,7 +18,7 @@ use crate::model;
 ///
 /// > Returns an object containing various state info regarding blockchain processing.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockchainInfo {
     /// Current network name as defined in BIP70 (main, test, signet, regtest).
     pub chain: String,

--- a/types/src/v28/control.rs
+++ b/types/src/v28/control.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// > Gets and sets the logging configuration.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Logging {
     pub addrman: bool,
     pub bench: bool,

--- a/types/src/v28/mining.rs
+++ b/types/src/v28/mining.rs
@@ -15,7 +15,7 @@ use crate::model;
 /// >
 /// > Returns a json object containing mining-related information.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMiningInfo {
     /// The current block.
     pub blocks: u64,

--- a/types/src/v28/network.rs
+++ b/types/src/v28/network.rs
@@ -14,7 +14,7 @@ use crate::model;
 ///
 /// > Returns an object containing various state info regarding P2P networking.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetNetworkInfo {
     /// The server version.
     pub version: usize,

--- a/types/src/v28/raw_transactions/mod.rs
+++ b/types/src/v28/raw_transactions/mod.rs
@@ -33,7 +33,7 @@ use crate::model;
 /// >        ...
 /// >      ]
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SubmitPackage {
     /// The transaction package result message.
     ///
@@ -49,7 +49,7 @@ pub struct SubmitPackage {
 
 /// The per-transaction result. Part of `submitpackage`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SubmitPackageTxResult {
     /// The transaction id.
     pub txid: String,
@@ -68,7 +68,7 @@ pub struct SubmitPackageTxResult {
 
 /// The fees included in the per-transaction result. Part of `submitpackage`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SubmitPackageTxResultFees {
     /// Transaction fee.
     #[serde(rename = "base")]

--- a/types/src/v28/wallet/mod.rs
+++ b/types/src/v28/wallet/mod.rs
@@ -26,7 +26,7 @@ pub use super::{
 /// > Arguments:
 /// > 1. type       (string, required) The address type the descriptor will produce. Options are "legacy", "p2sh-segwit", "bech32", and "bech32m".
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct CreateWalletDescriptor {
     /// The public descriptors that were added to the wallet.
     #[serde(rename = "descs")]
@@ -43,7 +43,7 @@ pub struct CreateWalletDescriptor {
 /// > Arguments:
 /// > 1. "address"                    (string, required) The bitcoin address to get the information of.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetAddressInfo {
     /// The bitcoin address validated.
     pub address: String,
@@ -115,7 +115,7 @@ pub struct GetAddressInfo {
 /// It includes all getaddressinfo output fields for the embedded address, excluding metadata
 /// ("timestamp", "hdkeypath", "hdseedid") and relation to the wallet ("ismine", "iswatchonly").
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetAddressInfoEmbedded {
     /// The bitcoin address validated.
     pub address: String,
@@ -169,12 +169,12 @@ pub struct GetAddressInfoEmbedded {
 /// >
 /// > List all BIP 32 HD keys in the wallet and which descriptors use them.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetHdKeys(pub Vec<HdKey>);
 
 /// HD key entry. Part of `gethdkeys`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct HdKey {
     /// The extended public key.
     pub xpub: String,
@@ -189,7 +189,7 @@ pub struct HdKey {
 
 /// Descriptor object. Part of `gethdkeys`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct HdKeyDescriptor {
     /// Descriptor string representation.
     #[serde(rename = "desc")]
@@ -207,7 +207,7 @@ pub struct HdKeyDescriptor {
 /// > Arguments:
 /// > 1. txid                 (string, required) The transaction id
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetTransaction {
     /// The transaction amount in BTC.
     pub amount: f64,
@@ -278,7 +278,7 @@ pub struct GetTransaction {
 
 /// Result of the JSON-RPC method `listsinceblock`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListSinceBlock {
     /// All the transactions.
     pub transactions: Vec<TransactionItem>,
@@ -298,7 +298,7 @@ pub struct ListSinceBlock {
 
 /// Transaction item. Part of `listsinceblock`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct TransactionItem {
     /// Only returns true if imported addresses were involved in transaction.
     #[serde(rename = "involvesWatchonly")]
@@ -383,5 +383,5 @@ pub struct TransactionItem {
 /// > Note that the "account" argument and "otheraccount" return value have been removed in V0.17. To use this RPC with an "account" argument, restart
 /// > bitcoind with -deprecatedrpc=accounts
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListTransactions(pub Vec<TransactionItem>);

--- a/types/src/v29/blockchain/mod.rs
+++ b/types/src/v29/blockchain/mod.rs
@@ -18,7 +18,7 @@ use crate::{model, ScriptPubkey};
 
 /// Result of JSON-RPC method `getblock` with verbosity set to 1.
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockVerboseOne {
     /// The block hash (same as provided) in RPC call.
     pub hash: String,
@@ -76,7 +76,7 @@ pub struct GetBlockVerboseOne {
 /// >
 /// > Returns an object containing various state info regarding blockchain processing.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockchainInfo {
     /// Current network name as defined in BIP70 (main, test, signet, regtest).
     pub chain: String,
@@ -129,7 +129,7 @@ pub struct GetBlockchainInfo {
 /// > Arguments:
 /// > 1. "hash"          (string, required) The block hash
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockHeader(pub String);
 
 /// Result of JSON-RPC method `getblockheader` with verbosity set to `true`.
@@ -140,7 +140,7 @@ pub struct GetBlockHeader(pub String);
 /// > Arguments:
 /// > 1. "hash"          (string, required) The block hash
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockHeaderVerbose {
     /// The block hash.
     pub hash: String,
@@ -189,7 +189,7 @@ pub struct GetBlockHeaderVerbose {
 /// >
 /// > Return information about chainstates.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetChainStates {
     /// The number of headers seen so far.
     pub headers: i64,
@@ -200,7 +200,7 @@ pub struct GetChainStates {
 
 /// A single chainstate. Part of `getchainstates`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ChainState {
     /// Number of blocks in this chainstate.
     pub blocks: i64,
@@ -236,7 +236,7 @@ pub struct ChainState {
 /// > 2. scanobjects  (json array, optional) Array of scan objects. Required for "start" action
 /// > 3. include_mempool  (boolean, optional, default=true) Whether to include unconfirmed activitydata
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetDescriptorActivity {
     pub activity: Vec<ActivityEntry>,
 }
@@ -253,7 +253,7 @@ pub enum ActivityEntry {
 
 /// Represents a 'spend' activity event. Part of `getdescriptoractivity`.
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SpendActivity {
     // Note: 'type' field is used for deserialization tag, not included here explicitly.
     /// The total amount in BTC of the spent output.
@@ -279,7 +279,7 @@ pub struct SpendActivity {
 
 /// Represents a 'receive' activity event. Part of `getdescriptoractivity`.
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ReceiveActivity {
     // Note: 'type' field is used for deserialization tag, not included here explicitly.
     /// The total amount in BTC of the new output.

--- a/types/src/v29/mining/mod.rs
+++ b/types/src/v29/mining/mod.rs
@@ -17,7 +17,7 @@ pub use self::error::{GetMiningInfoError, NextBlockInfoError};
 /// >
 /// > Returns a json object containing mining-related information.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMiningInfo {
     /// The current block.
     pub blocks: u64,
@@ -54,7 +54,7 @@ pub struct GetMiningInfo {
 
 /// Represents the `next` block information. Part of `getmininginfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct NextBlockInfo {
     /// The next height.
     pub height: u64,

--- a/types/src/v29/raw_transactions/mod.rs
+++ b/types/src/v29/raw_transactions/mod.rs
@@ -25,12 +25,12 @@ pub use super::{MempoolAcceptanceError, TestMempoolAcceptError};
 /// >                                         Length must be one for now.
 /// > 2. allowhighfees    (boolean, optional, default=false) Allow high fees
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct TestMempoolAccept(pub Vec<MempoolAcceptance>);
 
 /// A single mempool acceptance test result. Part of `testmempoolaccept`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct MempoolAcceptance {
     /// The transaction hash in hex.
     pub txid: String,
@@ -52,7 +52,7 @@ pub struct MempoolAcceptance {
 
 /// Wrapper for the fees field. Part of `testmempoolaccept`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct MempoolAcceptanceFees {
     /// Transaction fee in BTC.
     pub base: f64,

--- a/types/src/v29/util.rs
+++ b/types/src/v29/util.rs
@@ -17,7 +17,7 @@ use crate::model;
 /// > Derives one or more addresses corresponding to an output descriptor.
 /// > Returns an array of derived addresses.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DeriveAddressesMultipath(pub Vec<DeriveAddresses>);
 
 impl DeriveAddressesMultipath {
@@ -39,7 +39,7 @@ impl DeriveAddressesMultipath {
 /// > Analyses a descriptor.
 /// > Returns information about the descriptor.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetDescriptorInfo {
     /// The descriptor in canonical form, without private keys. For a multipath descriptor, only the
     /// first will be returned.


### PR DESCRIPTION
Currently there is no way to turn off the deny unknown fields attribute. This can cause issues when using the crate in cases where there are fields returned by the RPC that are not yet in the types structs, e.g. in unmerged Core PRs (see #366).

- Reorder the dependencies in the `Cargo.toml` files to make checking for consistency across the crates easier.
- Use relative paths for the `corepc` crates dependencies.
- Remove one case of `#[serde(deny_unknown_fields)]` in `client` that is not needed.
- Add a feature that can be used to enable the attribute, which is off by default since it is only needed in testing. Enable the feature in `integration_test` by adding a `types` dependency.
- Search and replace all occurrences of `#[serde(deny_unknown_fields)]` with `#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]`

Closes #366