### PR TITLE
Bump versions to 0.11.0

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -265,7 +265,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "corepc-client"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bitcoin",
  "corepc-types",
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-node"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-types"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "bitcoin",
  "serde",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -265,7 +265,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "corepc-client"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bitcoin",
  "corepc-types",
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-node"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-types"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "bitcoin",
  "serde",

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.11.0 - 2025-11-18
+
+- Add support for Bitcoin Core 30.0 [#387](https://github.com/rust-bitcoin/corepc/pull/387),
+  [#388](https://github.com/rust-bitcoin/corepc/pull/388).
+- Bump MSRV to 1.75.0 [#405](https://github.com/rust-bitcoin/corepc/pull/405)
+- Update to use latest `types v0.11.0`.
+
 # 0.10.0 - 2025-10-07
 
 - Update to use latest `types v0.10.0`.

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-client"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Tobin C. Harding <me@tobin.cc>", "Jamil Lambert <Jamil.Lambert@proton.me>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/corepc"
@@ -25,7 +25,7 @@ bitcoin = { version = "0.32.0", default-features = false, features = ["std", "se
 log = "0.4"
 serde = { version = "1.0.103", default-features = false, features = [ "derive", "alloc" ] }
 serde_json = { version = "1.0.117" }
-types = { package = "corepc-types", version = "0.10.0", path = "../types", default-features = false, features = ["std"] }
+types = { package = "corepc-types", version = "0.11.0", path = "../types", default-features = false, features = ["std"] }
 
 jsonrpc = { version = "0.18.0", path = "../jsonrpc", features = ["bitreq_http"], optional = true }
 

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -59,10 +59,10 @@ TODO = []                       # This is a dirty hack while writing the tests.
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false, features = ["std", "serde"] }
 env_logger = "0.9.0"
-node = { package = "corepc-node", version = "0.10.0", path = "../node", default-features = false }
+node = { package = "corepc-node", version = "0.11.0", path = "../node", default-features = false }
 rand = "0.8.5"
 # Just so we can enable the feature.
-types = { package = "corepc-types", version = "0.10.0", path = "../types", features = ["serde-deny-unknown-fields"] }
+types = { package = "corepc-types", version = "0.11.0", path = "../types", features = ["serde-deny-unknown-fields"] }
 
 [dev-dependencies]
 

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.11.0 - 2025-11-18
+
+- Bump MSRV to 1.75.0 [#405](https://github.com/rust-bitcoin/corepc/pull/405)
+- Update to use latest `client v0.11.0`.
+
+# 0.10.1 2025-11-18
+
+- Remove `doc_auto_cfg` to fix build on docs.rs
+
 # 0.10.0 - 2025-10-07
 
 - Update to use latest `client v0.10.0`.

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-node"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Riccardo Casatta <riccardo@casatta.it>", "Tobin C. Harding <me@tobin.cc>"]
 license = "MIT"
 repository = "https://github.com/rust-bitcoin/corepc"
@@ -14,7 +14,7 @@ exclude = ["tests", "contrib"]
 
 [dependencies]
 anyhow = { version = "1.0.66", default-features = false, features = ["std"] }
-corepc-client = { version = "0.10.0", path = "../client", features = ["client-sync"] }
+corepc-client = { version = "0.11.0", path = "../client", features = ["client-sync"] }
 log = { version = "0.4", default-features = false }
 serde_json = { version = "1.0.117", default-features = false }
 tempfile = { version = "3", default-features = false }

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.11.0 - 2025-11-18
+
+- Add support for Bitcoin Core 30.0 [#387](https://github.com/rust-bitcoin/corepc/pull/387),
+  [#388](https://github.com/rust-bitcoin/corepc/pull/388),
+  [#409](https://github.com/rust-bitcoin/corepc/pull/409),
+  [#410](https://github.com/rust-bitcoin/corepc/pull/410),
+  [#412](https://github.com/rust-bitcoin/corepc/pull/412).
+- Bump MSRV to 1.75.0 [#405](https://github.com/rust-bitcoin/corepc/pull/405)
+
 # 0.10.1 - 2025-10-10
 
 - v24+ should use the correct `GetRawMempoolVerbose` [#381](https://github.com/rust-bitcoin/corepc/pull/381)

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-types"
-version = "0.10.1"
+version = "0.11.0"
 authors = ["Tobin C. Harding <me@tobin.cc>", "Jamil Lambert <Jamil.Lambert@proton.me>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/corepc"


### PR DESCRIPTION
In preparation for release add a changelog entry, bump the version, and update the lockfiles.