### PR TITLE
bitreq: Remove unnecessary main.rs

### DIFF
--- a/bitreq/src/main.rs
+++ b/bitreq/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}


### PR DESCRIPTION
Remove the left over `main.rs` file in `bitreq` that does nothing. Addresses one of the points in #402.