### PR TITLE
Drop Githooks section from `jsonrpc` README.md

### DIFF
--- a/jsonrpc/README.md
+++ b/jsonrpc/README.md
@@ -34,14 +34,3 @@ fn main() {
     println!("bitcoind uptime: {}", result);
 }
 ```
-
-## Githooks
-
-To assist devs in catching errors _before_ running CI we provide some githooks. If you do not
-already have locally configured githooks you can use the ones in this repository by running, in the
-root directory of the repository:
-```
-git config --local core.hooksPath githooks/
-```
-
-Alternatively add symlinks in your `.git/hooks` directory to any of the githooks we provide.


### PR DESCRIPTION
Since this repository doesn't have a `githooks/` directory.