### PR TITLE
Add version and patch to dependencies

### DIFF
--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -57,9 +57,22 @@ TODO = []                       # This is a dirty hack while writing the tests.
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false, features = ["std", "serde"] }
 env_logger = "0.9.0"
-node = { package = "corepc-node", path = "../node", default-features = false }
+node = { package = "corepc-node", version = "0.10.0", path = "../node", default-features = false }
 rand = "0.8.5"
 # Just so we can enable the feature.
-types = { package = "corepc-types", path = "../types", features = ["serde-deny-unknown-fields"] }
+types = { package = "corepc-types", version = "0.10.0", path = "../types", features = ["serde-deny-unknown-fields"] }
 
 [dev-dependencies]
+
+
+[patch.crates-io.corepc-client]
+path = "../client"
+
+[patch.crates-io.jsonrpc]
+path = "../jsonrpc"
+
+[patch.crates-io.corepc-node]
+path = "../node"
+
+[patch.crates-io.corepc-types]
+path = "../types"


### PR DESCRIPTION
Having a version, path and patch for dependencies ensures that the local version is used during development including indirect dependencies, and publishing is still possible.

Closes #380