### PR TITLE
Add 'all' recipe to justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -60,3 +60,15 @@ docsrs *flags:
 # Update the recent and minimal lock files.
 update-lock-files:
   contrib/update-lock-files.sh
+
+# Run all just recipes(commands)
+all:
+    just build
+    just check
+    just lint
+    just lint-verify
+    just lint-integration-tests
+    just fmt
+    just format
+    just docsrs
+    just update-lock-files


### PR DESCRIPTION
Include a new Just Recipe to run all other recipes.
Useful to run locally before opening the pull request for review.

to run:
`    just all
`  
