### PR TITLE
bitreq: Re-implement `json-using-serde` feature

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -165,6 +165,8 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "rustls-webpki",
+ "serde",
+ "serde_json",
  "tiny_http",
  "tokio",
  "tokio-rustls",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -165,6 +165,8 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "rustls-webpki",
+ "serde",
+ "serde_json",
  "tiny_http",
  "tokio",
  "tokio-rustls",

--- a/bitreq/Cargo.toml
+++ b/bitreq/Cargo.toml
@@ -20,6 +20,9 @@ maintenance = { status = "experimental" }
 urlencoding = { version = "2.1.0", optional = true }
 # For the punycode feature:
 punycode = { version = "0.4.1", optional = true }
+# For the json-using-serde feature:
+serde = { version = "1.0.101", optional = true }
+serde_json = { version = "1.0.0", optional = true }
 # For the proxy feature:
 base64 = { version = "0.22", optional = true }
 # For the https features:
@@ -37,7 +40,7 @@ tiny_http = "0.12"
 chrono = "0.4.0"
 
 [package.metadata.docs.rs]
-features = ["proxy", "https", "punycode"]
+features = ["json-using-serde", "proxy", "https", "punycode"]
 
 [features]
 default = ["std"]
@@ -46,6 +49,7 @@ log = ["dep:log"]
 https = ["https-rustls"]
 https-rustls = ["rustls", "webpki-roots", "rustls-webpki"]
 https-rustls-probe = ["rustls", "rustls-native-certs"]
+json-using-serde = ["serde", "serde_json"]
 proxy = ["base64"]
 async = ["tokio", "std"]
 async-https = ["async", "https-rustls", "tokio-rustls"]

--- a/bitreq/src/error.rs
+++ b/bitreq/src/error.rs
@@ -9,6 +9,9 @@ use std::{error, io};
 // what the user might want to handle? This error doesn't really invite graceful
 // handling.
 pub enum Error {
+    #[cfg(feature = "json-using-serde")]
+    /// Ran into a Serde error.
+    SerdeJsonError(serde_json::Error),
     /// The response body contains invalid UTF-8, so the `as_str()`
     /// conversion failed.
     InvalidUtf8InBody(str::Utf8Error),
@@ -88,6 +91,8 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use Error::*;
         match self {
+            #[cfg(feature = "json-using-serde")]
+            SerdeJsonError(err) => write!(f, "{}", err),
             #[cfg(feature = "std")]
             IoError(err) => write!(f, "{}", err),
             InvalidUtf8InBody(err) => write!(f, "{}", err),
@@ -124,6 +129,8 @@ impl error::Error for Error {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         use Error::*;
         match self {
+            #[cfg(feature = "json-using-serde")]
+            SerdeJsonError(err) => Some(err),
             #[cfg(feature = "std")]
             IoError(err) => Some(err),
             InvalidUtf8InBody(err) => Some(err),

--- a/bitreq/src/request.rs
+++ b/bitreq/src/request.rs
@@ -173,6 +173,24 @@ impl Request {
         self
     }
 
+    /// Converts given argument to JSON and sets it as body.
+    ///
+    /// # Errors
+    ///
+    /// Returns
+    /// [`SerdeJsonError`](enum.Error.html#variant.SerdeJsonError) if
+    /// Serde runs into a problem when converting `body` into a
+    /// string.
+    #[cfg(feature = "json-using-serde")]
+    pub fn with_json<T: serde::ser::Serialize>(mut self, body: &T) -> Result<Request, Error> {
+        self.headers
+            .insert("Content-Type".to_string(), "application/json; charset=UTF-8".to_string());
+        match serde_json::to_string(&body) {
+            Ok(json) => Ok(self.with_body(json)),
+            Err(err) => Err(Error::SerdeJsonError(err)),
+        }
+    }
+
     /// Sets the request timeout in seconds.
     pub fn with_timeout(mut self, timeout: u64) -> Request {
         self.timeout = Some(timeout);

--- a/bitreq/src/response.rs
+++ b/bitreq/src/response.rs
@@ -127,6 +127,41 @@ impl Response {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> { Ok(()) }
     /// ```
     pub fn into_bytes(self) -> Vec<u8> { self.body }
+
+    /// Converts JSON body to a `struct` using Serde.
+    ///
+    /// # Errors
+    ///
+    /// Returns
+    /// [`SerdeJsonError`](enum.Error.html#variant.SerdeJsonError) if
+    /// Serde runs into a problem, or
+    /// [`InvalidUtf8InBody`](enum.Error.html#variant.InvalidUtf8InBody)
+    /// if the body is not UTF-8.
+    ///
+    /// # Example
+    /// In case compiler cannot figure out return type you might need to declare it explicitly:
+    ///
+    /// ```no_run
+    /// use serde_json::Value;
+    ///
+    /// # fn main() -> Result<(), bitreq::Error> {
+    /// # let url_to_json_resource = "http://example.org/resource.json";
+    /// // Value could be any type that implements Deserialize!
+    /// let user = bitreq::get(url_to_json_resource).send()?.json::<Value>()?;
+    /// println!("User name is '{}'", user["name"]);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "json-using-serde")]
+    pub fn json<'a, T>(&'a self) -> Result<T, Error>
+    where
+        T: serde::de::Deserialize<'a>,
+    {
+        match serde_json::from_str(self.as_str()?) {
+            Ok(json) => Ok(json),
+            Err(err) => Err(Error::SerdeJsonError(err)),
+        }
+    }
 }
 
 /// An HTTP response, which is loaded lazily.

--- a/bitreq/tests/main.rs
+++ b/bitreq/tests/main.rs
@@ -15,6 +15,21 @@ fn test_https() {
 }
 
 #[test]
+#[cfg(feature = "json-using-serde")]
+fn test_json_using_serde() {
+    const JSON_SRC: &str = r#"{
+        "str": "Json test",
+        "num": 42
+    }"#;
+
+    setup();
+    let original_json: serde_json::Value = serde_json::from_str(JSON_SRC).unwrap();
+    let response = bitreq::post(url("/echo")).with_json(&original_json).unwrap().send().unwrap();
+    let actual_json: serde_json::Value = response.json().unwrap();
+    assert_eq!(actual_json, original_json);
+}
+
+#[test]
 fn test_timeout_too_low() {
     setup();
     let result = bitreq::get(url("/slow_a")).with_body("Q".to_string()).with_timeout(1).send();


### PR DESCRIPTION
This feature was removed when we gutted `minreq` after forking it. Turns out we need it to be able to use `bitreq` in `jsonrpc`.

Re-implement the feature by copying code from `minreq`.

Close: #393