### PR TITLE
Bump versions to 0.10.0

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -153,7 +153,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "corepc-client"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bitcoin",
  "corepc-types",
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-node"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-types"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bitcoin",
  "serde",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -153,7 +153,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "corepc-client"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bitcoin",
  "corepc-types",
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-node"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-types"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bitcoin",
  "serde",

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.10.0 2025-10-07
+
+- Update to use latest `types v0.10.0`.
+
 # 0.9.0 2025-09-11
 
 Add support for all the new methods added as part of the `types v0.9.0`

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-client"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Tobin C. Harding <me@tobin.cc>", "Jamil Lambert <Jamil.Lambert@proton.me>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/corepc"

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.10.0 2025-10-07
+
+- Update to use latest `client v0.10.0`.
+
 # 0.9.0 2025-09-11
 
 The `types v0.9.0` release adds support for **all** remaining documented

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-node"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Riccardo Casatta <riccardo@casatta.it>", "Tobin C. Harding <me@tobin.cc>"]
 license = "MIT"
 repository = "https://github.com/rust-bitcoin/corepc"

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.10.0 2025-10-07
+
+- Add `ScriptPubKey` model [#370](https://github.com/rust-bitcoin/corepc/pull/370)
+- Add a feature for `serde` deny unknown fields [#367](https://github.com/rust-bitcoin/corepc/pull/367)
+- Fix a few of type fields in v24 and v28 fixes [#375](https://github.com/rust-bitcoin/corepc/pull/375)
+
 # 0.9.0 2025-09-11
 
 This release is massive, it delivers support for **all** documented Core RPC

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-types"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Tobin C. Harding <me@tobin.cc>", "Jamil Lambert <Jamil.Lambert@proton.me>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/corepc"


### PR DESCRIPTION
In preparation for release add a changelog entry, bump the version, and update the lockfiles.

This is for all three released crates. FTR because they depend on each other release of `types` triggers release of the others too (if I'm not mistaken).