### PR TITLE
Release tracking PR: `bitreq 0.3.4`

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -147,7 +147,7 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "bitreq"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "base64 0.22.1",
  "log",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -147,7 +147,7 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "bitreq"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "base64 0.22.1",
  "log",

--- a/bitreq/Cargo.toml
+++ b/bitreq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitreq"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Jens Pitkanen <jens@neon.moe>", "Tobin C. Harding <me@tobin.cc>", "Matt Corallo", "Elias Rohrer <dev@tnull.de>"]
 description = "Simple, minimal-dependency HTTP client"
 documentation = "https://docs.rs/bitreq"


### PR DESCRIPTION
I released `bitreq 0.3.3` without first merging PR #500 which was the whole point of the release - face palm.

`v0.3.3` has been yanked.

Changelog is correct already. Bump the version and update the lock files.