### PR TITLE
Release tracking PR: `corepc-types v0.10.1`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-types"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "bitcoin",
  "serde",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-types"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "bitcoin",
  "serde",

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.10.1 2025-10-10
+
+- v24+ should use the correct `GetRawMempoolVerbose` [#381](https://github.com/rust-bitcoin/corepc/pull/381)
+
 # 0.10.0 2025-10-07
 
 - Add `ScriptPubKey` model [#370](https://github.com/rust-bitcoin/corepc/pull/370)

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-types"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Tobin C. Harding <me@tobin.cc>", "Jamil Lambert <Jamil.Lambert@proton.me>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/corepc"


### PR DESCRIPTION
We just merged a wee bug fix. In preparation for a point release, bump the version, add a changelog entry, and update the lock files.

Point release so we don't need to do `node`, and `client`.