### PR TITLE
Specify version of dependencies instead of path

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -25,8 +25,8 @@ bitcoin = { version = "0.32.0", default-features = false, features = ["std", "se
 log = "0.4"
 serde = { version = "1.0.103", default-features = false, features = [ "derive", "alloc" ] }
 serde_json = { version = "1.0.117" }
-types = { package = "corepc-types", path = "../types", default-features = false, features = ["std"] }
+types = { package = "corepc-types", version = "0.10.0", path = "../types", default-features = false, features = ["std"] }
 
-jsonrpc = { path = "../jsonrpc", features = ["minreq_http"], optional = true }
+jsonrpc = { version = "0.18.0", path = "../jsonrpc", features = ["minreq_http"], optional = true }
 
 [dev-dependencies]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["tests", "contrib"]
 
 [dependencies]
 anyhow = { version = "1.0.66", default-features = false, features = ["std"] }
-corepc-client = { path = "../client", features = ["client-sync"] }
+corepc-client = { version = "0.10.0", path = "../client", features = ["client-sync"] }
 log = { version = "0.4", default-features = false }
 serde_json = { version = "1.0.117", default-features = false }
 tempfile = { version = "3", default-features = false }


### PR DESCRIPTION
I just tried to publish `corepc-client 0.10.0` and got an error from `cargo`.

  error: all dependencies must have a version specified when publishing.

We recently switched to using `path` instead of versions, seems like this was wrong.