### PR TITLE
Create an async corepc-client

### DIFF
--- a/bitreq/src/connection.rs
+++ b/bitreq/src/connection.rs
@@ -389,7 +389,7 @@ impl AsyncConnection {
         }
 
         #[cfg(not(feature = "proxy"))]
-        Self::tcp_connect(&params.host, params.port).await
+        Self::tcp_connect(params.host, params.port).await
     }
 
     async fn timeout<O, F: Future<Output = O>>(timeout: Option<Instant>, f: F) -> Result<O, Error> {

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -22,7 +22,7 @@ allowed_duplicates = ["base64"]
 
 [features]
 # Enable this feature to get a blocking JSON-RPC client.
-client-sync = ["jsonrpc"]
+client-sync = ["jsonrpc", "jsonrpc/bitreq_http"]
 
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false, features = ["std", "serde"] }
@@ -31,6 +31,6 @@ serde = { version = "1.0.103", default-features = false, features = [ "derive", 
 serde_json = { version = "1.0.117" }
 types = { package = "corepc-types", version = "0.15.0", path = "../types", default-features = false, features = ["std"] }
 
-jsonrpc = { version = "0.20.0", path = "../jsonrpc", features = ["bitreq_http"], optional = true }
+jsonrpc = { version = "0.20.0", path = "../jsonrpc", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -23,6 +23,8 @@ allowed_duplicates = ["base64"]
 [features]
 # Enable this feature to get a blocking JSON-RPC client.
 client-sync = ["jsonrpc", "jsonrpc/bitreq_http"]
+# Enable this feature to get an async JSON-RPC client.
+client-async = ["jsonrpc", "jsonrpc/bitreq_http_async", "jsonrpc/client_async"]
 
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false, features = ["std", "serde"] }

--- a/client/README.md
+++ b/client/README.md
@@ -1,7 +1,16 @@
 # corepc-client
 
-Rust client for the Bitcoin Core daemon's JSON-RPC API. Currently this
-is only a blocking client and is intended to be used in integration testing.
+Rust client for the Bitcoin Core daemon's JSON-RPC API.
+
+This crate provides:
+
+- A blocking client intended for integration testing (`client-sync`).
+- An async client intended for production (`client-async`).
+
+## Features
+
+- `client-sync`: Blocking JSON-RPC client.
+- `client-async`: Async JSON-RPC client.
 
 ## Minimum Supported Rust Version (MSRV)
 

--- a/client/src/client_async/error.rs
+++ b/client/src/client_async/error.rs
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: CC0-1.0
+
+use std::{error, fmt, io};
+
+use bitcoin::hex;
+
+/// The error type for errors produced in this library.
+#[derive(Debug)]
+pub enum Error {
+    JsonRpc(jsonrpc::error::Error),
+    HexToArray(hex::HexToArrayError),
+    HexToBytes(hex::HexToBytesError),
+    Json(serde_json::error::Error),
+    BitcoinSerialization(bitcoin::consensus::encode::FromHexError),
+    Io(io::Error),
+    InvalidCookieFile,
+    /// The JSON result had an unexpected structure.
+    UnexpectedStructure,
+    /// The daemon returned an error string.
+    Returned(String),
+    /// The server version did not match what was expected.
+    ServerVersion(UnexpectedServerVersionError),
+    /// Missing user/password.
+    MissingUserPassword,
+}
+
+impl From<jsonrpc::error::Error> for Error {
+    fn from(e: jsonrpc::error::Error) -> Error { Error::JsonRpc(e) }
+}
+
+impl From<hex::HexToArrayError> for Error {
+    fn from(e: hex::HexToArrayError) -> Self { Self::HexToArray(e) }
+}
+
+impl From<hex::HexToBytesError> for Error {
+    fn from(e: hex::HexToBytesError) -> Self { Self::HexToBytes(e) }
+}
+
+impl From<serde_json::error::Error> for Error {
+    fn from(e: serde_json::error::Error) -> Error { Error::Json(e) }
+}
+
+impl From<bitcoin::consensus::encode::FromHexError> for Error {
+    fn from(e: bitcoin::consensus::encode::FromHexError) -> Error { Error::BitcoinSerialization(e) }
+}
+
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Error { Error::Io(e) }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Error::*;
+
+        match *self {
+            JsonRpc(ref e) => write!(f, "JSON-RPC error: {}", e),
+            HexToArray(ref e) => write!(f, "hex to array decode error: {}", e),
+            HexToBytes(ref e) => write!(f, "hex to bytes decode error: {}", e),
+            Json(ref e) => write!(f, "JSON error: {}", e),
+            BitcoinSerialization(ref e) => write!(f, "Bitcoin serialization error: {}", e),
+            Io(ref e) => write!(f, "I/O error: {}", e),
+            InvalidCookieFile => write!(f, "invalid cookie file"),
+            UnexpectedStructure => write!(f, "the JSON result had an unexpected structure"),
+            Returned(ref s) => write!(f, "the daemon returned an error string: {}", s),
+            ServerVersion(ref e) => write!(f, "server version: {}", e),
+            MissingUserPassword => write!(f, "missing user and/or password"),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        use Error::*;
+
+        match *self {
+            JsonRpc(ref e) => Some(e),
+            HexToArray(ref e) => Some(e),
+            HexToBytes(ref e) => Some(e),
+            Json(ref e) => Some(e),
+            BitcoinSerialization(ref e) => Some(e),
+            Io(ref e) => Some(e),
+            ServerVersion(ref e) => Some(e),
+            InvalidCookieFile | UnexpectedStructure | Returned(_) | MissingUserPassword => None,
+        }
+    }
+}
+
+/// Error returned when RPC client expects a different version than bitcoind reports.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnexpectedServerVersionError {
+    /// Version from server.
+    pub got: usize,
+    /// Expected server version.
+    pub expected: Vec<usize>,
+}
+
+impl fmt::Display for UnexpectedServerVersionError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut expected = String::new();
+        for version in &self.expected {
+            let v = format!(" {} ", version);
+            expected.push_str(&v);
+        }
+        write!(f, "unexpected bitcoind version, got: {} expected one of: {}", self.got, expected)
+    }
+}
+
+impl error::Error for UnexpectedServerVersionError {}
+
+impl From<UnexpectedServerVersionError> for Error {
+    fn from(e: UnexpectedServerVersionError) -> Self { Self::ServerVersion(e) }
+}

--- a/client/src/client_async/error.rs
+++ b/client/src/client_async/error.rs
@@ -1,23 +1,30 @@
 // SPDX-License-Identifier: CC0-1.0
 
+//! Async client error types.
+//!
+//! Async RPC methods return per-method typed errors (for example, [`GetBlockError`])
+//! so callers can match method-specific `Model` conversion failures directly.
+//!
+//! Every method error exposes inherent helpers (`is_not_found_error`, `is_transport_error`,
+//! `rpc_code`, `as_client_error`) for common JSON-RPC and transport inspection.
+
+use core::convert::Infallible;
 use std::{error, fmt, io};
 
