### PR TITLE
[bitreq] Cut v0.3.3 patch release

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -147,7 +147,7 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "bitreq"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "base64 0.22.1",
  "log",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -147,7 +147,7 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "bitreq"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "base64 0.22.1",
  "log",

--- a/bitreq/CHANGELOG.md
+++ b/bitreq/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.3 - 2026-02-12
+
+* Make `Url::append_query_pairs` and `preserve_fragment_from` public methods [#500](https://github.com/rust-bitcoin/corepc/pull/500)
+
 # 0.3.2 - 2026-02-10
 
 * Fix issues with non-`std` builds and add `#[no_std]` attribute [#498](https://github.com/rust-bitcoin/corepc/pull/498)

--- a/bitreq/Cargo.toml
+++ b/bitreq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitreq"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Jens Pitkanen <jens@neon.moe>", "Tobin C. Harding <me@tobin.cc>"]
 description = "Simple, minimal-dependency HTTP client"
 documentation = "https://docs.rs/bitreq"


### PR DESCRIPTION
When switching a downstream dependency to `Url` we unfortunately
discovered that we need the changes in https://github.com/rust-bitcoin/corepc/pull/500. Here we therefore cut
another patch release to get them out.

(sorry for the churn tcharding)