### PR TITLE
Release tracking PR: `jsonrpc v0.19.0`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "base64 0.22.1",
  "bitreq",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "base64 0.22.1",
  "bitreq",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -27,6 +27,6 @@ serde = { version = "1.0.103", default-features = false, features = [ "derive", 
 serde_json = { version = "1.0.117" }
 types = { package = "corepc-types", version = "0.10.0", path = "../types", default-features = false, features = ["std"] }
 
-jsonrpc = { version = "0.18.0", path = "../jsonrpc", features = ["bitreq_http"], optional = true }
+jsonrpc = { version = "0.19.0", path = "../jsonrpc", features = ["bitreq_http"], optional = true }
 
 [dev-dependencies]

--- a/client/src/client_sync/mod.rs
+++ b/client/src/client_sync/mod.rs
@@ -83,7 +83,7 @@ macro_rules! define_jsonrpc_bitreq_client {
             pub fn new(url: &str) -> Self {
                 let transport = jsonrpc::http::bitreq_http::Builder::new()
                     .url(url)
-                    .expect("jsonrpc v0.18, this function does not error")
+                    .expect("jsonrpc v0.19, this function does not error")
                     .timeout(std::time::Duration::from_secs(60))
                     .build();
                 let inner = jsonrpc::client::Client::with_transport(transport);
@@ -100,7 +100,7 @@ macro_rules! define_jsonrpc_bitreq_client {
 
                 let transport = jsonrpc::http::bitreq_http::Builder::new()
                     .url(url)
-                    .expect("jsonrpc v0.18, this function does not error")
+                    .expect("jsonrpc v0.19, this function does not error")
                     .timeout(std::time::Duration::from_secs(60))
                     .basic_auth(user.unwrap(), pass)
                     .build();

--- a/jsonrpc/CHANGELOG.md
+++ b/jsonrpc/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.19.0 - 2025-10-31
+
+* Depend on `bitreq` [399](https://github.com/rust-bitcoin/corepc/pull/399)
+* Update MSRV to Rust `v1.75.0` [#405](https://github.com/rust-bitcoin/corepc/pull/405/)
+
 # 0.18.0 - 2024-04-12
 
 * simple_http: throw a specific error when transfer encoding is chunked

--- a/jsonrpc/Cargo.toml
+++ b/jsonrpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpc"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/corepc/"


### PR DESCRIPTION
Do a couple of minor cleanups then do the release patch - version bump, changelog, and lock files.