### PR TITLE
Make numeric error conversion consistent

### DIFF
--- a/types/src/v26/blockchain/into.rs
+++ b/types/src/v26/blockchain/into.rs
@@ -15,13 +15,13 @@ impl GetChainStates {
         use GetChainStatesError as E;
 
         Ok(model::GetChainStates {
-            headers: crate::to_u32(self.headers, "headers").map_err(E::Numeric)?,
+            headers: crate::to_u32(self.headers, "headers")?,
             chain_states: self
                 .chain_states
                 .into_iter()
                 .map(|s| {
                     Ok(model::ChainState {
-                        blocks: crate::to_u32(s.blocks, "blocks").map_err(E::Numeric)?,
+                        blocks: crate::to_u32(s.blocks, "blocks")?,
                         best_block_hash: s.best_block_hash.parse().map_err(E::BestBlockHash)?,
                         bits: None,   // v29 and later only.
                         target: None, // v29 and later only.

--- a/types/src/v29/blockchain/into.rs
+++ b/types/src/v29/blockchain/into.rs
@@ -176,13 +176,13 @@ impl GetChainStates {
         use GetChainStatesError as E;
 
         Ok(model::GetChainStates {
-            headers: crate::to_u32(self.headers, "headers").map_err(E::Numeric)?,
+            headers: crate::to_u32(self.headers, "headers")?,
             chain_states: self
                 .chain_states
                 .into_iter()
                 .map(|s| {
                     Ok(model::ChainState {
-                        blocks: crate::to_u32(s.blocks, "blocks").map_err(E::Numeric)?,
+                        blocks: crate::to_u32(s.blocks, "blocks")?,
                         best_block_hash: s.best_block_hash.parse().map_err(E::BestBlockHash)?,
                         bits: Some(CompactTarget::from_unprefixed_hex(&s.bits).map_err(E::Bits)?),
                         target: Some(


### PR DESCRIPTION
Most of the repo uses a bare `?` operator in numeric type conversion, but some places use `.map_err(E::Numeric)?`.

Use the bare `?` operator everywhere for consistency.