### PR TITLE
Implement hidden RPC `addconnection`

### DIFF
--- a/client/src/client_sync/v22/hidden.rs
+++ b/client/src/client_sync/v22/hidden.rs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Macros for implementing JSON-RPC methods on a client.
+//!
+//! Specifically this is `== Hidden ==` methods that are not listed in the
+//! API docs of Bitcoin Core `v22`.
+//!
+//! All macros require `Client` to be in scope.
+//!
+//! See, or use the `define_jsonrpc_bitreq_client!` macro to define a `Client`.
+
+/// Implements Bitcoin Core JSON-RPC API method `addconnection`.
+#[macro_export]
+macro_rules! impl_client_v22__add_connection {
+    () => {
+        impl Client {
+            pub fn add_connection(
+                &self,
+                address: &str,
+                connection_type: &str,
+            ) -> Result<AddConnection> {
+                self.call("addconnection", &[into_json(address)?, into_json(connection_type)?])
+            }
+        }
+    };
+}

--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -4,6 +4,7 @@
 //!
 //! We ignore option arguments unless they effect the shape of the returned JSON data.
 
+mod hidden;
 mod signer;
 mod wallet;
 
@@ -69,6 +70,7 @@ crate::impl_client_v20__generate_to_descriptor!();
 crate::impl_client_v17__invalidate_block!();
 
 // == Hidden ==
+crate::impl_client_v22__add_connection!();
 crate::impl_client_v21__add_peer_address!();
 crate::impl_client_v17__estimate_raw_fee!();
 crate::impl_client_v17__wait_for_block!();

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -72,6 +72,7 @@ crate::impl_client_v20__generate_to_descriptor!();
 crate::impl_client_v17__invalidate_block!();
 
 // == Hidden ==
+crate::impl_client_v22__add_connection!();
 crate::impl_client_v21__add_peer_address!();
 crate::impl_client_v17__estimate_raw_fee!();
 crate::impl_client_v17__wait_for_block!();

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -73,6 +73,7 @@ crate::impl_client_v20__generate_to_descriptor!();
 crate::impl_client_v17__invalidate_block!();
 
 // == Hidden ==
+crate::impl_client_v22__add_connection!();
 crate::impl_client_v21__add_peer_address!();
 crate::impl_client_v17__estimate_raw_fee!();
 crate::impl_client_v17__wait_for_block!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -74,6 +74,7 @@ crate::impl_client_v20__generate_to_descriptor!();
 crate::impl_client_v17__invalidate_block!();
 
 // == Hidden ==
+crate::impl_client_v22__add_connection!();
 crate::impl_client_v21__add_peer_address!();
 crate::impl_client_v17__estimate_raw_fee!();
 crate::impl_client_v17__wait_for_block!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -80,6 +80,7 @@ crate::impl_client_v20__generate_to_descriptor!();
 crate::impl_client_v17__invalidate_block!();
 
 // == Hidden ==
+crate::impl_client_v22__add_connection!();
 crate::impl_client_v21__add_peer_address!();
 crate::impl_client_v17__estimate_raw_fee!();
 crate::impl_client_v17__wait_for_block!();

--- a/client/src/client_sync/v27/hidden.rs
+++ b/client/src/client_sync/v27/hidden.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Macros for implementing JSON-RPC methods on a client.
+//!
+//! Specifically this is `== Hidden ==` methods that are not listed in the
+//! API docs of Bitcoin Core `v27`.
+//!
+//! All macros require `Client` to be in scope.
+//!
+//! See, or use the `define_jsonrpc_bitreq_client!` macro to define a `Client`.
+
+/// Implements Bitcoin Core JSON-RPC API method `addconnection`.
+#[macro_export]
+macro_rules! impl_client_v27__add_connection {
+    () => {
+        impl Client {
+            pub fn add_connection(
+                &self,
+                address: &str,
+                connection_type: &str,
+                v2transport: bool,
+            ) -> Result<AddConnection> {
+                self.call(
+                    "addconnection",
+                    &[into_json(address)?, into_json(connection_type)?, into_json(v2transport)?],
+                )
+            }
+        }
+    };
+}

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -4,6 +4,8 @@
 //!
 //! We ignore option arguments unless they effect the shape of the returned JSON data.
 
+pub mod hidden;
+
 use std::collections::BTreeMap;
 use std::path::Path;
 
@@ -74,6 +76,7 @@ crate::impl_client_v20__generate_to_descriptor!();
 crate::impl_client_v17__invalidate_block!();
 
 // == Hidden ==
