### PR TITLE
bitreq: Fix issues with non-`std` builds and add `#[no_std]` attribute

### DIFF
--- a/bitreq/src/lib.rs
+++ b/bitreq/src/lib.rs
@@ -242,6 +242,7 @@
 //! If the timeout is set with `with_timeout`, the environment
 //! variable will be ignored.
 
+#![cfg_attr(all(not(feature = "std"), not(test)), no_std)]
 #![deny(missing_docs)]
 // std::io::Error::other was added in 1.74, so occurrences of this lint can't be
 // fixed before our MSRV gets that high.
@@ -256,7 +257,9 @@ mod connection;
 mod error;
 #[cfg(feature = "proxy")]
 mod proxy;
+#[cfg(feature = "std")]
 mod request;
+#[cfg(feature = "std")]
 mod response;
 mod url;
 
@@ -265,8 +268,8 @@ pub use client::{Client, RequestExt};
 pub use error::*;
 #[cfg(feature = "proxy")]
 pub use proxy::*;
-pub use request::*;
-pub use response::Response;
 #[cfg(feature = "std")]
-pub use response::ResponseLazy;
+pub use request::*;
+#[cfg(feature = "std")]
+pub use response::{Response, ResponseLazy};
 pub use url::{ParseError as UrlParseError, Url};

--- a/bitreq/src/url.rs
+++ b/bitreq/src/url.rs
@@ -1,7 +1,10 @@
 //! A minimal library for parsing and validating URLs.
 
+use alloc::format;
+use alloc::string::{String, ToString as _};
+use alloc::vec::Vec;
 use core::fmt;
-use std::ops::Range;
+use core::ops::Range;
 
 /// Macro to conditionally set visibility to `pub` when fuzzing, `pub(crate)` otherwise.
 /// Used to expose internal methods for fuzz testing without making them part of the public API.
@@ -522,8 +525,8 @@ impl Url {
     }
 }
 
-impl std::fmt::Display for Url {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Url {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_str(self.as_str())
     }
 }


### PR DESCRIPTION
When bitreq doesn't have the std feature enabled, it currently fails to correctly disable the use of std-specific features. In some cases, std is used where core would suffice. Importantly, types that have no use without std remain public from the crate.

Introduce a gated no_std attribute to the crate.
Fix feature gates in url module.
Gate out Response and Request for no-std.

Closes #492
