### PR TITLE
Release tracking PR: `corepc-node 0.10.1`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-node"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -165,7 +165,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-node"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.10.1 2025-11-18
+
+- Remove `doc_auto_cfg` to fix build on docs.rs
+
 # 0.10.0 2025-10-07
 
 - Update to use latest `client v0.10.0`.

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-node"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Riccardo Casatta <riccardo@casatta.it>", "Tobin C. Harding <me@tobin.cc>"]
 license = "MIT"
 repository = "https://github.com/rust-bitcoin/corepc"


### PR DESCRIPTION
We released with `doc_auto_cfg` in the crate and this caused the docs build on docs.rs to fail.

Bump the version, add a changelog entry, and update the lock files.