-use bitcoin::hex;
-
-/// The error type for errors produced in this library.
+/// The general error type for the async client.
+///
+/// This covers connecting, authenticating, and performing a JSON-RPC call. Each RPC method returns
+/// its own error type (e.g. [`GetBlockError`]) which wraps this type in its `Rpc` variant.
 #[derive(Debug)]
 pub enum Error {
+    /// A JSON-RPC error occurred (transport error or the node returned an error).
     JsonRpc(jsonrpc::error::Error),
-    HexToArray(hex::HexToArrayError),
-    HexToBytes(hex::HexToBytesError),
+    /// Serializing an argument or deserializing the response failed.
     Json(serde_json::error::Error),
-    BitcoinSerialization(bitcoin::consensus::encode::FromHexError),
+    /// An I/O error occurred (e.g. reading the cookie file).
     Io(io::Error),
+    /// The cookie file was invalid.
     InvalidCookieFile,
-    /// The JSON result had an unexpected structure.
-    UnexpectedStructure,
-    /// The daemon returned an error string.
-    Returned(String),
     /// The server version did not match what was expected.
     ServerVersion(UnexpectedServerVersionError),
     /// Missing user/password.
@@ -28,20 +35,8 @@ impl From<jsonrpc::error::Error> for Error {
     fn from(e: jsonrpc::error::Error) -> Error { Error::JsonRpc(e) }
 }
 
-impl From<hex::HexToArrayError> for Error {
-    fn from(e: hex::HexToArrayError) -> Self { Self::HexToArray(e) }
-}
-
-impl From<hex::HexToBytesError> for Error {
-    fn from(e: hex::HexToBytesError) -> Self { Self::HexToBytes(e) }
-}
-
 impl From<serde_json::error::Error> for Error {
     fn from(e: serde_json::error::Error) -> Error { Error::Json(e) }
-}
-
-impl From<bitcoin::consensus::encode::FromHexError> for Error {
-    fn from(e: bitcoin::consensus::encode::FromHexError) -> Error { Error::BitcoinSerialization(e) }
 }
 
 impl From<io::Error> for Error {
@@ -54,14 +49,9 @@ impl fmt::Display for Error {
 
         match *self {
             JsonRpc(ref e) => write!(f, "JSON-RPC error: {}", e),
-            HexToArray(ref e) => write!(f, "hex to array decode error: {}", e),
-            HexToBytes(ref e) => write!(f, "hex to bytes decode error: {}", e),
             Json(ref e) => write!(f, "JSON error: {}", e),
-            BitcoinSerialization(ref e) => write!(f, "Bitcoin serialization error: {}", e),
             Io(ref e) => write!(f, "I/O error: {}", e),
             InvalidCookieFile => write!(f, "invalid cookie file"),
-            UnexpectedStructure => write!(f, "the JSON result had an unexpected structure"),
-            Returned(ref s) => write!(f, "the daemon returned an error string: {}", s),
             ServerVersion(ref e) => write!(f, "server version: {}", e),
             MissingUserPassword => write!(f, "missing user and/or password"),
         }
@@ -74,15 +64,501 @@ impl error::Error for Error {
 
         match *self {
             JsonRpc(ref e) => Some(e),
-            HexToArray(ref e) => Some(e),
-            HexToBytes(ref e) => Some(e),
             Json(ref e) => Some(e),
-            BitcoinSerialization(ref e) => Some(e),
             Io(ref e) => Some(e),
             ServerVersion(ref e) => Some(e),
-            InvalidCookieFile | UnexpectedStructure | Returned(_) | MissingUserPassword => None,
+            InvalidCookieFile | MissingUserPassword => None,
         }
     }
+}
+
+fn rpc_code_from_client_error(err: &Error) -> Option<i64> {
+    match err {
+        Error::JsonRpc(jsonrpc::error::Error::Rpc(rpc)) => Some(i64::from(rpc.code)),
+        _ => None,
+    }
+}
+
+fn is_jsonrpc_not_found_error(err: &Error) -> bool {
+    matches!(rpc_code_from_client_error(err), Some(-5))
+}
+
+fn is_jsonrpc_transport_error(err: &Error) -> bool {
+    matches!(err, Error::JsonRpc(jsonrpc::error::Error::Transport(_)))
+}
+
+/// Defines the error type returned by a single RPC method on the async `Client`.
+///
+/// Every method error has an `Rpc` variant, holding the [`Error`] from making the call. Methods
+/// that convert the response into a model type additionally have a `Model` variant holding the
+/// conversion error. There are three forms:
+///
+/// - `Name => Type`: `Model` holds the concrete conversion error `Type`.
+/// - `Name => boxed`: `Model` holds a boxed error. Used by methods that select a version specific
+///   type at runtime and so have no single concrete conversion error type.
+/// - `Name`: no `Model` variant, for methods whose response conversion cannot fail.
+macro_rules! define_method_error {
+    // Version-agnostic (boxed) model conversion error.
+    ($(#[$doc:meta])* $name:ident => boxed) => {
+        $(#[$doc])*
+        #[derive(Debug)]
+        pub enum $name {
+            /// Making the JSON-RPC call failed.
+            Rpc(Error),
+            /// Converting the returned JSON into the model type failed.
+            Model(Box<dyn std::error::Error + Send + Sync + 'static>),
+        }
+
+        impl From<Error> for $name {
+            fn from(e: Error) -> Self { Self::Rpc(e) }
+        }
+
+        impl From<serde_json::error::Error> for $name {
+            fn from(e: serde_json::error::Error) -> Self { Error::Json(e).into() }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                match *self {
+                    Self::Rpc(ref e) => write!(f, "JSON-RPC call failed: {}", e),
+                    Self::Model(ref e) => write!(f, "conversion to the model type failed: {}", e),
+                }
+            }
+        }
+
+        impl error::Error for $name {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                match *self {
+                    Self::Rpc(ref e) => Some(e),
+                    Self::Model(ref e) => Some(&**e),
+                }
+            }
+        }
+
+        impl $name {
+            /// Returns the top-level async client error if this method error wraps one.
+            pub fn as_client_error(&self) -> Option<&Error> {
+                match self {
+                    Self::Rpc(e) => Some(e),
+                    Self::Model(_) => None,
+                }
+            }
+
+            /// Returns `true` when this error is an RPC error with JSON-RPC code `-5`.
+            pub fn is_not_found_error(&self) -> bool {
+                self.as_client_error().is_some_and(is_jsonrpc_not_found_error)
+            }
+
+            /// Returns the JSON-RPC error code when this error wraps an RPC error.
+            pub fn rpc_code(&self) -> Option<i64> {
+                self.as_client_error().and_then(rpc_code_from_client_error)
+            }
+
+            /// Returns `true` when this error wraps a transport-layer failure.
+            pub fn is_transport_error(&self) -> bool {
+                self.as_client_error().is_some_and(is_jsonrpc_transport_error)
+            }
+        }
+    };
+    // Strongly typed model conversion error.
+    ($(#[$doc:meta])* $name:ident => $model:ty) => {
+        $(#[$doc])*
+        #[derive(Debug)]
+        pub enum $name {
+            /// Making the JSON-RPC call failed.
+            Rpc(Error),
+            /// Converting the returned JSON into the model type failed.
+            Model($model),
+        }
+
+        impl From<Error> for $name {
+            fn from(e: Error) -> Self { Self::Rpc(e) }
+        }
+
+        impl From<serde_json::error::Error> for $name {
+            fn from(e: serde_json::error::Error) -> Self { Error::Json(e).into() }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                match *self {
+                    Self::Rpc(ref e) => write!(f, "JSON-RPC call failed: {}", e),
+                    Self::Model(ref e) => write!(f, "conversion to the model type failed: {}", e),
+                }
+            }
+        }
+
+        impl error::Error for $name {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                match *self {
+                    Self::Rpc(ref e) => Some(e),
+                    Self::Model(ref e) => Some(e),
+                }
+            }
+        }
+
+        impl $name {
+            /// Returns the top-level async client error if this method error wraps one.
+            pub fn as_client_error(&self) -> Option<&Error> {
+                match self {
+                    Self::Rpc(e) => Some(e),
+                    Self::Model(_) => None,
+                }
+            }
+
+            /// Returns `true` when this error is an RPC error with JSON-RPC code `-5`.
+            pub fn is_not_found_error(&self) -> bool {
+                self.as_client_error().is_some_and(is_jsonrpc_not_found_error)
+            }
+
+            /// Returns the JSON-RPC error code when this error wraps an RPC error.
+            pub fn rpc_code(&self) -> Option<i64> {
+                self.as_client_error().and_then(rpc_code_from_client_error)
+            }
+
+            /// Returns `true` when this error wraps a transport-layer failure.
+            pub fn is_transport_error(&self) -> bool {
+                self.as_client_error().is_some_and(is_jsonrpc_transport_error)
+            }
+        }
+    };
+    // RPC failure only (response conversion cannot fail).
+    ($(#[$doc:meta])* $name:ident) => {
+        $(#[$doc])*
+        #[derive(Debug)]
+        pub enum $name {
+            /// Making the JSON-RPC call failed.
+            Rpc(Error),
+        }
+
+        impl From<Error> for $name {
+            fn from(e: Error) -> Self { Self::Rpc(e) }
+        }
+
+        impl From<serde_json::error::Error> for $name {
+            fn from(e: serde_json::error::Error) -> Self { Error::Json(e).into() }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                match *self {
+                    Self::Rpc(ref e) => write!(f, "JSON-RPC call failed: {}", e),
+                }
+            }
+        }
+
+        impl error::Error for $name {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                match *self {
+                    Self::Rpc(ref e) => Some(e),
+                }
+            }
+        }
+
+        impl $name {
+            /// Returns the top-level async client error if this method error wraps one.
+            pub fn as_client_error(&self) -> Option<&Error> {
+                match self {
+                    Self::Rpc(e) => Some(e),
+                }
+            }
+
+            /// Returns `true` when this error is an RPC error with JSON-RPC code `-5`.
+            pub fn is_not_found_error(&self) -> bool {
+                self.as_client_error().is_some_and(is_jsonrpc_not_found_error)
+            }
+
+            /// Returns the JSON-RPC error code when this error wraps an RPC error.
+            pub fn rpc_code(&self) -> Option<i64> {
+                self.as_client_error().and_then(rpc_code_from_client_error)
+            }
+
+            /// Returns `true` when this error wraps a transport-layer failure.
+            pub fn is_transport_error(&self) -> bool {
+                self.as_client_error().is_some_and(is_jsonrpc_transport_error)
+            }
+        }
+    };
+}
+
+define_method_error! {
+    /// Error returned by [`Client::get_block`](crate::client_async::Client::get_block).
+    GetBlockError => bitcoin::consensus::encode::FromHexError
+}
+
+define_method_error! {
+    /// Error returned by [`Client::get_block_count`](crate::client_async::Client::get_block_count).
+    GetBlockCountError
+}
+
+define_method_error! {
+    /// Error returned by [`Client::server_version`](crate::client_async::Client::server_version).
+    ServerVersionError
+}
+
+define_method_error! {
+    /// Error returned by [`Client::get_block_hash`](crate::client_async::Client::get_block_hash).
+    GetBlockHashError => bitcoin::hex::HexToArrayError
+}
+
+define_method_error! {
+    /// Error returned by
+    /// [`Client::get_best_block_hash`](crate::client_async::Client::get_best_block_hash).
+    GetBestBlockHashError => bitcoin::hex::HexToArrayError
+}
+
+define_method_error! {
+    /// Error returned by [`Client::get_block_header`](crate::client_async::Client::get_block_header).
+    GetBlockHeaderError => types::v17::GetBlockHeaderError
+}
+
+/// Error returned by
+/// [`Client::get_block_header_verbose`](crate::client_async::Client::get_block_header_verbose).
+///
+/// The response shape depends on the Core version, so conversion failures are reported per version.
+#[derive(Debug)]
+pub enum GetBlockHeaderVerboseError {
+    /// Making the JSON-RPC call failed.
+    Rpc(Error),
+    /// Converting the returned v29 JSON into the model type failed.
+    ModelV29(types::v29::GetBlockHeaderVerboseError),
+    /// Converting the returned v25 JSON into the model type failed.
+    ModelV25(types::v25::GetBlockHeaderVerboseError),
+}
+
+impl fmt::Display for GetBlockHeaderVerboseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Self::Rpc(ref e) => write!(f, "JSON-RPC call failed: {}", e),
+            Self::ModelV29(ref e) =>
+                write!(f, "conversion to the model type from the v29 type failed: {}", e),
+            Self::ModelV25(ref e) =>
+                write!(f, "conversion to the model type from the v25 type failed: {}", e),
+        }
+    }
+}
+
+impl error::Error for GetBlockHeaderVerboseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match *self {
+            Self::Rpc(ref e) => Some(e),
+            Self::ModelV29(ref e) => Some(e),
+            Self::ModelV25(ref e) => Some(e),
+        }
+    }
+}
+
+impl From<Infallible> for GetBlockHeaderVerboseError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+impl From<Error> for GetBlockHeaderVerboseError {
+    fn from(e: Error) -> Self { Self::Rpc(e) }
+}
+
+impl From<serde_json::error::Error> for GetBlockHeaderVerboseError {
+    fn from(e: serde_json::error::Error) -> Self { Self::Rpc(Error::Json(e)) }
+}
+
+impl GetBlockHeaderVerboseError {
+    /// Returns the top-level async client error if this method error wraps one.
+    pub fn as_client_error(&self) -> Option<&Error> {
+        match self {
+            Self::Rpc(e) => Some(e),
+            Self::ModelV29(_) | Self::ModelV25(_) => None,
+        }
+    }
+
+    /// Returns `true` when this error is an RPC error with JSON-RPC code `-5`.
+    pub fn is_not_found_error(&self) -> bool {
+        self.as_client_error().is_some_and(is_jsonrpc_not_found_error)
+    }
+
+    /// Returns the JSON-RPC error code when this error wraps an RPC error.
+    pub fn rpc_code(&self) -> Option<i64> {
+        self.as_client_error().and_then(rpc_code_from_client_error)
+    }
+
+    /// Returns `true` when this error wraps a transport-layer failure.
+    pub fn is_transport_error(&self) -> bool {
+        self.as_client_error().is_some_and(is_jsonrpc_transport_error)
+    }
+}
+
+/// Error returned by [`Client::get_block_verbose`](crate::client_async::Client::get_block_verbose).
+///
+/// The response shape depends on the Core version, so conversion failures are reported per version.
+#[derive(Debug)]
+pub enum GetBlockVerboseError {
+    /// Making the JSON-RPC call failed.
+    Rpc(Error),
+    /// Converting the returned v31 JSON into the model type failed.
+    ModelV31(types::v31::GetBlockVerboseOneError),
+    /// Converting the returned v29 JSON into the model type failed.
+    ModelV29(types::v29::GetBlockVerboseOneError),
+    /// Converting the returned v25 JSON into the model type failed.
+    ModelV25(types::v25::GetBlockVerboseOneError),
+}
+
+impl fmt::Display for GetBlockVerboseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Self::Rpc(ref e) => write!(f, "JSON-RPC call failed: {}", e),
+            Self::ModelV31(ref e) =>
+                write!(f, "conversion to the model type from the v31 type failed: {}", e),
+            Self::ModelV29(ref e) =>
+                write!(f, "conversion to the model type from the v29 type failed: {}", e),
+            Self::ModelV25(ref e) =>
+                write!(f, "conversion to the model type from the v25 type failed: {}", e),
+        }
+    }
+}
+
+impl error::Error for GetBlockVerboseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match *self {
+            Self::Rpc(ref e) => Some(e),
+            Self::ModelV31(ref e) => Some(e),
+            Self::ModelV29(ref e) => Some(e),
+            Self::ModelV25(ref e) => Some(e),
+        }
+    }
+}
+
+impl From<Infallible> for GetBlockVerboseError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+impl From<Error> for GetBlockVerboseError {
+    fn from(e: Error) -> Self { Self::Rpc(e) }
+}
+
+impl From<serde_json::error::Error> for GetBlockVerboseError {
+    fn from(e: serde_json::error::Error) -> Self { Self::Rpc(Error::Json(e)) }
+}
+
+impl GetBlockVerboseError {
+    /// Returns the top-level async client error if this method error wraps one.
+    pub fn as_client_error(&self) -> Option<&Error> {
+        match self {
+            Self::Rpc(e) => Some(e),
+            Self::ModelV31(_) | Self::ModelV29(_) | Self::ModelV25(_) => None,
+        }
+    }
+
+    /// Returns `true` when this error is an RPC error with JSON-RPC code `-5`.
+    pub fn is_not_found_error(&self) -> bool {
+        self.as_client_error().is_some_and(is_jsonrpc_not_found_error)
+    }
+
+    /// Returns the JSON-RPC error code when this error wraps an RPC error.
+    pub fn rpc_code(&self) -> Option<i64> {
+        self.as_client_error().and_then(rpc_code_from_client_error)
+    }
+
+    /// Returns `true` when this error wraps a transport-layer failure.
+    pub fn is_transport_error(&self) -> bool {
+        self.as_client_error().is_some_and(is_jsonrpc_transport_error)
+    }
+}
+
+define_method_error! {
+    /// Error returned by [`Client::get_block_filter`](crate::client_async::Client::get_block_filter).
+    GetBlockFilterError => types::v19::GetBlockFilterError
+}
+
+define_method_error! {
+    /// Error returned by [`Client::get_raw_mempool`](crate::client_async::Client::get_raw_mempool).
+    GetRawMempoolError => bitcoin::hex::HexToArrayError
+}
+
+define_method_error! {
+    /// Error returned by
+    /// [`Client::get_raw_transaction`](crate::client_async::Client::get_raw_transaction).
+    GetRawTransactionError => bitcoin::consensus::encode::FromHexError
+}
+
+/// Error returned by
+/// [`Client::get_blockchain_info`](crate::client_async::Client::get_blockchain_info).
+///
+/// The response shape depends on the Core version, so conversion failures are reported per version.
+#[derive(Debug)]
+pub enum GetBlockchainInfoError {
+    /// Making the JSON-RPC call failed.
+    Rpc(Error),
+    /// Converting the returned v29 JSON into the model type failed.
+    ModelV29(types::v29::GetBlockchainInfoError),
+    /// Converting the returned v28 JSON into the model type failed.
+    ModelV28(types::v28::GetBlockchainInfoError),
+    /// Converting the returned v25 JSON into the model type failed.
+    ModelV25(types::v25::GetBlockchainInfoError),
+}
+
+impl fmt::Display for GetBlockchainInfoError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Self::Rpc(ref e) => write!(f, "JSON-RPC call failed: {}", e),
+            Self::ModelV29(ref e) =>
+                write!(f, "conversion to the model type from the v29 type failed: {}", e),
+            Self::ModelV28(ref e) =>
+                write!(f, "conversion to the model type from the v28 type failed: {}", e),
+            Self::ModelV25(ref e) =>
+                write!(f, "conversion to the model type from the v25 type failed: {}", e),
+        }
+    }
+}
+
+impl error::Error for GetBlockchainInfoError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match *self {
+            Self::Rpc(ref e) => Some(e),
+            Self::ModelV29(ref e) => Some(e),
+            Self::ModelV28(ref e) => Some(e),
+            Self::ModelV25(ref e) => Some(e),
+        }
+    }
+}
+
+impl From<Infallible> for GetBlockchainInfoError {
+    fn from(never: Infallible) -> Self { match never {} }
+}
+
+impl From<Error> for GetBlockchainInfoError {
+    fn from(e: Error) -> Self { Self::Rpc(e) }
+}
+
+impl From<serde_json::error::Error> for GetBlockchainInfoError {
+    fn from(e: serde_json::error::Error) -> Self { Self::Rpc(Error::Json(e)) }
+}
+
+impl GetBlockchainInfoError {
+    /// Returns the top-level async client error if this method error wraps one.
+    pub fn as_client_error(&self) -> Option<&Error> {
+        match self {
+            Self::Rpc(e) => Some(e),
+            Self::ModelV29(_) | Self::ModelV28(_) | Self::ModelV25(_) => None,
+        }
+    }
+
+    /// Returns `true` when this error is an RPC error with JSON-RPC code `-5`.
+    pub fn is_not_found_error(&self) -> bool {
+        self.as_client_error().is_some_and(is_jsonrpc_not_found_error)
+    }
+
+    /// Returns the JSON-RPC error code when this error wraps an RPC error.
+    pub fn rpc_code(&self) -> Option<i64> {
+        self.as_client_error().and_then(rpc_code_from_client_error)
+    }
+
+    /// Returns `true` when this error wraps a transport-layer failure.
+    pub fn is_transport_error(&self) -> bool {
+        self.as_client_error().is_some_and(is_jsonrpc_transport_error)
+    }
+}
+
+define_method_error! {
+    /// Error returned by [`Client::get_tx_out`](crate::client_async::Client::get_tx_out).
+    GetTxOutError => types::v17::GetTxOutError
 }
 
 /// Error returned when RPC client expects a different version than bitcoind reports.
