### PR TITLE
ci: use ubuntu-slim for label & prepare ci tasks

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   label-pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -10,7 +10,7 @@ name: Continuous integration
 
 jobs:
   Prepare:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       nightly_version: ${{ steps.read_toolchain.outputs.nightly_version }}
     steps:


### PR DESCRIPTION
The `ubuntu-slim` 1vCPU runners were recently introduced and seem to be the right fit here.

https://github.blog/changelog/2026-01-22-1-vcpu-linux-runner-now-generally-available-in-github-actions/

https://docs.github.com/en/actions/reference/runners/github-hosted-runners#single-cpu-runners