### PR TITLE
Fix BTC/kB conversion logic

### DIFF
--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -288,3 +288,16 @@ impl ScriptSig {
         ScriptBuf::from_hex(&self.hex)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn convert_btc_per_kb() {
+        // per kB = per kvB because this is a conversion of legacy transaction weights.
+        let f: f64 = 0.000001;
+        let got = btc_per_kb(f).unwrap();
+        assert_eq!(got, Some(FeeRate::from_sat_per_kwu(25)))
+    }
+}


### PR DESCRIPTION
Old RPC calls use BTC/kB, we need a `FeeRate` but `v0.32` cannot elegantly handle the conversion so we do it manually - and surprise surprise its buggy.

This bug is why we spent so much time on the `FeeRate` API in `rust-bitcoin`.

The original code was written by me, was untested, and was buggy (even after I worked on the API in `rust-bitcoin`) - bad Tobin no biscuit.

Patch 2 adds a unit test and can be put before patch 1 to see the bug.

Fix: #482