### PR TITLE
[bitreq] Make `Url::append_query_pairs` and `preserve_fragment_from` public methods

### DIFF
--- a/bitreq/fuzz/src/url_parse.rs
+++ b/bitreq/fuzz/src/url_parse.rs
@@ -86,7 +86,7 @@ pub fn do_test(data: &[u8]) {
             {
                 let mut url_clone = bitreq_url.clone();
                 // Use the input itself as both key and value to exercise encoding
-                url_clone.append_query_params([(input.to_string(), input.to_string())]);
+                url_clone.append_query_params([(&*input, &*input)]);
                 // Verify the URL is still valid by accessing its fields
                 let _ = url_clone.query();
                 let _ = url_clone.as_str();
@@ -98,10 +98,7 @@ pub fn do_test(data: &[u8]) {
 
                 // Test appending multiple params in one call
                 let mut url_clone3 = bitreq_url.clone();
-                url_clone3.append_query_params([
-                    ("key1".into(), "value1".into()),
-                    ("key2".into(), input.to_string()),
-                ]);
+                url_clone3.append_query_params([("key1", "value1"), ("key2", &input)]);
                 let _ = url_clone3.as_str();
             }
 

--- a/bitreq/src/request.rs
+++ b/bitreq/src/request.rs
@@ -364,7 +364,8 @@ impl ParsedRequest {
     #[allow(unused_mut)]
     pub(crate) fn new(mut config: Request) -> Result<ParsedRequest, Error> {
         let mut url = Url::parse(&config.url)?;
-        url.append_query_params(config.params.drain(..));
+        let params = config.params.iter().map(|(a, b)| (a.as_str(), b.as_str()));
+        url.append_query_params(params);
 
         #[cfg(all(feature = "proxy", feature = "std"))]
         // Set default proxy from environment variables


### PR DESCRIPTION
We previously considered `append_query_pairs` and
`preserve_fragment_from` only internal methods and hence made them only `pub` when fuzzing.

Unfortunately it turns out that they are very useful and we need them for downstream migration, so here we make them `pub` for everybody.