### PR TITLE
Add lock! macro to handle mutex poisoning gracefully

### DIFF
--- a/bitreq/src/client.rs
+++ b/bitreq/src/client.rs
@@ -66,7 +66,7 @@ impl Client {
 
         // Try to get cached connection
         let conn_opt = {
-            let state = self.r#async.lock().unwrap();
+            let state = lock!(self.r#async);
 
             if let Some(conn) = state.connections.get(&owned_key) {
                 Some(Arc::clone(conn))
@@ -80,7 +80,7 @@ impl Client {
             let connection = AsyncConnection::new(key, parsed_request.timeout_at).await?;
             let connection = Arc::new(connection);
 
-            let mut state = self.r#async.lock().unwrap();
+            let mut state = lock!(self.r#async);
             if let hash_map::Entry::Vacant(entry) = state.connections.entry(owned_key) {
                 entry.insert(Arc::clone(&connection));
                 state.lru_order.push_back(key.into());

--- a/bitreq/src/lib.rs
+++ b/bitreq/src/lib.rs
@@ -249,6 +249,29 @@
 
 extern crate alloc;
 
+/// Acquires a mutex lock, recovering from poisoning.
+///
+/// A mutex becomes poisoned when a thread panics while holding the lock.
+/// This macro ignores poisoning and returns the guard anyway, which is
+/// usually the right behavior since:
+/// - The data may still be in a valid state
+/// - Propagating panics across threads is rarely useful
+///
+/// # Example
+///
+/// ```ignore
+/// use std::sync::Mutex;
+///
+/// let mutex = Mutex::new(42);
+/// let guard = lock!(mutex);
+/// ```
+#[cfg(feature = "async")]
+macro_rules! lock {
+    ($mutex:expr) => {
+        $mutex.lock().unwrap_or_else(|e| e.into_inner())
+    };
+}
+
 #[cfg(feature = "std")]
 mod client;
 #[cfg(feature = "std")]


### PR DESCRIPTION
Mutex::lock().unwrap() panics if the mutex is poisoned (when a thread panicked while holding the lock). In practice, this is rarely the desired behavior - the data may still be valid and propagating panics across threads is usually unhelpful.

This adds a lock! macro that recovers from poisoning via unwrap_or_else(|e| e.into_inner()), providing a concise and consistent way to acquire locks throughout the codebase.

An alternative would be using parking_lot::Mutex which has no poisoning semantics, but this avoids adding an external dependency.