### PR TITLE
[client] Fix: require arguments for v30 `getdescriptoractivity` RPC

### DIFF
--- a/client/src/client_sync/v30/blockchain.rs
+++ b/client/src/client_sync/v30/blockchain.rs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Macros for implementing JSON-RPC methods on a client.
+//!
+//! Specifically this is methods found under the `== Blockchain ==` section of the
+//! API docs of Bitcoin Core `v30`.
+//!
+//! All macros require `Client` to be in scope.
+//!
+//! See or use the `define_jsonrpc_bitreq_client!` macro to define a `Client`.
+
+/// Implements Bitcoin Core JSON-RPC API method `getdescriptoractivity`.
+#[macro_export]
+macro_rules! impl_client_v30__get_descriptor_activity {
+    () => {
+        impl Client {
+            pub fn get_descriptor_activity(
+                &self,
+                block_hashes: &[BlockHash],
+                scan_objects: &[&str],
+            ) -> Result<GetDescriptorActivity> {
+                let params = vec![json!(block_hashes), json!(scan_objects)];
+                self.call("getdescriptoractivity", &params)
+            }
+        }
+    };
+}

--- a/client/src/client_sync/v30/mod.rs
+++ b/client/src/client_sync/v30/mod.rs
@@ -4,6 +4,8 @@
 //!
 //! We ignore option arguments unless they effect the shape of the returned JSON data.
 
+pub mod blockchain;
+
 use std::collections::BTreeMap;
 use std::path::Path;
 
@@ -40,7 +42,7 @@ crate::impl_client_v26__get_chain_states!();
 crate::impl_client_v17__get_chain_tips!();
 crate::impl_client_v17__get_chain_tx_stats!();
 crate::impl_client_v23__get_deployment_info!();
-crate::impl_client_v29__get_descriptor_activity!();
+crate::impl_client_v30__get_descriptor_activity!();
 crate::impl_client_v17__get_difficulty!();
 crate::impl_client_v17__get_mempool_ancestors!();
 crate::impl_client_v17__get_mempool_descendants!();

--- a/integration_test/tests/blockchain.rs
+++ b/integration_test/tests/blockchain.rs
@@ -246,8 +246,25 @@ fn blockchain__get_deployment_info__modelled() {
 fn blockchain__get_descriptor_activity__modelled() {
     let node = Node::with_wallet(Wallet::None, &["-coinstatsindex=1", "-txindex=1"]);
 
-    let json: GetDescriptorActivity =
-        node.client.get_descriptor_activity().expect("getdescriptoractivity");
+    // In Core v30, `getdescriptoractivity` requires `blockhashes` and `scanobjects` arguments.
+    // Older versions accepted omitting them.
+    let json: GetDescriptorActivity = {
+        #[cfg(feature = "v29_and_below")]
+        {
+            node.client.get_descriptor_activity().expect("getdescriptoractivity")
+        }
+
+        #[cfg(not(feature = "v29_and_below"))]
+        {
+            let block_hash = node.client.best_block_hash().expect("best_block_hash failed");
+            node.client
+                .get_descriptor_activity(
+                    &[block_hash],
+                    &["pkh(022afc20bf379bc96a2f4e9e63ffceb8652b2b6a097f63fbee6ecec2a49a48010e)"],
+                )
+                .expect("getdescriptoractivity")
+        }
+    };
     let model: Result<mtype::GetDescriptorActivity, GetDescriptorActivityError> = json.into_model();
     model.unwrap();
 }


### PR DESCRIPTION
Bitcoin Core v30 marks the `blockhashes` and `scanobjects` arguments of `getdescriptoractivity` RPC as required, instead of failing with a JSON parsing error when omitted.

This change is listed [here in Bitcoin Core's v30 release notes](https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-30.0.md#wallet). 

Partially fixes issue #474.