@@ -109,4 +585,62 @@ impl error::Error for UnexpectedServerVersionError {}
 
 impl From<UnexpectedServerVersionError> for Error {
     fn from(e: UnexpectedServerVersionError) -> Self { Self::ServerVersion(e) }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+
+    use super::*;
+
+    fn rpc_client_error(code: i32) -> Error {
+        Error::JsonRpc(jsonrpc::error::Error::Rpc(jsonrpc::error::RpcError {
+            code,
+            message: "rpc error".to_owned(),
+            data: None,
+        }))
+    }
+
+    fn transport_client_error() -> Error {
+        Error::JsonRpc(jsonrpc::error::Error::Transport(Box::new(io::Error::other(
+            "transport failed",
+        ))))
+    }
+
+    #[test]
+    fn rpc_minus_five_is_not_found() {
+        let err = GetBlockError::Rpc(rpc_client_error(-5));
+        assert!(err.is_not_found_error());
+        assert_eq!(err.rpc_code(), Some(-5));
+        assert!(!err.is_transport_error());
+        assert!(err.as_client_error().is_some());
+    }
+
+    #[test]
+    fn other_rpc_code_is_not_not_found() {
+        let err = GetBlockCountError::Rpc(rpc_client_error(-8));
+        assert!(!err.is_not_found_error());
+        assert_eq!(err.rpc_code(), Some(-8));
+        assert!(!err.is_transport_error());
+    }
+
+    #[test]
+    fn transport_errors_are_detected() {
+        let err = GetBlockCountError::Rpc(transport_client_error());
+        assert!(err.is_transport_error());
+        assert!(!err.is_not_found_error());
+        assert_eq!(err.rpc_code(), None);
+        assert!(err.as_client_error().is_some());
+    }
+
+    #[test]
+    fn model_errors_do_not_report_rpc_details() {
+        let err = GetBlockVerboseError::ModelV31(types::v31::GetBlockVerboseOneError::Numeric(
+            types::NumericError::Negative { field: "height".to_owned(), value: -1 },
+        ));
+        assert!(!err.is_not_found_error());
+        assert_eq!(err.rpc_code(), None);
+        assert!(!err.is_transport_error());
+        assert!(err.as_client_error().is_none());
+    }
 }

