### PR TITLE
Add empty bitreq crate

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -110,6 +110,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
+name = "bitreq"
+version = "0.0.0"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -110,6 +110,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
+name = "bitreq"
+version = "0.0.0"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["client", "jsonrpc", "node", "types"]
+members = [ "bitreq", "client", "jsonrpc", "node", "types"]
 exclude = ["integration_test", "verify"]
 resolver = "2"
 

--- a/bitreq/CHANGELOG.md
+++ b/bitreq/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 2025-10-21 - 0.0.0
+
+Grabbing the name on crates.io.

--- a/bitreq/Cargo.toml
+++ b/bitreq/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "bitreq"
+version = "0.0.0"
+authors = ["Tobin C. Harding <me@tobin.cc>"]
+description = "Simple, minimal-dependency HTTP client"
+documentation = "https://docs.rs/bitreq"
+repository = "https://github.com/rust-bitcoin/corepc"
+readme = "README.md"
+keywords = ["http", "https", "client", "request", "json"]
+categories = ["web-programming::http-client"]
+license = "ISC"
+edition = "2021"
+rust-version = "1.74.0"
+
+[dependencies]

--- a/bitreq/README.md
+++ b/bitreq/README.md
@@ -1,0 +1,3 @@
+# bitreq
+
+Minimal dependency HTTP crate.

--- a/bitreq/src/main.rs
+++ b/bitreq/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}


### PR DESCRIPTION
We are going to create a new HTTP crate for the Rust Bitcoin eccosystem. Add an empty crate so we can grab the name on crates.io.