### PR TITLE
[types] Add `completed` field to `ScanBlocksStart` return type  

### DIFF
--- a/integration_test/tests/blockchain.rs
+++ b/integration_test/tests/blockchain.rs
@@ -500,11 +500,18 @@ fn blockchain__scan_blocks_modelled() {
     let json: ScanBlocksStart =
         node.client.scan_blocks_start(&[scan_desc]).expect("scanblocks start");
     let model: Result<mtype::ScanBlocksStart, ScanBlocksStartError> = json.into_model();
-    model.unwrap();
+    let model = model.unwrap();
 
     let _: Option<ScanBlocksStatus> = node.client.scan_blocks_status().expect("scanblocks status");
 
     let _: ScanBlocksAbort = node.client.scan_blocks_abort().expect("scanblocks abort");
+
+    assert!(model.from_height <= model.to_height);
+
+    #[cfg(not(feature = "v25_and_below"))]
+    {
+        assert!(model.completed.is_some());
+    }
 }
 
 #[test]

--- a/types/src/model/blockchain.rs
+++ b/types/src/model/blockchain.rs
@@ -772,6 +772,8 @@ pub struct ScanBlocksStart {
     pub to_height: u32,
     /// Blocks that may have matched a scanobject
     pub relevant_blocks: Vec<BlockHash>,
+    /// Whether the scan is completed. For v26 onwards.
+    pub completed: Option<bool>,
 }
 
 /// Models the result of JSON-RPC method `verifytxoutproof`.