--- a/client/src/client_async/mod.rs
+++ b/client/src/client_async/mod.rs
@@ -1,35 +1,47 @@
 // SPDX-License-Identifier: CC0-1.0
 
-//! JSON-RPC clients for testing against specific versions of Bitcoin Core.
+//! Async JSON-RPC client for Bitcoin Core v25 to v31.
+//!
+//! Each RPC method returns a typed error with inherent helpers for common error inspection
+//! (`is_not_found_error`, `is_transport_error`, `rpc_code`, `as_client_error`) — no trait
+//! imports required.
+//!
+//! # Examples
+//!
+//! ```rust,no_run
+//! use corepc_client::client_async::GetBlockError;
+//!
+//! fn handle_get_block_error(err: GetBlockError) {
+//!     if err.is_not_found_error() {
+//!         return;
+//!     }
+//!     match err {
+//!         GetBlockError::Model(model_err) => {
+//!             // Method-specific model-conversion branch.
+//!             let _ = model_err;
+//!         }
+//!         GetBlockError::Rpc(client_err) => {
+//!             // Top-level client error branch.
+//!             let _ = client_err;
+//!         }
+//!     }
+//! }
+//! ```
 
 mod error;
-pub mod v17;
-pub mod v18;
-pub mod v19;
-pub mod v20;
-pub mod v21;
-pub mod v22;
-pub mod v23;
-pub mod v24;
-pub mod v25;
-pub mod v26;
-pub mod v27;
-pub mod v28;
-pub mod v29;
-pub mod v30;
-pub mod v31;
+mod rpcs;
 