+crate::impl_client_v27__add_connection!();
 crate::impl_client_v21__add_peer_address!();
 crate::impl_client_v17__estimate_raw_fee!();
 crate::impl_client_v17__wait_for_block!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -77,6 +77,7 @@ crate::impl_client_v20__generate_to_descriptor!();
 crate::impl_client_v17__invalidate_block!();
 
 // == Hidden ==
+crate::impl_client_v27__add_connection!();
 crate::impl_client_v21__add_peer_address!();
 crate::impl_client_v17__estimate_raw_fee!();
 crate::impl_client_v17__wait_for_block!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -77,6 +77,7 @@ crate::impl_client_v20__generate_to_descriptor!();
 crate::impl_client_v17__invalidate_block!();
 
 // == Hidden ==
+crate::impl_client_v27__add_connection!();
 crate::impl_client_v21__add_peer_address!();
 crate::impl_client_v17__estimate_raw_fee!();
 crate::impl_client_v17__wait_for_block!();

--- a/client/src/client_sync/v30/mod.rs
+++ b/client/src/client_sync/v30/mod.rs
@@ -78,6 +78,7 @@ crate::impl_client_v20__generate_to_descriptor!();
 crate::impl_client_v17__invalidate_block!();
 
 // == Hidden ==
+crate::impl_client_v27__add_connection!();
 crate::impl_client_v21__add_peer_address!();
 
 // == Mining ==

--- a/types/src/v22/hidden/mod.rs
+++ b/types/src/v22/hidden/mod.rs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! The JSON-RPC API for Bitcoin Core `v22` - hidden.
+//!
+//! Types for methods that are excluded from the API docs by default.
+
+use serde::{Deserialize, Serialize};
+
+/// Result of JSON-RPC method `addconnection`.
+///
+/// > addconnection "address" "connection_type"
+/// >
+/// > Open an outbound connection to a specified node.
+/// > This RPC is for testing only.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
+pub struct AddConnection {
+    /// The address of the newly added connection.
+    pub address: String,
+    /// Type of connection.
+    pub connection_type: String,
+}

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -245,6 +245,7 @@
 // JSON-RPC types by API section.
 mod blockchain;
 mod control;
+mod hidden;
 mod network;
 mod raw_transactions;
 mod signer;