--- a/types/src/v25/blockchain/into.rs
+++ b/types/src/v25/blockchain/into.rs
@@ -67,17 +67,20 @@ impl GetBlockStats {
 
 impl ScanBlocksStart {
     pub fn into_model(self) -> Result<model::ScanBlocksStart, ScanBlocksStartError> {
+        use ScanBlocksStartError as E;
+
         let relevant_blocks = self
             .relevant_blocks
             .iter()
             .map(|s| s.parse())
             .collect::<Result<Vec<_>, _>>()
-            .map_err(ScanBlocksStartError::RelevantBlocks)?;
+            .map_err(E::RelevantBlocks)?;
 
         Ok(model::ScanBlocksStart {
             from_height: crate::to_u32(self.from_height, "from_height")?,
             to_height: crate::to_u32(self.to_height, "to_height")?,
             relevant_blocks,
+            completed: None,
         })
     }
 }

--- a/types/src/v26/blockchain/mod.rs
+++ b/types/src/v26/blockchain/mod.rs
@@ -175,3 +175,22 @@ pub struct LoadTxOutSet {
     /// The absolute path that the snapshot was loaded from.
     pub path: String,
 }
+
+/// Result of JSON-RPC method `scanblocks` with action "start".
+///
+/// > scanblocks "start" [scanobjects,...] ( start_height stop_height "filtertype" "options" )
+/// >
+/// > Arguments:
+/// > 1. scanobjects                            (json array, required) Array of scan objects
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
+pub struct ScanBlocksStart {
+    /// The height we started the scan from
+    pub from_height: i64,
+    /// The height we ended the scan at
+    pub to_height: i64,
+    /// Blocks that may have matched a scanobject
+    pub relevant_blocks: Vec<String>,
+    /// True if the scan process was not aborted
+    pub completed: bool,
+}

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -261,7 +261,7 @@ pub use self::{
     blockchain::{
         ChainState, DumpTxOutSet, DumpTxOutSetError, GetChainStates, GetChainStatesError,
         GetTxOutSetInfo, GetTxOutSetInfoBlockInfo, GetTxOutSetInfoError,
-        GetTxOutSetInfoUnspendables, LoadTxOutSet, LoadTxOutSetError,
+        GetTxOutSetInfoUnspendables, LoadTxOutSet, LoadTxOutSetError, ScanBlocksStart,
     },
     control::Logging,
     hidden::{GetRawAddrMan, RawAddrManEntry},
@@ -356,7 +356,7 @@ pub use crate::{
     v25::{
         DescriptorInfo, GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors,
         MempoolAcceptance, MempoolAcceptanceError, MempoolAcceptanceFees, ScanBlocksAbort,
-        ScanBlocksStart, ScanBlocksStartError, ScanBlocksStatus, ScanTxOutSetStart,
-        ScanTxOutSetUnspent, TestMempoolAccept, TestMempoolAcceptError,
+        ScanBlocksStartError, ScanBlocksStatus, ScanTxOutSetStart, ScanTxOutSetUnspent,
+        TestMempoolAccept, TestMempoolAcceptError,
     },
 };

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -329,8 +329,8 @@ pub use crate::{
     v25::{
         DescriptorInfo, GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors,
         MempoolAcceptance, MempoolAcceptanceError, MempoolAcceptanceFees, ScanBlocksAbort,
-        ScanBlocksStart, ScanBlocksStartError, ScanBlocksStatus, ScanTxOutSetStart,
-        ScanTxOutSetUnspent, TestMempoolAccept, TestMempoolAcceptError,
+        ScanBlocksStartError, ScanBlocksStatus, ScanTxOutSetStart, ScanTxOutSetUnspent,
+        TestMempoolAccept, TestMempoolAcceptError,
     },
     v26::{
         AddrManInfoNetwork, ChainState, CreateWallet, DescriptorProcessPsbt,
@@ -339,8 +339,8 @@ pub use crate::{
         GetTransaction, GetTransactionError, GetTxOutSetInfo, GetTxOutSetInfoBlockInfo,
         GetTxOutSetInfoError, GetTxOutSetInfoUnspendables, GetWalletInfo, GetWalletInfoError,
         GetWalletInfoScanning, LastProcessedBlock, LastProcessedBlockError, LoadTxOutSet,
-        LoadTxOutSetError, LoadWallet, Logging, PeerInfo, RawAddrManEntry, SubmitPackage,
-        SubmitPackageError, SubmitPackageTxResult, SubmitPackageTxResultError,
+        LoadTxOutSetError, LoadWallet, Logging, PeerInfo, RawAddrManEntry, ScanBlocksStart,
+        SubmitPackage, SubmitPackageError, SubmitPackageTxResult, SubmitPackageTxResultError,
         SubmitPackageTxResultFees, SubmitPackageTxResultFeesError, UnloadWallet, WalletProcessPsbt,
         WalletProcessPsbtError,
     },

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -350,8 +350,7 @@ pub use crate::{
     v25::{
         DescriptorInfo, GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors,
         MempoolAcceptance, MempoolAcceptanceError, MempoolAcceptanceFees, ScanBlocksAbort,
-        ScanBlocksStart, ScanBlocksStartError, ScanBlocksStatus, TestMempoolAccept,
-        TestMempoolAcceptError,
+        ScanBlocksStartError, ScanBlocksStatus, TestMempoolAccept, TestMempoolAcceptError,
     },
     v26::{
         AddrManInfoNetwork, ChainState, CreateWallet, DescriptorProcessPsbt,
@@ -360,7 +359,7 @@ pub use crate::{
         GetTxOutSetInfo, GetTxOutSetInfoBlockInfo, GetTxOutSetInfoError,
         GetTxOutSetInfoUnspendables, GetWalletInfo, GetWalletInfoError, GetWalletInfoScanning,
         LastProcessedBlock, LastProcessedBlockError, LoadTxOutSet, LoadTxOutSetError, LoadWallet,
-        PeerInfo, UnloadWallet, WalletProcessPsbt, WalletProcessPsbtError,
+        PeerInfo, ScanBlocksStart, UnloadWallet, WalletProcessPsbt, WalletProcessPsbtError,
     },
     v27::{GetPrioritisedTransactions, PrioritisedTransaction},
 };

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -347,8 +347,8 @@ pub use crate::{
     },
     v25::{
         DescriptorInfo, GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors,
-        MempoolAcceptanceError, ScanBlocksAbort, ScanBlocksStart, ScanBlocksStartError,
-        ScanBlocksStatus, TestMempoolAcceptError,
+        MempoolAcceptanceError, ScanBlocksAbort, ScanBlocksStartError, ScanBlocksStatus,
+        TestMempoolAcceptError,
     },
     v26::{
         AddrManInfoNetwork, CreateWallet, DescriptorProcessPsbt, DescriptorProcessPsbtError,
@@ -356,7 +356,7 @@ pub use crate::{
         GetPeerInfo, GetTransactionError, GetTxOutSetInfo, GetTxOutSetInfoBlockInfo,
         GetTxOutSetInfoError, GetTxOutSetInfoUnspendables, GetWalletInfo, GetWalletInfoError,
         GetWalletInfoScanning, LastProcessedBlock, LastProcessedBlockError, LoadTxOutSet,
-        LoadTxOutSetError, LoadWallet, PeerInfo, UnloadWallet, WalletProcessPsbt,
+        LoadTxOutSetError, LoadWallet, PeerInfo, ScanBlocksStart, UnloadWallet, WalletProcessPsbt,
         WalletProcessPsbtError,
     },
     v27::{GetPrioritisedTransactions, PrioritisedTransaction},

--- a/types/src/v30/mod.rs
+++ b/types/src/v30/mod.rs
@@ -336,15 +336,16 @@ pub use crate::{
     },
     v25::{
         DescriptorInfo, GenerateBlock, GenerateBlockError, GetBlockStats, ListDescriptors,
-        MempoolAcceptanceError, ScanBlocksAbort, ScanBlocksStart, ScanBlocksStartError,
-        ScanBlocksStatus, TestMempoolAcceptError,
+        MempoolAcceptanceError, ScanBlocksAbort, ScanBlocksStartError, ScanBlocksStatus,
+        TestMempoolAcceptError,
     },
     v26::{
         AddrManInfoNetwork, CreateWallet, DescriptorProcessPsbt, DescriptorProcessPsbtError,
         DumpTxOutSet, DumpTxOutSetError, GetAddrManInfo, GetBalances, GetBalancesError,
         GetPeerInfo, GetTransactionError, GetTxOutSetInfo, GetTxOutSetInfoBlockInfo,
         GetTxOutSetInfoError, GetTxOutSetInfoUnspendables, LoadTxOutSet, LoadTxOutSetError,
-        LoadWallet, PeerInfo, UnloadWallet, WalletProcessPsbt, WalletProcessPsbtError,
+        LoadWallet, PeerInfo, ScanBlocksStart, UnloadWallet, WalletProcessPsbt,
+        WalletProcessPsbtError,
     },
     v27::{GetPrioritisedTransactions, PrioritisedTransaction},
     v28::{


### PR DESCRIPTION
From v26 onward, the return type of `scanblocks` RPC has an argument called `completed`, this PR adds it and handles into type conversion and in previous versions changes.

Partially fixes issue #474.