### PR TITLE
Set `all-features = true ` in `docs.rs` builds

### DIFF
--- a/bitreq/Cargo.toml
+++ b/bitreq/Cargo.toml
@@ -44,7 +44,7 @@ tiny_http = "0.12"
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt-multi-thread", "time"] }
 
 [package.metadata.docs.rs]
-features = ["json-using-serde", "proxy", "https"]
+all-features = true
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Previously, the docs have been generated without the `async` feature, so `Client` for example never showed up. Here we add the feature to the doc list.