### PR TITLE
Remove `serde-deny-unknown-fields` from `model` types

### DIFF
--- a/types/src/model/blockchain.rs
+++ b/types/src/model/blockchain.rs
@@ -19,7 +19,6 @@ use crate::ScriptPubkey;
 
 /// Models the result of JSON-RPC method `dumptxoutset`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DumpTxOutSet {
     /// The number of coins written in the snapshot.
     pub coins_written: Amount,
@@ -37,17 +36,14 @@ pub struct DumpTxOutSet {
 
 /// Models the result of JSON-RPC method `getbestblockhash`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBestBlockHash(pub BlockHash);
 
 /// Models the result of JSON-RPC method `getblock` with verbosity set to 0.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockVerboseZero(pub Block);
 
 /// Models the result of JSON-RPC method `getblock` with verbosity set to 1.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockVerboseOne {
     /// The block hash (same as provided) in RPC call.
     pub hash: BlockHash,
@@ -91,7 +87,6 @@ pub struct GetBlockVerboseOne {
 
 /// Models the result of JSON-RPC method `getblockchaininfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockchainInfo {
     /// Current network name as defined in BIP70 (main, test, signet, regtest).
     pub chain: Network,
@@ -137,7 +132,6 @@ pub struct GetBlockchainInfo {
 
 /// Softfork status. Part of `getblockchaininfo`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Softfork {
     /// The [`SoftforkType`]: one of "buried", "bip9".
     #[serde(rename = "type")]
@@ -166,7 +160,6 @@ pub enum SoftforkType {
 
 /// BIP-9 softfork info. Part of `getblockchaininfo`.
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Bip9SoftforkInfo {
     /// One of "defined", "started", "locked_in", "active", "failed".
     pub status: Bip9SoftforkStatus,
@@ -201,7 +194,6 @@ pub enum Bip9SoftforkStatus {
 
 /// BIP-9 softfork statistics. Part of `getblockchaininfo`.
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Bip9SoftforkStatistics {
     /// The length in blocks of the BIP9 signalling period.
     pub period: u32,
@@ -217,12 +209,10 @@ pub struct Bip9SoftforkStatistics {
 
 /// Models the result of JSON-RPC method `getblockcount`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockCount(pub u64);
 
 /// Models the result of JSON-RPC method `getblockfilter`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockFilter {
     /// The filter data.
     pub filter: Vec<u8>,
@@ -232,17 +222,14 @@ pub struct GetBlockFilter {
 
 /// Models the result of JSON-RPC method `getblockhash`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockHash(pub BlockHash);
 
 /// Models the result of JSON-RPC method `getblockheader`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockHeader(pub block::Header);
 
 /// Models the result of JSON-RPC method `getblockheader`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockHeaderVerbose {
     /// the block hash (same as provided).
     pub hash: BlockHash,
@@ -278,7 +265,6 @@ pub struct GetBlockHeaderVerbose {
 
 /// Models the result of JSON-RPC method `getblockstats`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockStats {
     /// Average fee in the block.
     pub average_fee: Amount,
@@ -348,7 +334,6 @@ pub struct GetBlockStats {
 
 /// Models the result of JSON-RPC method `getchainstates`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetChainStates {
     /// The number of headers seen so far.
     pub headers: u32,
@@ -358,7 +343,6 @@ pub struct GetChainStates {
 
 /// A single chainstate. Part of `getchainstates`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ChainState {
     /// Number of blocks in this chainstate.
     pub blocks: u32,
@@ -384,12 +368,10 @@ pub struct ChainState {
 
 /// Models the result of JSON-RPC method `getchaintips`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetChainTips(pub Vec<ChainTips>);
 
 /// An individual list item from the result of JSON-RPC method `getchaintips`.
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ChainTips {
     /// Height of the chain tip.
     pub height: u32,
@@ -419,7 +401,6 @@ pub enum ChainTipsStatus {
 
 /// Models the result of JSON-RPC method `getchaintxstats`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetChainTxStats {
     /// The timestamp for the final block in the window in UNIX format.
     pub time: u32,
@@ -441,7 +422,6 @@ pub struct GetChainTxStats {
 
 /// Models the result of JSON-RPC method `getdeploymentinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetDeploymentInfo {
     /// Requested block hash (or tip).
     pub hash: BlockHash,
@@ -453,7 +433,6 @@ pub struct GetDeploymentInfo {
 
 /// Deployment info. Part of `getdeploymentinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DeploymentInfo {
     /// One of "buried", "bip9".
     pub deployment_type: String,
@@ -467,7 +446,6 @@ pub struct DeploymentInfo {
 
 /// Status of bip9 softforks. Part of `getdeploymentinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Bip9Info {
     /// The bit (0-28) in the block version field used to signal this softfork (only for "started" and "locked_in" status).
     pub bit: Option<u8>,
@@ -491,7 +469,6 @@ pub struct Bip9Info {
 
 /// Numeric statistics about signalling for a softfork. Part of `getdeploymentinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Bip9Statistics {
     /// The length in blocks of the signalling period.
     pub period: u32,
@@ -507,7 +484,6 @@ pub struct Bip9Statistics {
 
 /// Models the result of the JSON-RPC method `getdescriptoractivity`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetDescriptorActivity {
     /// A list of activity events related to the descriptors.
     pub activity: Vec<ActivityEntry>,
@@ -524,7 +500,6 @@ pub enum ActivityEntry {
 
 /// Models a 'spend' activity event. Part of `getdescriptoractivity`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SpendActivity {
     /// The total amount of the spent output.
     pub amount: Amount,
@@ -546,7 +521,6 @@ pub struct SpendActivity {
 
 /// Models a 'receive' activity event. Part of `getdescriptoractivity`
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ReceiveActivity {
     /// The total amount in BTC of the new output.
     pub amount: Amount,
@@ -564,37 +538,30 @@ pub struct ReceiveActivity {
 
 /// Models the result of JSON-RPC method `getdifficulty`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetDifficulty(pub f64);
 
 /// Models the result of JSON-RPC method `getmempoolancestors` with verbose set to false.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolAncestors(pub Vec<Txid>);
 
 /// Models the result of JSON-RPC method `getmempoolancestors` with verbose set to true.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolAncestorsVerbose(pub BTreeMap<Txid, MempoolEntry>);
 
 /// Models the result of JSON-RPC method `getmempooldescendants` with verbose set to false.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolDescendants(pub Vec<Txid>);
 
 /// Models the result of JSON-RPC method `getmempooldescendants` with verbose set to true.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolDescendantsVerbose(pub BTreeMap<Txid, MempoolEntry>);
 
 /// Models the result of JSON-RPC method `getmempoolentry`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolEntry(pub MempoolEntry);
 
 /// Mempool data. Part of `getmempoolentry`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct MempoolEntry {
     /// Virtual transaction size as defined in BIP 141. v0.19 and later only.
     ///
@@ -637,7 +604,6 @@ pub struct MempoolEntry {
 
 /// Fee object. Part of `getmempoolentry`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct MempoolEntryFees {
     /// Transaction fee in BTC.
     pub base: Amount,
@@ -651,7 +617,6 @@ pub struct MempoolEntryFees {
 
 /// Models the result of JSON-RPC method `getmempoolinfo` with verbose set to true.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolInfo {
     /// True if the mempool is fully loaded. v0.19 and later only.
     pub loaded: Option<bool>,
@@ -685,17 +650,14 @@ pub struct GetMempoolInfo {
 
 /// Models the result of JSON-RPC method `getrawmempool` with verbose set to false.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetRawMempool(pub Vec<Txid>);
 
 /// Models the result of JSON-RPC method `getrawmempool` with verbose set to true.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetRawMempoolVerbose(pub BTreeMap<Txid, MempoolEntry>);
 
 /// Models the result of JSON-RPC method `gettxout`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetTxOut {
     /// The hash of the block at the tip of the chain.
     pub best_block: BlockHash,
@@ -713,7 +675,6 @@ pub struct GetTxOut {
 
 /// Models the result of JSON-RPC method `gettxoutsetinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetTxOutSetInfo {
     /// The current block height (index).
     pub height: u32,
@@ -740,12 +701,10 @@ pub struct GetTxOutSetInfo {
 
 /// Models the result of JSON-RPC method `gettxspendingprevout`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetTxSpendingPrevout(pub Vec<GetTxSpendingPrevoutItem>);
 
 /// A transaction item. Part of `gettxspendingprevout`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetTxSpendingPrevoutItem {
     /// The outpoint containing the transaction id and vout value of the checked output.
     pub outpoint: OutPoint,
@@ -755,7 +714,6 @@ pub struct GetTxSpendingPrevoutItem {
 
 /// Models the result of JSON-RPC method `loadtxoutset`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct LoadTxOutSet {
     /// The number of coins loaded from the snapshot.
     pub coins_loaded: Amount,
@@ -780,5 +738,4 @@ pub struct ScanBlocksStart {
 
 /// Models the result of JSON-RPC method `verifytxoutproof`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct VerifyTxOutProof(pub Vec<Txid>);

--- a/types/src/model/generating.rs
+++ b/types/src/model/generating.rs
@@ -10,7 +10,6 @@ use serde::{Deserialize, Serialize};
 
 /// Models the result of JSON-RPC method `generate`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Generate(pub Vec<BlockHash>);
 
 impl Generate {
@@ -23,7 +22,6 @@ impl Generate {
 
 /// Models the result of JSON-RPC method `generateblock`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GenerateBlock {
     /// Hash of generated block.
     pub hash: BlockHash,
@@ -33,7 +31,6 @@ pub struct GenerateBlock {
 
 /// Models the result of JSON-RPC method `generatetoaddress`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GenerateToAddress(pub Vec<BlockHash>);
 
 impl GenerateToAddress {
@@ -46,7 +43,6 @@ impl GenerateToAddress {
 
 /// Models the result of JSON-RPC method `generatetodescriptor`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GenerateToDescriptor(pub Vec<BlockHash>);
 
 impl GenerateToDescriptor {

--- a/types/src/model/mining.rs
+++ b/types/src/model/mining.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
 
 /// Models the result of JSON-RPC method `getblocktemplate`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBlockTemplate {
     /// The preferred block version.
     pub version: block::Version,
@@ -72,7 +71,6 @@ pub struct GetBlockTemplate {
 
 /// Non-coinbase transaction contents. Part of `getblocktemplate`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct BlockTemplateTransaction {
     /// The transaction.
     pub data: Transaction,
@@ -99,7 +97,6 @@ pub struct BlockTemplateTransaction {
 
 /// Models the result of JSON-RPC method `getmininginfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMiningInfo {
     /// The current block.
     pub blocks: u64,
@@ -132,7 +129,6 @@ pub struct GetMiningInfo {
 
 /// Represents the `next` block information. Part of `getmininginfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct NextBlockInfo {
     /// The next height.
     pub height: u64,
@@ -146,12 +142,10 @@ pub struct NextBlockInfo {
 
 /// Models the result of JSON-RPC method `getprioritisedtransactions`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetPrioritisedTransactions(pub BTreeMap<Txid, PrioritisedTransaction>);
 
 /// An individual prioritised transaction. Part of `getprioritisedtransactions`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct PrioritisedTransaction {
     /// Transaction fee delta in satoshis.
     pub fee_delta: Amount,

--- a/types/src/model/network.rs
+++ b/types/src/model/network.rs
@@ -10,7 +10,6 @@ use serde::{Deserialize, Serialize};
 
 /// Models the result of JSON-RPC method `getnetworkinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetNetworkInfo {
     /// The server version.
     pub version: usize,
@@ -48,7 +47,6 @@ pub struct GetNetworkInfo {
 
 /// Information per network. Part of `getnetworkinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetNetworkInfoNetwork {
     /// Network (ipv4, ipv6, onion, i2p, cjdns).
     pub name: String,
@@ -64,7 +62,6 @@ pub struct GetNetworkInfoNetwork {
 
 /// Local address info. Part of `getnetworkinfo`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetNetworkInfoAddress {
     /// Network address.
     pub address: String,

--- a/types/src/model/raw_transactions.rs
+++ b/types/src/model/raw_transactions.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
 
 /// Models the result of JSON-RPC method `analyzepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct AnalyzePsbt {
     /// Array of input objects.
     pub inputs: Vec<AnalyzePsbtInput>,
@@ -32,7 +31,6 @@ pub struct AnalyzePsbt {
 
 /// An input in a PSBT operation. Part of `analyzepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct AnalyzePsbtInput {
     /// Whether a UTXO is provided.
     pub has_utxo: bool,
@@ -46,7 +44,6 @@ pub struct AnalyzePsbtInput {
 
 /// Missing elements required to complete an input. Part of `analyzepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct AnalyzePsbtInputMissing {
     /// Public key IDs of public keys whose BIP 32 derivation paths are missing.
     pub pubkeys: Vec<hash160::Hash>,
@@ -60,32 +57,26 @@ pub struct AnalyzePsbtInputMissing {
 
 /// Models the result of JSON-RPC method `combinepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct CombinePsbt(pub Psbt);
 
 /// Models the result of JSON-RPC method `combinerawtransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct CombineRawTransaction(pub Transaction);
 
 /// Models the result of JSON-RPC method `converttopsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ConvertToPsbt(pub Psbt);
 
 /// Models the result of JSON-RPC method `createpsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct CreatePsbt(pub Psbt);
 
 /// Models the result of JSON-RPC method `createrawtransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct CreateRawTransaction(pub Transaction);
 
 /// Models the result of JSON-RPC method `decodepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DecodePsbt {
     /// The decoded PSBT.
     pub psbt: Psbt,
@@ -95,12 +86,10 @@ pub struct DecodePsbt {
 
 /// Models the result of JSON-RPC method `decoderawtransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DecodeRawTransaction(pub Transaction);
 
 /// Models the result of JSON-RPC method `decodescript`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DecodeScript {
     /// The `scriptPubkey`.
     pub script_pubkey: Option<ScriptBuf>,
@@ -122,7 +111,6 @@ pub struct DecodeScript {
 
 /// Models the result of JSON-RPC method `descriptorprocesspsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DescriptorProcessPsbt {
     /// The decoded PSBT.
     pub psbt: Psbt,
@@ -134,7 +122,6 @@ pub struct DescriptorProcessPsbt {
 
 /// Models the result of JSON-RPC method `finalizepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct FinalizePsbt {
     /// The partially signed transaction if not extracted.
     pub psbt: Option<Psbt>,
@@ -146,7 +133,6 @@ pub struct FinalizePsbt {
 
 /// Models the result of JSON-RPC method `fundrawtransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct FundRawTransaction {
     /// The resulting raw transaction.
     pub tx: Transaction,
@@ -158,13 +144,11 @@ pub struct FundRawTransaction {
 
 /// Models the result of JSON-RPC method `getrawtransaction` with verbose set to `false`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetRawTransaction(pub Transaction);
 
 /// Models the result of JSON-RPC method `getrawtransaction` with verbose set to `true`.
 /// Result of JSON-RPC method `getrawtransaction`
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetRawTransactionVerbose {
     /// Whether specified block is in the active chain or not (only present with explicit "blockhash" argument).
     pub in_active_chain: Option<bool>,
@@ -182,17 +166,14 @@ pub struct GetRawTransactionVerbose {
 
 /// Models the result of JSON-RPC method `joinpsbts`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct JoinPsbts(pub Psbt);
 
 /// Models the result of JSON-RPC method `sendrawtransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SendRawTransaction(pub Txid);
 
 /// Models the result of JSON-RPC method `signrawtransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SignRawTransaction {
     /// The raw transaction with signature(s).
     pub tx: Transaction,
@@ -210,7 +191,6 @@ pub type SignRawTransactionWithKey = SignRawTransaction;
 
 /// A script verification error. Part of `signrawtransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SignFail {
     /// The referenced, previous transaction.
     pub txid: Txid,
@@ -226,7 +206,6 @@ pub struct SignFail {
 
 /// Models the result of JSON-RPC method `submitpackage`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SubmitPackage {
     /// The transaction package result message. "success" indicates all transactions were accepted into or are already in the mempool.
     pub package_msg: String,
@@ -238,7 +217,6 @@ pub struct SubmitPackage {
 
 /// Models the per-transaction result included in the JSON-RPC method `submitpackage`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SubmitPackageTxResult {
     /// The transaction id.
     pub txid: Txid,
@@ -256,7 +234,6 @@ pub struct SubmitPackageTxResult {
 
 /// Models the fees included in the per-transaction result of the JSON-RPC method `submitpackage`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SubmitPackageTxResultFees {
     /// Transaction fee.
     pub base_fee: Amount,
@@ -272,7 +249,6 @@ pub struct SubmitPackageTxResultFees {
 
 /// Models the result of JSON-RPC method `testmempoolaccept`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct TestMempoolAccept {
     /// Test results for each raw transaction in the input array.
     pub results: Vec<MempoolAcceptance>,
@@ -280,7 +256,6 @@ pub struct TestMempoolAccept {
 
 /// Models a single mempool acceptance test result. Part of `testmempoolaccept`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct MempoolAcceptance {
     /// The transaction ID.
     pub txid: Txid,
@@ -300,7 +275,6 @@ pub struct MempoolAcceptance {
 
 /// Models the fees field. Part of `testmempoolaccept`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct MempoolAcceptanceFees {
     /// Transaction fee in BTC.
     pub base: Amount,
@@ -313,5 +287,4 @@ pub struct MempoolAcceptanceFees {
 
 /// Models the result of JSON-RPC method `utxoupdatepsbt;`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct UtxoUpdatePsbt(pub Psbt);

--- a/types/src/model/util.rs
+++ b/types/src/model/util.rs
@@ -11,7 +11,6 @@ use serde::{Deserialize, Serialize};
 
 /// Models the result of JSON-RPC method `createmultisig`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct CreateMultisig {
     /// The value of the new multisig address.
     pub address: Address<NetworkUnchecked>,
@@ -30,7 +29,6 @@ pub struct CreateMultisig {
 /// > Derives one or more addresses corresponding to an output descriptor.
 /// > Returns an array of derived addresses.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DeriveAddresses {
     /// The derived addresses.
     pub addresses: Vec<Address<NetworkUnchecked>>,
@@ -38,7 +36,6 @@ pub struct DeriveAddresses {
 
 /// Models the result of JSON-RPC method `deriveaddresses` for multipath descriptors.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DeriveAddressesMultipath {
     /// The derived addresses for each of the multipath expansions of the descriptor, in multipath specifier order.
     pub addresses: Vec<DeriveAddresses>,
@@ -46,7 +43,6 @@ pub struct DeriveAddressesMultipath {
 
 /// Models the result of JSON-RPC method `estimatesmartfee`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct EstimateSmartFee {
     /// Estimate fee rate in BTC/kB.
     pub fee_rate: Option<FeeRate>,

--- a/types/src/model/wallet.rs
+++ b/types/src/model/wallet.rs
@@ -56,7 +56,6 @@ pub enum Bip125Replaceable {
 
 /// Models the result of JSON-RPC method `addmultisigaddress`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct AddMultisigAddress {
     /// The new multisig address.
     pub address: Address<NetworkUnchecked>,
@@ -70,7 +69,6 @@ pub struct AddMultisigAddress {
 
 /// Models the result of JSON-RPC method `bumpfee`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct BumpFee {
     /// The id of the new transaction.
     pub txid: Txid,
@@ -84,7 +82,6 @@ pub struct BumpFee {
 
 /// Models the result of JSON-RPC method `createwallet`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct CreateWallet {
     /// The wallet name if created successfully.
     ///
@@ -96,17 +93,14 @@ pub struct CreateWallet {
 
 /// Models the result of JSON-RPC method `dumpprivkey`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct DumpPrivKey(pub PrivateKey);
 
 /// Models the result of JSON-RPC method `getaddressesbylabel`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetAddressesByLabel(pub BTreeMap<Address<NetworkUnchecked>, AddressInformation>);
 
 /// Address information. Part of `getaddressesbylabel`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct AddressInformation {
     /// Purpose of address.
     pub purpose: AddressPurpose,
@@ -246,14 +240,12 @@ pub struct GetAddressInfoEmbedded {
 
 /// Models the result of JSON-RPC method `getbalance`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBalance(pub Amount);
 
 /// Models the result of JSON-RPC method `getbalances`.
 ///
 /// Core version 0.19 onwards.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBalances {
     /// Balances from outputs that the wallet can sign.
     pub mine: GetBalancesMine,
@@ -266,7 +258,6 @@ pub struct GetBalances {
 
 /// Balances from outputs that the wallet can sign. Part of `getbalances`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBalancesMine {
     /// Trusted balance (outputs created by the wallet or confirmed outputs).
     pub trusted: Amount,
@@ -282,7 +273,6 @@ pub struct GetBalancesMine {
 
 /// Hash and height of the block this information was generated on. Part of `getbalances`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetBalancesWatchOnly {
     /// Trusted balance (outputs created by the wallet or confirmed outputs).
     pub trusted: Amount,
@@ -294,12 +284,10 @@ pub struct GetBalancesWatchOnly {
 
 /// Models the result of JSON-RPC method `gethdkeys`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetHdKeys(pub Vec<HdKey>);
 
 /// An HD key entry. Part of `gethdkeys`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct HdKey {
     /// The extended public key.
     pub xpub: Xpub,
@@ -313,7 +301,6 @@ pub struct HdKey {
 
 /// Descriptor object. Part of `gethdkeys`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct HdKeyDescriptor {
     /// Descriptor string representation.
     pub descriptor: String,
@@ -323,27 +310,22 @@ pub struct HdKeyDescriptor {
 
 /// Models the result of JSON-RPC method `getnewaddress`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetNewAddress(pub Address<NetworkUnchecked>);
 
 /// Models the result of JSON-RPC method `getrawchangeaddress`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetRawChangeAddress(pub Address<NetworkUnchecked>);
 
 /// Models the result of JSON-RPC method `getreceivedbyaddress`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetReceivedByAddress(pub Amount);
 
 /// Models the result of JSON-RPC method `getreceivedbylabel`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetReceivedByLabel(pub Amount);
 
 /// Models the result of JSON-RPC method `gettransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetTransaction {
     /// The transaction amount.
     #[serde(default, with = "bitcoin::amount::serde::as_btc")]
@@ -404,7 +386,6 @@ pub struct GetTransaction {
 
 /// Transaction detail. Part of the `gettransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetTransactionDetail {
     /// Only returns true if imported addresses were involved in transaction. v20 and later only.
     pub involves_watch_only: Option<bool>,
@@ -437,7 +418,6 @@ pub struct GetTransactionDetail {
 
 /// Last processed block item. Part of of `gettransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct LastProcessedBlock {
     /// Hash of the block this information was generated on.
     pub hash: BlockHash,
@@ -447,12 +427,10 @@ pub struct LastProcessedBlock {
 
 /// Models the result of JSON-RPC method `getunconfirmedbalance`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetUnconfirmedBalance(pub Amount);
 
 /// Models the result of JSON-RPC method `getwalletinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetWalletInfo {
     /// The wallet name.
     pub wallet_name: String,
@@ -515,13 +493,11 @@ pub enum GetWalletInfoScanning {
 
 /// Models the result of JSON-RPC method `listaddressgroupings`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListAddressGroupings(pub Vec<Vec<ListAddressGroupingsItem>>);
 
 /// List address item. Part of `listaddressgroupings`.
 // FIXME: The Core docs seem wrong, not sure what shape this should be?
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListAddressGroupingsItem {
     /// The bitcoin address.
     pub address: Address<NetworkUnchecked>,
@@ -533,12 +509,10 @@ pub struct ListAddressGroupingsItem {
 
 /// Models the result of JSON-RPC method `listlockunspent`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListLockUnspent(pub Vec<ListLockUnspentItem>);
 
 /// List lock unspent item. Part of of `listlockunspent`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListLockUnspentItem {
     /// The transaction id locked.
     pub txid: Txid,
@@ -548,12 +522,10 @@ pub struct ListLockUnspentItem {
 
 /// Models the result of JSON-RPC method `listreceivedbyaddress`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListReceivedByAddress(pub Vec<ListReceivedByAddressItem>);
 
 /// List received by address item. Part of of `listreceivedbyaddress`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListReceivedByAddressItem {
     /// Only returned if imported addresses were involved in transaction.
     pub involves_watch_only: Option<bool>,
@@ -571,12 +543,10 @@ pub struct ListReceivedByAddressItem {
 
 /// Models the result of JSON-RPC method `listreceivedbylabel`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListReceivedByLabel(pub Vec<ListReceivedByLabelItem>);
 
 /// List received by label item. Part of of `listreceivedbyaddress`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListReceivedByLabelItem {
     /// Only returned if imported addresses were involved in transaction.
     pub involves_watch_only: Option<bool>,
@@ -590,7 +560,6 @@ pub struct ListReceivedByLabelItem {
 
 /// Models the result of JSON-RPC method `listsinceblock`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListSinceBlock {
     /// All the transactions.
     pub transactions: Vec<TransactionItem>,
@@ -609,7 +578,6 @@ pub struct ListSinceBlock {
 
 /// Transaction item. Part of `listsinceblock` and `listtransactions`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct TransactionItem {
     /// Only returns true if imported addresses were involved in transaction.
     pub involves_watch_only: Option<bool>,
@@ -691,17 +659,14 @@ pub struct TransactionItem {
 
 /// Models the result of JSON-RPC method `listtransactions`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListTransactions(pub Vec<TransactionItem>);
 
 /// Models the result of JSON-RPC method `listunspent`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListUnspent(pub Vec<ListUnspentItem>);
 
 /// Unspent transaction output. Part of `listunspent`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListUnspentItem {
     /// The transaction id.
     pub txid: Txid,
@@ -737,12 +702,10 @@ pub struct ListUnspentItem {
 
 /// Models the result of JSON-RPC method `listwallets`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct ListWallets(pub Vec<String>);
 
 /// Models the result of JSON-RPC method `loadwallet`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct LoadWallet {
     /// The wallet name if loaded successfully.
     pub name: String,
@@ -752,7 +715,6 @@ pub struct LoadWallet {
 
 /// Models the result of JSON-RPC method `psbtbumpfee`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct PsbtBumpFee {
     /// The base64-encoded unsigned PSBT of the new transaction.
     pub psbt: Psbt,
@@ -766,7 +728,6 @@ pub struct PsbtBumpFee {
 
 /// Models the result of JSON-RPC method `rescanblockchain`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct RescanBlockchain {
     /// The block height where the rescan has started.
     pub start_height: u32,
@@ -776,7 +737,6 @@ pub struct RescanBlockchain {
 
 /// Models the result of JSON-RPC method `send`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct Send {
     /// If the transaction has a complete set of signatures.
     pub complete: bool,
@@ -791,7 +751,6 @@ pub struct Send {
 
 /// Models the result of JSON-RPC method `sendall`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SendAll {
     /// If the transaction has a complete set of signatures.
     pub complete: bool,
@@ -806,12 +765,10 @@ pub struct SendAll {
 
 /// Models the result of JSON-RPC method `sendmany`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SendMany(pub Txid);
 
 /// Models the verbose result of JSON-RPC method `sendmany` when `verbose=true`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SendManyVerbose {
     /// The transaction id for the send. Only 1 transaction is created regardless of the number of addresses.
     pub txid: Txid,
@@ -821,7 +778,6 @@ pub struct SendManyVerbose {
 
 /// Models the result of JSON-RPC method `sendtoaddress`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SendToAddress {
     pub txid: Txid,
 }
@@ -838,7 +794,6 @@ pub type SignRawTransactionWithWallet = SignRawTransaction;
 
 /// Models the result of JSON-RPC method `simulaterawtransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct SimulateRawTransaction {
     /// The wallet balance change (negative means decrease).
     #[serde(default, with = "bitcoin::amount::serde::as_btc")]
@@ -849,7 +804,6 @@ pub struct SimulateRawTransaction {
 ///
 /// Core version v0.21 onwards.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct UnloadWallet {
     /// Warning messages, if any, related to unloading the wallet.
     // Changes from single string to vector in Core v25
@@ -858,7 +812,6 @@ pub struct UnloadWallet {
 
 /// Models the result of JSON-RPC method `walletcreatefundedpsbt`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct WalletCreateFundedPsbt {
     /// The resulting PSBT.
     pub psbt: Psbt,
@@ -871,7 +824,6 @@ pub struct WalletCreateFundedPsbt {
 
 /// Models the result of JSON-RPC method `walletdisplayaddress`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct WalletDisplayAddress {
     /// The address as confirmed by the signer
     pub address: Address<NetworkUnchecked>,
@@ -879,7 +831,6 @@ pub struct WalletDisplayAddress {
 
 /// Models the result of JSON-RPC method `walletprocesspsbt`.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct WalletProcessPsbt {
     /// The partially signed transaction.
     pub psbt: Psbt,


### PR DESCRIPTION
The attribute was added to catch mistakes in what core returns compared to what is in the structs. This has no meaning in `model` since they are internal conversions of the version specific types.

Remove the attribute from all `model` types.

Closes #373