### PR TITLE
fix(types): use f64 for GetMiningInfo networkhashps field

### DIFF
--- a/integration_test/tests/mining.rs
+++ b/integration_test/tests/mining.rs
@@ -39,19 +39,21 @@ fn mining__get_block_template__modelled() {
 #[test]
 fn mining__get_mining_info() {
     let node = Node::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
 
     let json: GetMiningInfo = node.client.get_mining_info().expect("rpc");
 
     // Up to v28 (i.e., not 29_0) there is no error converting into model.
     #[cfg(feature = "v28_and_below")]
-    let _: mtype::GetMiningInfo = json.into_model();
+    let model: mtype::GetMiningInfo = json.into_model();
 
-    // v29 onwards
     #[cfg(not(feature = "v28_and_below"))]
-    {
-        let model: Result<mtype::GetMiningInfo, GetMiningInfoError> = json.into_model();
-        model.unwrap();
-    }
+    let model: mtype::GetMiningInfo = {
+        let result: Result<mtype::GetMiningInfo, GetMiningInfoError> = json.into_model();
+        result.unwrap()
+    };
+
+    assert!(model.network_hash_ps > 0.0);
 }
 
 #[test]

--- a/types/src/model/mining.rs
+++ b/types/src/model/mining.rs
@@ -113,7 +113,7 @@ pub struct GetMiningInfo {
     /// The current target (v29 onwards).
     pub target: Option<Target>,
     /// The network hashes per second.
-    pub network_hash_ps: i64,
+    pub network_hash_ps: f64,
     /// The size of the mempool.
     pub pooled_tx: i64,
     /// Minimum feerate of packages selected for block inclusion.

--- a/types/src/v17/mining/mod.rs
+++ b/types/src/v17/mining/mod.rs
@@ -157,7 +157,7 @@ pub struct GetMiningInfo {
     pub difficulty: f64,
     /// The network hashes per second.
     #[serde(rename = "networkhashps")]
-    pub network_hash_ps: i64,
+    pub network_hash_ps: f64,
     /// The size of the mempool.
     #[serde(rename = "pooledtx")]
     pub pooled_tx: i64,

--- a/types/src/v28/mining.rs
+++ b/types/src/v28/mining.rs
@@ -29,7 +29,7 @@ pub struct GetMiningInfo {
     pub difficulty: f64,
     /// The network hashes per second.
     #[serde(rename = "networkhashps")]
-    pub network_hash_ps: i64,
+    pub network_hash_ps: f64,
     /// The size of the mempool.
     #[serde(rename = "pooledtx")]
     pub pooled_tx: i64,

--- a/types/src/v29/mining/mod.rs
+++ b/types/src/v29/mining/mod.rs
@@ -37,7 +37,7 @@ pub struct GetMiningInfo {
     pub target: String,
     /// The network hashes per second.
     #[serde(rename = "networkhashps")]
-    pub network_hash_ps: i64,
+    pub network_hash_ps: f64,
     /// The size of the mempool.
     #[serde(rename = "pooledtx")]
     pub pooled_tx: i64,

--- a/types/src/v30/mining/mod.rs
+++ b/types/src/v30/mining/mod.rs
@@ -38,7 +38,7 @@ pub struct GetMiningInfo {
     pub target: String,
     /// The network hashes per second.
     #[serde(rename = "networkhashps")]
-    pub network_hash_ps: i64,
+    pub network_hash_ps: f64,
     /// The size of the mempool.
     #[serde(rename = "pooledtx")]
     pub pooled_tx: i64,


### PR DESCRIPTION
As per raised in https://github.com/rust-bitcoin/corepc/issues/429, addressing type discrepancies between corepc-types and Bitcoin Core.

Bitcoin Core has always returned `networkhashps` as a double since `getmininginfo` was introduced. The previous type (`i64`) causes deserialisation to fail. Here's a minimal example:

```rust
use corepc_client::client_sync::v28::Client;
use corepc_client::client_sync::Auth;

fn main() -> Result<(), Box<dyn std::error::Error>> {
    let auth = Auth::UserPass("bitcoin".to_string(), "bitcoin".to_string());
    let client = Client::new_with_auth("http://127.0.0.1:8332", auth)?;
    let info = client.get_mining_info()?;
    println!("networkhashps: {}", info.network_hash_ps);
    Ok(())
}
```

```
Error: JsonRpc(Json(Error("invalid type: floating point `1.055282156351532e+21`, expected i64", line: 1, column: 179)))
```

This change:
- Changes the `networkhashps` field type from `i64` to `f64`
- Modifies existing integration test to verify correct deserialisation (mines some blocks to yield a `networkhashps` `> 0.0`) and remove redundant comments