### PR TITLE
[client] Validate `conf_target` argument value range in `estimaterawfee` RPC

### DIFF
--- a/client/src/client_sync/v17/hidden.rs
+++ b/client/src/client_sync/v17/hidden.rs
@@ -14,7 +14,15 @@
 macro_rules! impl_client_v17__estimate_raw_fee {
     () => {
         impl Client {
+            /// # Panics
+            ///
+            /// * Panics if `conf_target` is outside the range [1, 1008].
             pub fn estimate_raw_fee(&self, conf_target: u32) -> Result<EstimateRawFee> {
+                assert!(
+                    (1..=1008).contains(&conf_target),
+                    "invalid conf_target, must be between 1 and 1008 inclusive"
+                );
+
                 self.call("estimaterawfee", &[conf_target.into()])
             }
         }

--- a/integration_test/tests/hidden.rs
+++ b/integration_test/tests/hidden.rs
@@ -74,6 +74,29 @@ fn hidden__estimate_raw_fee__modelled() {
     let estimate = model.unwrap();
 
     assert!(estimate.long.scale > 0);
+
+    // Boundary checks enforced by the client:
+    // conf_target must be between 1 and 1008 inclusive.
+    // 0 is invalid and should panic
+    assert!(
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            node.client.estimate_raw_fee(0)
+        }))
+        .is_err(),
+        "conf_target 0 must panic"
+    );
+    // 1009 is invalid and should panic
+    assert!(
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            node.client.estimate_raw_fee(1009)
+        }))
+        .is_err(),
+        "conf_target > 1008 must panic"
+    );
+
+    // Check inclusive bounds are accepted by the client
+    let _ = node.client.estimate_raw_fee(1).expect("conf_target 1 must be valid");
+    let _ = node.client.estimate_raw_fee(1008).expect("conf_target 1008 must be valid");
 }
 
 #[test]


### PR DESCRIPTION
The `conf_target` argument only takes in values from 1 to 1008 inclusive. All values outside these ranges return an error. This commit adds validation for it in all versions from v17 to v30 with tests.

Partially fixes issue #474.