+use std::fmt;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 
-pub use crate::client_sync::error::Error;
-pub(crate) use crate::{into_json, log_response};
-
-/// Crate-specific Result type.
-///
-/// Shorthand for `std::result::Result` with our crate-specific [`Error`] type.
-pub type Result<T> = std::result::Result<T, Error>;
+pub use crate::client_async::error::{
+    Error, GetBestBlockHashError, GetBlockCountError, GetBlockError, GetBlockFilterError,
+    GetBlockHashError, GetBlockHeaderError, GetBlockHeaderVerboseError, GetBlockVerboseError,
+    GetBlockchainInfoError, GetRawMempoolError, GetRawTransactionError, GetTxOutError,
+    ServerVersionError, UnexpectedServerVersionError,
+};
 
 /// The different authentication methods for the client.
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
@@ -41,7 +53,7 @@ pub enum Auth {
 
 impl Auth {
     /// Convert into the arguments that jsonrpc::Client needs.
-    pub fn get_user_pass(self) -> Result<(Option<String>, Option<String>)> {
+    pub fn get_user_pass(self) -> Result<(Option<String>, Option<String>), Error> {
         match self {
             Auth::None => Ok((None, None)),
             Auth::UserPass(u, p) => Ok((Some(u), Some(p))),
@@ -57,103 +69,86 @@ impl Auth {
     }
 }
 
-/// Defines a `jsonrpc::Client` using `bitreq`.
-#[macro_export]
-macro_rules! define_jsonrpc_bitreq_client {
-    ($version:literal) => {
-        use std::fmt;
+/// Client implements an async JSON-RPC client for the Bitcoin Core daemon or compatible APIs.
+pub struct Client {
+    inner: jsonrpc::client_async::Client,
+}
 
-        use $crate::client_sync::{log_response, Auth, Result};
-        use $crate::client_sync::error::Error;
-
-        /// Client implements a JSON-RPC client for the Bitcoin Core daemon or compatible APIs.
-        pub struct Client {
-            inner: jsonrpc::client::Client,
-        }
-
-        impl fmt::Debug for Client {
-            fn fmt(&self, f: &mut fmt::Formatter) -> core::fmt::Result {
-                write!(
-                    f,
-                    "corepc_client::client_sync::{}::Client({:?})", $version, self.inner
-                )
-            }
-        }
-
-        impl Client {
-            /// Creates a client to a bitcoind JSON-RPC server without authentication.
-            pub fn new(url: &str) -> Self {
-                let transport = jsonrpc::http::bitreq_http::Builder::new()
-                    .url(url)
-                    .expect("jsonrpc v0.19, this function does not error")
-                    .timeout(std::time::Duration::from_secs(60))
-                    .build();
-                let inner = jsonrpc::client::Client::with_transport(transport);
-
-                Self { inner }
-            }
-
-            /// Creates a client to a bitcoind JSON-RPC server with authentication.
-            pub fn new_with_auth(url: &str, auth: Auth) -> Result<Self> {
-                if matches!(auth, Auth::None) {
-                    return Err(Error::MissingUserPassword);
-                }
-                let (user, pass) = auth.get_user_pass()?;
-
-                let transport = jsonrpc::http::bitreq_http::Builder::new()
-                    .url(url)
-                    .expect("jsonrpc v0.19, this function does not error")
-                    .timeout(std::time::Duration::from_secs(60))
-                    .basic_auth(user.unwrap(), pass)
-                    .build();
-                let inner = jsonrpc::client::Client::with_transport(transport);
-
-                Ok(Self { inner })
-            }
-
-            /// Call an RPC `method` with given `args` list.
-            pub fn call<T: for<'a> serde::de::Deserialize<'a>>(
-                &self,
-                method: &str,
-                args: &[serde_json::Value],
-            ) -> Result<T> {
-                let raw = serde_json::value::to_raw_value(args)?;
-                let req = self.inner.build_request(&method, Some(&*raw));
-                if log::log_enabled!(log::Level::Debug) {
-                    log::debug!(target: "corepc", "request: {} {}", method, serde_json::Value::from(args));
-                }
-
-                let resp = self.inner.send_request(req).map_err(Error::from);
-                log_response(method, &resp);
-                Ok(resp?.result()?)
-            }
-        }
+impl fmt::Debug for Client {
+    fn fmt(&self, f: &mut fmt::Formatter) -> core::fmt::Result {
+        write!(f, "corepc_client::client_async::Client({:?})", self.inner)
     }
 }
 
-/// Implements the `check_expected_server_version()` on `Client`.
-///
-/// Requires `Client` to be in scope and implement `server_version()`.
-/// See and/or use `impl_client_v17__getnetworkinfo`.
-///
-/// # Parameters
-///
-/// - `$expected_versions`: An vector of expected server versions e.g., `[230100, 230200]`.
-#[macro_export]
-macro_rules! impl_client_check_expected_server_version {
-    ($expected_versions:expr) => {
-        impl Client {
-            /// Checks that the JSON-RPC endpoint is for a `bitcoind` instance with the expected version.
-            pub fn check_expected_server_version(&self) -> Result<()> {
-                let server_version = self.server_version()?;
-                if !$expected_versions.contains(&server_version) {
-                    return Err($crate::client_sync::error::UnexpectedServerVersionError {
-                        got: server_version,
-                        expected: $expected_versions.to_vec(),
-                    })?;
-                }
-                Ok(())
+impl Client {
+    /// Creates a client to a bitcoind JSON-RPC server without authentication.
+    pub fn new(url: &str) -> Self {
+        let transport = jsonrpc::bitreq_http_async::Builder::new()
+            .url(url)
+            .expect("this function does not error")
+            .timeout(std::time::Duration::from_secs(60))
+            .build();
+        let inner = jsonrpc::client_async::Client::with_transport(transport);
+
+        Self { inner }
+    }
+
+    /// Creates a client to a bitcoind JSON-RPC server with authentication.
+    pub fn new_with_auth(url: &str, auth: Auth) -> Result<Self, Error> {
+        match auth {
+            Auth::None => Ok(Self::new(url)),
+            Auth::UserPass(user, pass) => {
+                let transport = jsonrpc::bitreq_http_async::Builder::new()
+                    .url(url)
+                    .expect("this function does not error")
+                    .timeout(std::time::Duration::from_secs(60))
+                    .basic_auth(user, Some(pass))
+                    .build();
+                let inner = jsonrpc::client_async::Client::with_transport(transport);
+
+                Ok(Self { inner })
+            }
+            Auth::CookieFile(path) => {
+                let (user, pass) = Auth::CookieFile(path).get_user_pass()?;
+                let user = user.ok_or(Error::InvalidCookieFile)?;
+                let pass = pass.ok_or(Error::InvalidCookieFile)?;
+                let transport = jsonrpc::bitreq_http_async::Builder::new()
+                    .url(url)
+                    .expect("this function does not error")
+                    .timeout(std::time::Duration::from_secs(60))
+                    .basic_auth(user, Some(pass))
+                    .build();
+                let inner = jsonrpc::client_async::Client::with_transport(transport);
+
+                Ok(Self { inner })
             }
         }
-    };
+    }
+
+    /// Call an RPC `method` with given `args` list.
+    pub async fn call<T: for<'a> serde::de::Deserialize<'a>>(
+        &self,
+        method: &str,
+        args: &[serde_json::Value],
+    ) -> Result<T, Error> {
+        let raw = serde_json::value::to_raw_value(args)?;
+        let req = self.inner.build_request(method, Some(&*raw));
+        if log::log_enabled!(log::Level::Debug) {
+            log::debug!(target: "corepc", "request: {} {}", method, serde_json::Value::from(args));
+        }
+
+        let resp = self.inner.send_request(req).await.map_err(Error::from);
+        crate::log_response(method, &resp);
+        Ok(resp?.result()?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Auth, Client};
+
+    #[test]
+    fn new_with_auth_accepts_auth_none() {
+        Client::new_with_auth("http://127.0.0.1:8332", Auth::None).expect("client without auth");
+    }
 }

--- a/client/src/client_async/mod.rs
+++ b/client/src/client_async/mod.rs
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! JSON-RPC clients for testing against specific versions of Bitcoin Core.
+
+mod error;
+pub mod v17;
+pub mod v18;
+pub mod v19;
+pub mod v20;
+pub mod v21;
+pub mod v22;
+pub mod v23;
+pub mod v24;
+pub mod v25;
+pub mod v26;
+pub mod v27;
+pub mod v28;
+pub mod v29;
+pub mod v30;
+pub mod v31;
+
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+
+pub use crate::client_sync::error::Error;
+pub(crate) use crate::{into_json, log_response};
+
+/// Crate-specific Result type.
+///
+/// Shorthand for `std::result::Result` with our crate-specific [`Error`] type.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// The different authentication methods for the client.
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+pub enum Auth {
+    None,
+    UserPass(String, String),
+    CookieFile(PathBuf),
+}
+
+impl Auth {
+    /// Convert into the arguments that jsonrpc::Client needs.
+    pub fn get_user_pass(self) -> Result<(Option<String>, Option<String>)> {
+        match self {
+            Auth::None => Ok((None, None)),
+            Auth::UserPass(u, p) => Ok((Some(u), Some(p))),
+            Auth::CookieFile(path) => {
+                let line = BufReader::new(File::open(path)?)
+                    .lines()
+                    .next()
+                    .ok_or(Error::InvalidCookieFile)??;
+                let colon = line.find(':').ok_or(Error::InvalidCookieFile)?;
+                Ok((Some(line[..colon].into()), Some(line[colon + 1..].into())))
+            }
+        }
+    }
+}
+
+/// Defines a `jsonrpc::Client` using `bitreq`.
+#[macro_export]
+macro_rules! define_jsonrpc_bitreq_client {
+    ($version:literal) => {
+        use std::fmt;
+
+        use $crate::client_sync::{log_response, Auth, Result};
+        use $crate::client_sync::error::Error;
+
+        /// Client implements a JSON-RPC client for the Bitcoin Core daemon or compatible APIs.
+        pub struct Client {
+            inner: jsonrpc::client::Client,
+        }
+
+        impl fmt::Debug for Client {
+            fn fmt(&self, f: &mut fmt::Formatter) -> core::fmt::Result {
+                write!(
+                    f,
+                    "corepc_client::client_sync::{}::Client({:?})", $version, self.inner
+                )
+            }
+        }
+
+        impl Client {
+            /// Creates a client to a bitcoind JSON-RPC server without authentication.
+            pub fn new(url: &str) -> Self {
+                let transport = jsonrpc::http::bitreq_http::Builder::new()
+                    .url(url)
+                    .expect("jsonrpc v0.19, this function does not error")
+                    .timeout(std::time::Duration::from_secs(60))
+                    .build();
+                let inner = jsonrpc::client::Client::with_transport(transport);
+
+                Self { inner }
+            }
+
+            /// Creates a client to a bitcoind JSON-RPC server with authentication.
+            pub fn new_with_auth(url: &str, auth: Auth) -> Result<Self> {
+                if matches!(auth, Auth::None) {
+                    return Err(Error::MissingUserPassword);
+                }
+                let (user, pass) = auth.get_user_pass()?;
+
+                let transport = jsonrpc::http::bitreq_http::Builder::new()
+                    .url(url)
+                    .expect("jsonrpc v0.19, this function does not error")
+                    .timeout(std::time::Duration::from_secs(60))
+                    .basic_auth(user.unwrap(), pass)
+                    .build();
+                let inner = jsonrpc::client::Client::with_transport(transport);
+
+                Ok(Self { inner })
+            }
+
+            /// Call an RPC `method` with given `args` list.
+            pub fn call<T: for<'a> serde::de::Deserialize<'a>>(
+                &self,
+                method: &str,
+                args: &[serde_json::Value],
+            ) -> Result<T> {
+                let raw = serde_json::value::to_raw_value(args)?;
+                let req = self.inner.build_request(&method, Some(&*raw));
+                if log::log_enabled!(log::Level::Debug) {
+                    log::debug!(target: "corepc", "request: {} {}", method, serde_json::Value::from(args));
+                }
+
+                let resp = self.inner.send_request(req).map_err(Error::from);
+                log_response(method, &resp);
+                Ok(resp?.result()?)
+            }
+        }
+    }
+}
+
+/// Implements the `check_expected_server_version()` on `Client`.
+///
+/// Requires `Client` to be in scope and implement `server_version()`.
+/// See and/or use `impl_client_v17__getnetworkinfo`.
+///
+/// # Parameters
+///
+/// - `$expected_versions`: An vector of expected server versions e.g., `[230100, 230200]`.
+#[macro_export]
+macro_rules! impl_client_check_expected_server_version {
+    ($expected_versions:expr) => {
+        impl Client {
+            /// Checks that the JSON-RPC endpoint is for a `bitcoind` instance with the expected version.
+            pub fn check_expected_server_version(&self) -> Result<()> {
+                let server_version = self.server_version()?;
+                if !$expected_versions.contains(&server_version) {
+                    return Err($crate::client_sync::error::UnexpectedServerVersionError {
+                        got: server_version,
+                        expected: $expected_versions.to_vec(),
+                    })?;
+                }
+                Ok(())
+            }
+        }
+    };
+}

--- a/client/src/client_async/rpcs.rs
+++ b/client/src/client_async/rpcs.rs
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! RPC set used by BDK.
+//!
+//! All functions return the version nonspecific, strongly typed types.
+//!
+//! Some methods return a different JSON shape depending on the Core version (e.g. `getblock` at
+//! verbosity 1 gained a required `target` field in v29 and `coinbase_tx` in v31). These methods fetch
+//! the raw JSON and try to deserialize it into each version's type, newest first, falling back to
+//! older versions.
+
+use bitcoin::{block, Block, BlockHash, Transaction, Txid};
+
+use crate::client_async::error::{
+    GetBestBlockHashError, GetBlockCountError, GetBlockError, GetBlockFilterError,
+    GetBlockHashError, GetBlockHeaderError, GetBlockHeaderVerboseError, GetBlockVerboseError,
+    GetBlockchainInfoError, GetRawMempoolError, GetRawTransactionError, GetTxOutError,
+    ServerVersionError,
+};
+use crate::client_async::Client;
+use crate::into_json;
+use crate::types::{self, model};
+
+impl Client {
+    /// Gets a block by blockhash.
+    pub async fn get_block(&self, hash: &BlockHash) -> Result<Block, GetBlockError> {
+        // This type hasnt' changed between Core v17 and v31.
+        let json: types::v25::GetBlockVerboseZero =
+            self.call("getblock", &[into_json(hash)?, into_json(0)?]).await?;
+        Ok(json.into_model().map_err(GetBlockError::Model)?.0)
+    }
+
+    /// Gets the block count.
+    pub async fn get_block_count(&self) -> Result<u64, GetBlockCountError> {
+        // This type hasnt' changed between Core v17 and v31.
+        let json: types::v25::GetBlockCount = self.call("getblockcount", &[]).await?;
+        Ok(json.0)
+    }
+
+    /// Gets the block hash for a height.
+    pub async fn get_block_hash(&self, height: u32) -> Result<BlockHash, GetBlockHashError> {
+        // This type hasnt' changed between Core v17 and v31.
+        let json: types::v25::GetBlockHash =
+            self.call("getblockhash", &[into_json(height)?]).await?;
+        Ok(json.into_model().map_err(GetBlockHashError::Model)?.0)
+    }
+
+    /// Gets the hash of the chain tip.
+    pub async fn get_best_block_hash(&self) -> Result<BlockHash, GetBestBlockHashError> {
+        // This type hasnt' changed between Core v17 and v31.
+        let json: types::v25::GetBestBlockHash = self.call("getbestblockhash", &[]).await?;
+        Ok(json.into_model().map_err(GetBestBlockHashError::Model)?.0)
+    }
+
+    /// Gets the block header by blockhash.
+    pub async fn get_block_header(
+        &self,
+        hash: &BlockHash,
+    ) -> Result<block::Header, GetBlockHeaderError> {
+        // This type hasnt' changed between Core v17 and v31.
+        let json: types::v25::GetBlockHeader =
+            self.call("getblockheader", &[into_json(hash)?, into_json(false)?]).await?;
+        Ok(json.into_model().map_err(GetBlockHeaderError::Model)?.0)
+    }
+
+    /// Gets the block header with verbose output.
+    ///
+    /// The version specific type is detected by trying to deserialize the response, newest first.
+    pub async fn get_block_header_verbose(
+        &self,
+        hash: &BlockHash,
+    ) -> Result<model::GetBlockHeaderVerbose, GetBlockHeaderVerboseError> {
+        // This type changed in Core v29; assume node is up to date.
+        let res: Result<types::v29::GetBlockHeaderVerbose, _> =
+            self.call("getblockheader", &[into_json(hash)?, into_json(true)?]).await;
+        if let Ok(json) = res {
+            return json.into_model().map_err(GetBlockHeaderVerboseError::ModelV29);
+        }
+
+        // Fall back to v25 (same since Core v17).
+        let json: types::v25::GetBlockHeaderVerbose =
+            self.call("getblockheader", &[into_json(hash)?, into_json(true)?]).await?;
+        json.into_model().map_err(GetBlockHeaderVerboseError::ModelV25)
+    }
+
+    /// Gets a block by blockhash with verbose set to 1.
+    ///
+    /// The version specific type is detected by trying to deserialize the response, newest first.
+    pub async fn get_block_verbose(
+        &self,
+        hash: &BlockHash,
+    ) -> Result<model::GetBlockVerboseOne, GetBlockVerboseError> {
+        // This type changed in Core v31; assume node is up to date.
+        let res: Result<types::v31::GetBlockVerboseOne, _> =
+            self.call("getblock", &[into_json(hash)?, into_json(1)?]).await;
+        if let Ok(json) = res {
+            return json.into_model().map_err(GetBlockVerboseError::ModelV31);
+        }
+
+        // Fall back to v29 (changed since Core v29).
+        let res: Result<types::v29::GetBlockVerboseOne, _> =
+            self.call("getblock", &[into_json(hash)?, into_json(1)?]).await;
+        if let Ok(json) = res {
+            return json.into_model().map_err(GetBlockVerboseError::ModelV29);
+        }
+
+        // Fall back to v25 (same since Core v17).
+        let json: types::v25::GetBlockVerboseOne =
+            self.call("getblock", &[into_json(hash)?, into_json(1)?]).await?;
+        json.into_model().map_err(GetBlockVerboseError::ModelV25)
+    }
+
+    /// Gets the block filter for a blockhash.
+    pub async fn get_block_filter(
+        &self,
+        hash: &BlockHash,
+    ) -> Result<model::GetBlockFilter, GetBlockFilterError> {
+        // This type hasnt' changed between Core v19 and v31.
+        let json: types::v25::GetBlockFilter =
+            self.call("getblockfilter", &[into_json(hash)?]).await?;
+        json.into_model().map_err(GetBlockFilterError::Model)
+    }
+
+    /// Gets various state info regarding blockchain processing.
+    ///
+    /// The version specific type is detected by trying to deserialize the response, newest first.
+    pub async fn get_blockchain_info(
+        &self,
+    ) -> Result<model::GetBlockchainInfo, GetBlockchainInfoError> {
+        // This type changed in Core v29; assume node is up to date.
+        let res: Result<types::v29::GetBlockchainInfo, _> =
+            self.call("getblockchaininfo", &[]).await;
+        if let Ok(json) = res {
+            return json.into_model().map_err(GetBlockchainInfoError::ModelV29);
+        }
+
+        // Fall back to v28 (changed since Core v28).
+        let res: Result<types::v28::GetBlockchainInfo, _> =
+            self.call("getblockchaininfo", &[]).await;
+        if let Ok(json) = res {
+            return json.into_model().map_err(GetBlockchainInfoError::ModelV28);
+        }
+
+        // Fall back to v25 (same since Core v25).
+        let json: types::v25::GetBlockchainInfo = self.call("getblockchaininfo", &[]).await?;
+        json.into_model().map_err(GetBlockchainInfoError::ModelV25)
+    }
+
+    /// Gets the transaction IDs currently in the mempool.
+    pub async fn get_raw_mempool(&self) -> Result<Vec<Txid>, GetRawMempoolError> {
+        // This type hasnt' changed between Core v23 and v31.
+        let json: types::v25::GetRawMempool = self.call("getrawmempool", &[]).await?;
+        Ok(json.into_model().map_err(GetRawMempoolError::Model)?.0)
+    }
+
+    /// Gets the raw transaction by txid.
+    pub async fn get_raw_transaction(
+        &self,
+        txid: &Txid,
+    ) -> Result<Transaction, GetRawTransactionError> {
+        // This type hasnt' changed between Core v17 and v31.
+        let json: types::v25::GetRawTransaction =
+            self.call("getrawtransaction", &[into_json(txid)?]).await?;
+        Ok(json.into_model().map_err(GetRawTransactionError::Model)?.0)
+    }
+
+    /// Gets details about an unspent transaction output.
+    pub async fn get_tx_out(
+        &self,
+        txid: &Txid,
+        vout: u64,
+    ) -> Result<model::GetTxOut, GetTxOutError> {
+        // This type hasnt' changed between Core v17 and v31.
+        let json: types::v25::GetTxOut =
+            self.call("gettxout", &[into_json(txid)?, into_json(vout)?]).await?;
+        json.into_model().map_err(GetTxOutError::Model)
+    }
+
+    /// Returns the version integer reported by the server (e.g. `250200` for v25.2.0).
+    pub async fn server_version(&self) -> Result<usize, ServerVersionError> {
+        // Use a minimal type to read only the `version` field; the shape of other fields
+        // (e.g. `warnings` changed from String to Vec<String> at v28) differs across the
+        // supported version range.
+        #[derive(serde::Deserialize)]
+        struct NetworkVersion {
+            version: usize,
+        }
+        let json: NetworkVersion = self.call("getnetworkinfo", &[]).await?;
+        Ok(json.version)
+    }
+}

--- a/client/src/client_sync/mod.rs
+++ b/client/src/client_sync/mod.rs
@@ -24,6 +24,7 @@ use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 
 pub use crate::client_sync::error::Error;
+pub(crate) use crate::{into_json, log_response};
 
 /// Crate-specific Result type.
 ///
@@ -155,37 +156,4 @@ macro_rules! impl_client_check_expected_server_version {
             }
         }
     };
-}
-
-/// Shorthand for converting a variable into a `serde_json::Value`.
-fn into_json<T>(val: T) -> Result<serde_json::Value>
-where
-    T: serde::ser::Serialize,
-{
-    Ok(serde_json::to_value(val)?)
-}
-
-/// Helper to log an RPC response.
-fn log_response(method: &str, resp: &Result<jsonrpc::Response>) {
-    use log::Level::{Debug, Trace, Warn};
-
-    if log::log_enabled!(Warn) || log::log_enabled!(Debug) || log::log_enabled!(Trace) {
-        match resp {
-            Err(ref e) =>
-                if log::log_enabled!(Debug) {
-                    log::debug!(target: "corepc", "error: {}: {:?}", method, e);
-                },
-            Ok(ref resp) =>
-                if let Some(ref e) = resp.error {
-                    if log::log_enabled!(Debug) {
-                        log::debug!(target: "corepc", "response error for {}: {:?}", method, e);
-                    }
-                } else if log::log_enabled!(Trace) {
-                    let def =
-                        serde_json::value::to_raw_value(&serde_json::value::Value::Null).unwrap();
-                    let result = resp.result.as_ref().unwrap_or(&def);
-                    log::trace!(target: "corepc", "response for {}: {}", method, result);
-                },
-        }
-    }
 }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -11,3 +11,41 @@ pub extern crate types;
 #[cfg(feature = "client-sync")]
 #[macro_use]
 pub mod client_sync;
+
+#[cfg(feature = "client-sync")]
+use crate::client_sync::Result;
+
+/// Shorthand for converting a variable into a `serde_json::Value`.
+#[cfg(feature = "client-sync")]
+fn into_json<T>(val: T) -> Result<serde_json::Value>
+where
+    T: serde::ser::Serialize,
+{
+    Ok(serde_json::to_value(val)?)
+}
+
+/// Helper to log an RPC response.
+#[cfg(feature = "client-sync")]
+fn log_response(method: &str, resp: &Result<jsonrpc::Response>) {
+    use log::Level::{Debug, Trace, Warn};
+
+    if log::log_enabled!(Warn) || log::log_enabled!(Debug) || log::log_enabled!(Trace) {
+        match resp {
+            Err(ref e) =>
+                if log::log_enabled!(Debug) {
+                    log::debug!(target: "corepc", "error: {}: {:?}", method, e);
+                },
+            Ok(ref resp) =>
+                if let Some(ref e) = resp.error {
+                    if log::log_enabled!(Debug) {
+                        log::debug!(target: "corepc", "response error for {}: {:?}", method, e);
+                    }
+                } else if log::log_enabled!(Trace) {
+                    let def =
+                        serde_json::value::to_raw_value(&serde_json::value::Value::Null).unwrap();
+                    let result = resp.result.as_ref().unwrap_or(&def);
+                    log::trace!(target: "corepc", "response for {}: {}", method, result);
+                },
+        }
+    }
+}

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -12,21 +12,24 @@ pub extern crate types;
 #[macro_use]
 pub mod client_sync;
 
-#[cfg(feature = "client-sync")]
-use crate::client_sync::Result;
+#[cfg(feature = "client-async")]
+pub mod client_async;
 
 /// Shorthand for converting a variable into a `serde_json::Value`.
-#[cfg(feature = "client-sync")]
-fn into_json<T>(val: T) -> Result<serde_json::Value>
+#[cfg(any(feature = "client-sync", feature = "client-async"))]
+fn into_json<T>(val: T) -> Result<serde_json::Value, serde_json::Error>
 where
     T: serde::ser::Serialize,
 {
-    Ok(serde_json::to_value(val)?)
+    serde_json::to_value(val)
 }
 
 /// Helper to log an RPC response.
-#[cfg(feature = "client-sync")]
-fn log_response(method: &str, resp: &Result<jsonrpc::Response>) {
+#[cfg(any(feature = "client-sync", feature = "client-async"))]
+fn log_response<E: std::fmt::Debug>(
+    method: &str,
+    resp: &std::result::Result<jsonrpc::Response, E>,
+) {
     use log::Level::{Debug, Trace, Warn};
 
     if log::log_enabled!(Warn) || log::log_enabled!(Debug) || log::log_enabled!(Trace) {

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -59,6 +59,7 @@ TODO = []                       # This is a dirty hack while writing the tests.
 
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false, features = ["std", "serde"] }
+corepc-client = { version = "0.16.0", path = "../client", default-features = false, features = ["client-async"] }
 env_logger = "0.9.0"
 bitcoind = { package = "bitcoind", version = "0.41.0", path = "../bitcoind", default-features = false }
 rand = "0.8.5"
@@ -66,3 +67,4 @@ rand = "0.8.5"
 types = { package = "corepc-types", version = "0.15.0", path = "../types", features = ["serde-deny-unknown-fields"] }
 
 [dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/integration_test/tests/bdk_client.rs
+++ b/integration_test/tests/bdk_client.rs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Tests for the async client. Versions 25 to 31 are currently supported
+
+#![cfg(feature = "v31_and_below")]
+#![cfg(not(feature = "v24_and_below"))]
+
+use bitcoin::address::KnownHrp;
+use bitcoin::{Address, CompressedPublicKey, PrivateKey};
+use corepc_client::client_async::{Auth, Client};
+use integration_test::{BitcoinD, BitcoinDExt as _, Wallet};
+
+fn async_client_for(node: &BitcoinD) -> Client {
+    Client::new_with_auth(&node.rpc_url(), auth_for(node)).expect("async client")
+}
+
+#[tokio::test]
+async fn get_best_block_hash() {
+    let node = BitcoinD::with_wallet(Wallet::None, &[]);
+    let client = async_client_for(&node);
+
+    // Tests that the async-client has this function.
+    let got = client.get_best_block_hash().await.unwrap();
+    // Grabs the block hash using the sync client which we know works.
+    let want = node.client.best_block_hash().expect("best_block_hash");
+    // Tests that the async client returned the same block hash as the sync client.
+    assert_eq!(got, want);
+}
+
+#[tokio::test]
+async fn get_block() {
+    let node = BitcoinD::with_wallet(Wallet::None, &[]);
+    let client = async_client_for(&node);
+
+    let want = node.client.best_block_hash().expect("best_block_hash");
+    let got = client.get_block(&want).await.unwrap();
+    assert_eq!(got.block_hash(), want);
+
+    let got = client.get_block_verbose(&want).await.unwrap();
+    assert_eq!(got.hash, want);
+}
+
+#[tokio::test]
+async fn get_block_count() {
+    let node = BitcoinD::with_wallet(Wallet::None, &[]);
+    let client = async_client_for(&node);
+
+    let got = client.get_block_count().await.unwrap();
+    assert_eq!(got, 0);
+}
+
+#[tokio::test]
+#[cfg(not(feature = "v18_and_below"))]
+async fn get_block_filter() {
+    let node = BitcoinD::with_wallet(Wallet::None, &["-blockfilterindex"]);
+    let client = async_client_for(&node);
+
+    let best_hash = node.client.best_block_hash().expect("best_block_hash");
+    let got = client.get_block_filter(&best_hash).await.unwrap();
+
+    assert!(!got.filter.is_empty());
+    assert_eq!(got.header.to_string().len(), 64);
+}
+
+#[tokio::test]
+async fn get_block_hash() {
+    let node = BitcoinD::with_wallet(Wallet::None, &[]);
+    let client = async_client_for(&node);
+
+    let got = client.get_block_hash(0).await.unwrap();
+    let want = node.client.best_block_hash().expect("best_block_hash");
+    assert_eq!(got, want);
+}
+
+#[tokio::test]
+async fn get_block_header() {
+    let node = BitcoinD::with_wallet(Wallet::None, &[]);
+    let client = async_client_for(&node);
+
+    let want = node.client.best_block_hash().expect("best_block_hash");
+    let got = client.get_block_header(&want).await.unwrap();
+    assert_eq!(got.block_hash(), want);
+
+    let got = client.get_block_header_verbose(&want).await.unwrap();
+    assert_eq!(got.hash, want);
+    assert_eq!(got.height, 0);
+}
+
+#[tokio::test]
+async fn get_raw_mempool() {
+    let node = BitcoinD::with_wallet(Wallet::None, &[]);
+    let client = async_client_for(&node);
+
+    let got = client.get_raw_mempool().await.unwrap();
+    assert!(got.is_empty());
+}
+
+#[tokio::test]
+async fn get_raw_transaction() {
+    let node = BitcoinD::with_wallet(Wallet::None, &["-txindex"]);
+    let privkey =
+        PrivateKey::from_wif("cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy").expect("wif");
+    let secp = bitcoin::secp256k1::Secp256k1::new();
+    let pubkey = privkey.public_key(&secp);
+    let address = Address::p2wpkh(&CompressedPublicKey(pubkey.inner), KnownHrp::Regtest);
+    node.client.generate_to_address(1, &address).expect("generatetoaddress");
+
+    let client = async_client_for(&node);
+    let best_hash = node.client.best_block_hash().expect("best_block_hash");
+    let block = client.get_block(&best_hash).await.expect("getblock");
+    let txid = block.txdata[0].compute_txid();
+
+    let got = client.get_raw_transaction(&txid).await.unwrap();
+    assert_eq!(got.compute_txid(), txid);
+}
+
+#[tokio::test]
+async fn get_tx_out() {
+    let node = BitcoinD::with_wallet(Wallet::None, &[]);
+    let privkey =
+        PrivateKey::from_wif("cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy").expect("wif");
+    let secp = bitcoin::secp256k1::Secp256k1::new();
+    let pubkey = privkey.public_key(&secp);
+    let address = Address::p2wpkh(&CompressedPublicKey(pubkey.inner), KnownHrp::Regtest);
+    node.client.generate_to_address(1, &address).expect("generatetoaddress");
+
+    let client = async_client_for(&node);
+    let best_hash = node.client.best_block_hash().expect("best_block_hash");
+    let block = client.get_block(&best_hash).await.expect("getblock");
+    let txid = block.txdata[0].compute_txid();
+
+    let got = client.get_tx_out(&txid, 0).await.unwrap();
+    assert!(got.coinbase);
+    assert_eq!(got.tx_out, block.txdata[0].output[0]);
+}
+
+#[tokio::test]
+async fn get_blockchain_info() {
+    let node = BitcoinD::with_wallet(Wallet::None, &[]);
+    let client = async_client_for(&node);
+
+    let got = client.get_blockchain_info().await.unwrap();
+    assert_eq!(got.chain, bitcoin::Network::Regtest);
+}
+
+fn auth_for(node: &BitcoinD) -> Auth { Auth::CookieFile(node.params.cookie_file.clone()) }
+
+#[tokio::test]
+async fn server_version() {
+    let node = BitcoinD::with_wallet(Wallet::None, &[]);
+    let client = async_client_for(&node);
+
+    let got = client.server_version().await.unwrap();
+    assert!(got > 0);
+}


### PR DESCRIPTION
This PR adds an async corepc-client with the RPCs used by BDK.

The patches are structured to make it easier to see what was changed from sync to async. First the sync version is copied and renamed, then in a separate patch it is changed to async.