@@ -254,6 +255,7 @@ mod wallet;
 pub use self::{
     blockchain::GetMempoolInfo,
     control::Logging,
+    hidden::AddConnection,
     network::{Banned, GetNodeAddresses, GetPeerInfo, ListBanned, NodeAddress, PeerInfo},
     raw_transactions::{
         DecodeScript, DecodeScriptError, DecodeScriptSegwit, MempoolAcceptance,

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -321,9 +321,9 @@ pub use crate::{
         SendMany, SendManyVerbose, UnloadWallet, UpgradeWallet,
     },
     v22::{
-        Banned, DescriptorInfo, EnumerateSigners, GetAddressInfo, GetAddressInfoEmbedded,
-        GetMempoolInfo, GetNodeAddresses, ListBanned, ListDescriptors, MempoolAcceptance,
-        MempoolAcceptanceError, MempoolAcceptanceFees, NodeAddress, ScriptPubkey, Signers,
-        TestMempoolAccept, TestMempoolAcceptError, WalletDisplayAddress,
+        AddConnection, Banned, DescriptorInfo, EnumerateSigners, GetAddressInfo,
+        GetAddressInfoEmbedded, GetMempoolInfo, GetNodeAddresses, ListBanned, ListDescriptors,
+        MempoolAcceptance, MempoolAcceptanceError, MempoolAcceptanceFees, NodeAddress,
+        ScriptPubkey, Signers, TestMempoolAccept, TestMempoolAcceptError, WalletDisplayAddress,
     },
 };

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -321,10 +321,10 @@ pub use crate::{
         SendMany, SendManyVerbose, UnloadWallet, UpgradeWallet,
     },
     v22::{
-        Banned, DescriptorInfo, EnumerateSigners, GetAddressInfo, GetAddressInfoEmbedded,
-        GetNodeAddresses, ListBanned, ListDescriptors, MempoolAcceptance, MempoolAcceptanceError,
-        MempoolAcceptanceFees, NodeAddress, ScriptPubkey, Signers, TestMempoolAccept,
-        TestMempoolAcceptError, WalletDisplayAddress,
+        AddConnection, Banned, DescriptorInfo, EnumerateSigners, GetAddressInfo,
+        GetAddressInfoEmbedded, GetNodeAddresses, ListBanned, ListDescriptors, MempoolAcceptance,
+        MempoolAcceptanceError, MempoolAcceptanceFees, NodeAddress, ScriptPubkey, Signers,
+        TestMempoolAccept, TestMempoolAcceptError, WalletDisplayAddress,
     },
     v23::{
         AddMultisigAddress, Bip9Info, Bip9Statistics, CreateMultisig, DecodeScript,

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -314,8 +314,8 @@ pub use crate::{
         SendManyVerbose, UpgradeWallet,
     },
     v22::{
-        Banned, EnumerateSigners, GetAddressInfo, GetAddressInfoEmbedded, GetNodeAddresses,
-        ListBanned, NodeAddress, ScriptPubkey, Signers, WalletDisplayAddress,
+        AddConnection, Banned, EnumerateSigners, GetAddressInfo, GetAddressInfoEmbedded,
+        GetNodeAddresses, ListBanned, NodeAddress, ScriptPubkey, Signers, WalletDisplayAddress,
     },
     v23::{
         AddMultisigAddress, Bip9Info, Bip9Statistics, CreateMultisig, DecodeScript,

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -329,8 +329,8 @@ pub use crate::{
         SendManyVerbose, UpgradeWallet,
     },
     v22::{
-        Banned, EnumerateSigners, GetAddressInfo, GetAddressInfoEmbedded, GetNodeAddresses,
-        ListBanned, NodeAddress, ScriptPubkey, Signers, WalletDisplayAddress,
+        AddConnection, Banned, EnumerateSigners, GetAddressInfo, GetAddressInfoEmbedded,
+        GetNodeAddresses, ListBanned, NodeAddress, ScriptPubkey, Signers, WalletDisplayAddress,
     },
     v23::{
         AddMultisigAddress, Bip9Info, Bip9Statistics, CreateMultisig, DecodeScript,

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -305,8 +305,8 @@ pub use crate::{
         SendManyVerbose, UpgradeWallet,
     },
     v22::{
-        Banned, EnumerateSigners, GetAddressInfo, GetAddressInfoEmbedded, GetNodeAddresses,
-        ListBanned, NodeAddress, ScriptPubkey, Signers, WalletDisplayAddress,
+        AddConnection, Banned, EnumerateSigners, GetAddressInfo, GetAddressInfoEmbedded,
+        GetNodeAddresses, ListBanned, NodeAddress, ScriptPubkey, Signers, WalletDisplayAddress,
     },
     v23::{
         AddMultisigAddress, Bip9Info, Bip9Statistics, CreateMultisig, DecodeScript,

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -325,8 +325,8 @@ pub use crate::{
         PsbtBumpFee, PsbtBumpFeeError, Send, SendError, SendMany, SendManyVerbose, UpgradeWallet,
     },
     v22::{
-        Banned, EnumerateSigners, GetNodeAddresses, ListBanned, NodeAddress, ScriptPubkey, Signers,
-        WalletDisplayAddress,
+        AddConnection, Banned, EnumerateSigners, GetNodeAddresses, ListBanned, NodeAddress,
+        ScriptPubkey, Signers, WalletDisplayAddress,
     },
     v23::{
         AddMultisigAddress, Bip9Info, Bip9Statistics, CreateMultisig, DecodeScript,

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -319,8 +319,8 @@ pub use crate::{
         PsbtBumpFee, PsbtBumpFeeError, Send, SendError, SendMany, SendManyVerbose, UpgradeWallet,
     },
     v22::{
-        Banned, EnumerateSigners, GetNodeAddresses, ListBanned, NodeAddress, ScriptPubkey, Signers,
-        WalletDisplayAddress,
+        AddConnection, Banned, EnumerateSigners, GetNodeAddresses, ListBanned, NodeAddress,
+        ScriptPubkey, Signers, WalletDisplayAddress,
     },
     v23::{
         AddMultisigAddress, Bip9Info, Bip9Statistics, CreateMultisig, DecodeScript,

--- a/types/src/v30/mod.rs
+++ b/types/src/v30/mod.rs
@@ -312,8 +312,8 @@ pub use crate::{
         PsbtBumpFee, PsbtBumpFeeError, Send, SendError, SendMany, SendManyVerbose,
     },
     v22::{
-        Banned, EnumerateSigners, GetNodeAddresses, ListBanned, NodeAddress, ScriptPubkey, Signers,
-        WalletDisplayAddress,
+        AddConnection, Banned, EnumerateSigners, GetNodeAddresses, ListBanned, NodeAddress,
+        ScriptPubkey, Signers, WalletDisplayAddress,
     },
     v23::{
         Bip9Info, Bip9Statistics, CreateMultisig, DecodeScript, DecodeScriptError,


### PR DESCRIPTION
Implement the RPC in v22 hidden module, add the client macro, model and test.
Redefine the client macro in v29 where there is an added required argument.
Add all the reexports up to v30.