### PR TITLE
Remove vXY and later only comments from types

### DIFF
--- a/types/src/v19/blockchain/mod.rs
+++ b/types/src/v19/blockchain/mod.rs
@@ -245,7 +245,7 @@ pub struct GetMempoolEntry(pub MempoolEntry);
 pub struct MempoolEntry {
     /// Virtual transaction size as defined in BIP 141.
     ///
-    /// This is different from actual serialized size for witness transactions as witness data is discounted.  v0.19 and later only.
+    /// This is different from actual serialized size for witness transactions as witness data is discounted.
     pub vsize: i64,
     /// DEPRECATED: same as vsize. Only returned if bitcoind is started with -deprecatedrpc=size
     /// size will be completely removed in v0.20.
@@ -319,7 +319,7 @@ pub struct MempoolEntryFees {
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolInfo {
-    /// True if the mempool is fully loaded. v0.19 and later only.
+    /// True if the mempool is fully loaded.
     pub loaded: bool,
     /// Current transaction count.
     pub size: i64,

--- a/types/src/v19/network/mod.rs
+++ b/types/src/v19/network/mod.rs
@@ -140,7 +140,7 @@ pub struct PeerInfo {
     pub synced_blocks: i64,
     /// The heights of blocks we're currently asking from this peer.
     pub inflight: Vec<u64>,
-    /// Any special permissions that have been granted to this peer. v0.19 and later only.
+    /// Any special permissions that have been granted to this peer.
     pub permissions: Vec<String>,
     /// Whether the peer is whitelisted.
     pub whitelisted: Option<bool>,

--- a/types/src/v19/wallet/mod.rs
+++ b/types/src/v19/wallet/mod.rs
@@ -103,7 +103,7 @@ pub struct GetTransaction {
     pub details: Vec<GetTransactionDetail>,
     /// Raw data for transaction.
     pub hex: String,
-    /// The decoded transaction (only present when `verbose` is passed). v19 and later only.
+    /// The decoded transaction (only present when `verbose` is passed).
     pub decoded: Option<Transaction>,
 }
 

--- a/types/src/v20/wallet/mod.rs
+++ b/types/src/v20/wallet/mod.rs
@@ -184,14 +184,14 @@ pub struct GetTransaction {
     pub fee: Option<f64>,
     /// The number of confirmations.
     pub confirmations: i64,
-    /// Only present if the transaction's only input is a coinbase one. v20 and later only.
+    /// Only present if the transaction's only input is a coinbase one.
     pub generated: Option<bool>,
     /// Whether we consider the outputs of this unconfirmed transaction safe to spend.
     pub trusted: Option<bool>,
     /// The block hash.
     #[serde(rename = "blockhash")]
     pub block_hash: Option<String>,
-    /// The block height containing the transaction. v20 and later only.
+    /// The block height containing the transaction.
     #[serde(rename = "blockheight")]
     pub block_height: Option<i64>,
     /// The index of the transaction in the block that includes it.
@@ -220,7 +220,7 @@ pub struct GetTransaction {
     pub details: Vec<GetTransactionDetail>,
     /// Raw data for transaction.
     pub hex: String,
-    /// The decoded transaction (only present when `verbose` is passed). v19 and later only.
+    /// The decoded transaction (only present when `verbose` is passed).
     pub decoded: Option<Transaction>,
 }
 
@@ -228,7 +228,7 @@ pub struct GetTransaction {
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetTransactionDetail {
-    /// Only returns true if imported addresses were involved in transaction. v20 and later only.
+    /// Only returns true if imported addresses were involved in transaction.
     #[serde(rename = "involvesWatchonly")]
     pub involves_watch_only: Option<bool>,
     /// DEPRECATED. The account name involved in the transaction, can be "" for the default account.

--- a/types/src/v21/blockchain/mod.rs
+++ b/types/src/v21/blockchain/mod.rs
@@ -107,7 +107,7 @@ pub struct Bip9SoftforkInfo {
     pub timeout: i64,
     /// Height of the first block to which the status applies.
     pub since: i64,
-    /// Minimum height of blocks for which the rules may be enforced. v0.21 and later only.
+    /// Minimum height of blocks for which the rules may be enforced.
     pub min_activation_height: i64,
     /// Numeric statistics about BIP-9 signalling for a softfork (only for "started" status).
     pub statistics: Option<Bip9SoftforkStatistics>,
@@ -169,7 +169,7 @@ pub struct GetMempoolEntry(pub MempoolEntry);
 pub struct MempoolEntry {
     /// Virtual transaction size as defined in BIP 141.
     ///
-    /// This is different from actual serialized size for witness transactions as witness data is discounted.  v0.19 and later only.
+    /// This is different from actual serialized size for witness transactions as witness data is discounted.
     pub vsize: i64,
     /// Transaction weight as defined in BIP 141.
     pub weight: i64,
@@ -225,7 +225,7 @@ pub struct MempoolEntry {
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolInfo {
-    /// True if the mempool is fully loaded. v0.19 and later only.
+    /// True if the mempool is fully loaded.
     pub loaded: bool,
     /// Current transaction count.
     pub size: i64,
@@ -246,7 +246,7 @@ pub struct GetMempoolInfo {
     /// Current minimum relay fee for transactions.
     #[serde(rename = "minrelaytxfee")]
     pub min_relay_tx_fee: f64,
-    /// Current number of transactions that haven't passed initial broadcast yet. v21 and later only.
+    /// Current number of transactions that haven't passed initial broadcast yet.
     #[serde(rename = "unbroadcastcount")]
     pub unbroadcast_count: i64,
 }

--- a/types/src/v21/network/mod.rs
+++ b/types/src/v21/network/mod.rs
@@ -30,7 +30,7 @@ pub struct GetNetworkInfo {
     /// The services we offer to the network (hex string).
     #[serde(rename = "localservices")]
     pub local_services: String,
-    /// The services we offer to the network. v0.19 and later only.
+    /// The services we offer to the network.
     #[serde(rename = "localservicesnames")]
     pub local_services_names: Vec<String>,
     /// `true` if transaction relay is requested from peers.
@@ -41,9 +41,9 @@ pub struct GetNetworkInfo {
     pub time_offset: isize,
     /// The total number of connections.
     pub connections: usize,
-    /// The number of inbound connections. v21 and later only.
+    /// The number of inbound connections.
     pub connections_in: usize,
-    /// The number of outbound connections. v21 and later only.
+    /// The number of outbound connections.
     pub connections_out: usize,
     /// Whether p2p networking is enabled.
     #[serde(rename = "networkactive")]
@@ -103,9 +103,9 @@ pub struct PeerInfo {
     /// The time in seconds since epoch (Jan 1 1970 GMT) of the last receive.
     #[serde(rename = "lastrecv")]
     pub last_received: i64,
-    /// The UNIX epoch time of the last valid transaction received from this peer. v21 and later only.
+    /// The UNIX epoch time of the last valid transaction received from this peer.
     pub last_transaction: i64,
-    /// The UNIX epoch time of the last block received from this peer. v21 and later only.
+    /// The UNIX epoch time of the last block received from this peer.
     pub last_block: i64,
     /// The total bytes sent.
     #[serde(rename = "bytessent")]
@@ -147,14 +147,13 @@ pub struct PeerInfo {
     pub synced_blocks: i64,
     /// The heights of blocks we're currently asking from this peer.
     pub inflight: Vec<u64>,
-    /// The total number of addresses processed, excluding those dropped due to rate limiting. v21 and
-    /// later only.
+    /// The total number of addresses processed, excluding those dropped due to rate limiting.
     #[serde(rename = "addr_processed")]
     pub addresses_processed: usize,
-    /// The total number of addresses dropped due to rate limiting. v21 and later only.
+    /// The total number of addresses dropped due to rate limiting.
     #[serde(rename = "addr_rate_limited")]
     pub addresses_rate_limited: usize,
-    /// Any special permissions that have been granted to this peer. v0.19 and later only.
+    /// Any special permissions that have been granted to this peer.
     pub permissions: Vec<String>,
     /// Whether the peer is whitelisted.
     pub whitelisted: Option<bool>,

--- a/types/src/v22/blockchain/mod.rs
+++ b/types/src/v22/blockchain/mod.rs
@@ -18,7 +18,7 @@ pub use super::GetMempoolInfoError;
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolInfo {
-    /// True if the mempool is fully loaded. v0.19 and later only.
+    /// True if the mempool is fully loaded.
     pub loaded: bool,
     /// Current transaction count.
     pub size: i64,
@@ -28,8 +28,7 @@ pub struct GetMempoolInfo {
     pub bytes: i64,
     /// Total memory usage for the mempool.
     pub usage: i64,
-    /// Total fees for the mempool in BTC, ignoring modified fees through prioritisetransaction. v23
-    /// and later only.
+    /// Total fees for the mempool in BTC, ignoring modified fees through prioritisetransaction.
     pub total_fee: f64,
     /// Maximum memory usage for the mempool.
     #[serde(rename = "maxmempool")]
@@ -42,7 +41,7 @@ pub struct GetMempoolInfo {
     /// Current minimum relay fee for transactions.
     #[serde(rename = "minrelaytxfee")]
     pub min_relay_tx_fee: f64,
-    /// Current number of transactions that haven't passed initial broadcast yet. v21 and later only.
+    /// Current number of transactions that haven't passed initial broadcast yet.
     #[serde(rename = "unbroadcastcount")]
     pub unbroadcast_count: i64,
 }

--- a/types/src/v22/network.rs
+++ b/types/src/v22/network.rs
@@ -75,9 +75,9 @@ pub struct PeerInfo {
     /// The time in seconds since epoch (Jan 1 1970 GMT) of the last receive.
     #[serde(rename = "lastrecv")]
     pub last_received: i64,
-    /// The UNIX epoch time of the last valid transaction received from this peer. v21 and later only.
+    /// The UNIX epoch time of the last valid transaction received from this peer.
     pub last_transaction: i64,
-    /// The UNIX epoch time of the last block received from this peer. v21 and later only.
+    /// The UNIX epoch time of the last block received from this peer.
     pub last_block: i64,
     /// The total bytes sent.
     #[serde(rename = "bytessent")]
@@ -123,14 +123,13 @@ pub struct PeerInfo {
     pub synced_blocks: i64,
     /// The heights of blocks we're currently asking from this peer.
     pub inflight: Vec<u64>,
-    /// The total number of addresses processed, excluding those dropped due to rate limiting. v21 and
-    /// later only.
+    /// The total number of addresses processed, excluding those dropped due to rate limiting.
     #[serde(rename = "addr_processed")]
     pub addresses_processed: usize,
-    /// The total number of addresses dropped due to rate limiting. v21 and later only.
+    /// The total number of addresses dropped due to rate limiting.
     #[serde(rename = "addr_rate_limited")]
     pub addresses_rate_limited: usize,
-    /// Any special permissions that have been granted to this peer. v0.19 and later only.
+    /// Any special permissions that have been granted to this peer.
     pub permissions: Vec<String>,
     /// Whether the peer is whitelisted.
     pub whitelisted: Option<bool>,

--- a/types/src/v22/raw_transactions/mod.rs
+++ b/types/src/v22/raw_transactions/mod.rs
@@ -28,7 +28,7 @@ pub struct DecodeScript {
     /// The output type.
     #[serde(rename = "type")]
     pub type_: String,
-    /// Bitcoin address (only if a well-defined address exists). v22 and later only.
+    /// Bitcoin address (only if a well-defined address exists).
     pub address: Option<String>,
     /// The required signatures.
     #[serde(rename = "reqSigs")]
@@ -55,7 +55,7 @@ pub struct DecodeScriptSegwit {
     /// The output type.
     #[serde(rename = "type")]
     pub type_: String,
-    /// Bitcoin address (only if a well-defined address exists). v22 and later only.
+    /// Bitcoin address (only if a well-defined address exists).
     pub address: Option<String>,
     /// The required signatures.
     #[serde(rename = "reqSigs")]

--- a/types/src/v23/blockchain/mod.rs
+++ b/types/src/v23/blockchain/mod.rs
@@ -35,7 +35,7 @@ pub struct GetBlockchainInfo {
     pub best_block_hash: String,
     /// The current difficulty.
     pub difficulty: f64,
-    /// The block time expressed in UNIX epoch time. v23 and later only.
+    /// The block time expressed in UNIX epoch time.
     pub time: i64,
     /// Median time for the current best block.
     #[serde(rename = "mediantime")]
@@ -195,7 +195,7 @@ pub struct MempoolEntry {
     /// Virtual transaction size as defined in BIP 141.
     ///
     /// This is different from actual serialized size for witness transactions as witness data is
-    /// discounted. v0.19 and later only.
+    /// discounted.
     pub vsize: i64,
     /// Transaction weight as defined in BIP 141.
     pub weight: i64,

--- a/types/src/v23/control.rs
+++ b/types/src/v23/control.rs
@@ -16,13 +16,13 @@ use serde::{Deserialize, Serialize};
 pub struct Logging {
     pub addrman: bool,
     pub bench: bool,
-    pub blockstorage: bool, // v23 and later only
+    pub blockstorage: bool,
     pub cmpctblock: bool,
     pub coindb: bool,
     pub estimatefee: bool,
     pub http: bool,
-    pub i2p: bool, // v23 and later only
-    pub ipc: bool, // v23 and later only
+    pub i2p: bool,
+    pub ipc: bool,
     pub leveldb: bool,
     pub libevent: bool,
     pub mempool: bool,
@@ -36,8 +36,8 @@ pub struct Logging {
     pub rpc: bool,
     pub selectcoins: bool,
     pub tor: bool,
-    pub util: bool,       // v23 to v27 only
-    pub validation: bool, // v23 and later only
-    pub walletdb: bool,   // v23 and later only
+    pub util: bool,
+    pub validation: bool,
+    pub walletdb: bool,
     pub zmq: bool,
 }

--- a/types/src/v23/network.rs
+++ b/types/src/v23/network.rs
@@ -36,7 +36,7 @@ pub struct PeerInfo {
     pub network: Option<String>,
     /// The services offered.
     pub services: String,
-    /// The services offered, in human-readable form. v0.19 and later only.
+    /// The services offered, in human-readable form.
     #[serde(rename = "servicesnames")]
     pub services_names: Vec<String>,
     /// Whether peer has asked us to relay transactions to it.
@@ -48,9 +48,9 @@ pub struct PeerInfo {
     /// The time in seconds since epoch (Jan 1 1970 GMT) of the last receive.
     #[serde(rename = "lastrecv")]
     pub last_received: i64,
-    /// The UNIX epoch time of the last valid transaction received from this peer. v21 and later only.
+    /// The UNIX epoch time of the last valid transaction received from this peer.
     pub last_transaction: i64,
-    /// The UNIX epoch time of the last block received from this peer. v21 and later only.
+    /// The UNIX epoch time of the last block received from this peer.
     pub last_block: i64,
     /// The total bytes sent.
     #[serde(rename = "bytessent")]
@@ -80,9 +80,9 @@ pub struct PeerInfo {
     pub subversion: String,
     /// Inbound (true) or Outbound (false).
     pub inbound: bool,
-    /// Whether we selected peer as (compact blocks) high-bandwidth peer. v22 and later only.
+    /// Whether we selected peer as (compact blocks) high-bandwidth peer.
     pub bip152_hb_to: bool,
-    /// Whether peer selected us as (compact blocks) high-bandwidth peer. v22 and later only.
+    /// Whether peer selected us as (compact blocks) high-bandwidth peer.
     pub bip152_hb_from: bool,
     /// Whether connection was due to addnode/-connect or if it was an automatic/inbound connection.
     #[serde(rename = "addnode")]

--- a/types/src/v23/raw_transactions/mod.rs
+++ b/types/src/v23/raw_transactions/mod.rs
@@ -144,13 +144,13 @@ pub struct PsbtOutput {
 pub struct DecodeScript {
     /// Script public key.
     pub asm: String,
-    /// Inferred descriptor for the script. v23 and later only.
+    /// Inferred descriptor for the script.
     #[serde(rename = "desc")]
     pub descriptor: Option<String>,
     /// The output type.
     #[serde(rename = "type")]
     pub type_: String,
-    /// Bitcoin address (only if a well-defined address exists). v22 and later only.
+    /// Bitcoin address (only if a well-defined address exists).
     pub address: Option<String>,
     /// The required signatures.
     #[serde(rename = "reqSigs")]
@@ -177,14 +177,14 @@ pub struct DecodeScriptSegwit {
     /// The output type.
     #[serde(rename = "type")]
     pub type_: String,
-    /// Bitcoin address (only if a well-defined address exists). v22 and later only.
+    /// Bitcoin address (only if a well-defined address exists).
     pub address: Option<String>,
     /// The required signatures.
     #[serde(rename = "reqSigs")]
     pub required_signatures: Option<u64>,
     /// List of bitcoin addresses.
     pub addresses: Option<Vec<String>>,
-    /// Inferred descriptor for the script. v23 and later only.
+    /// Inferred descriptor for the script.
     #[serde(rename = "desc")]
     pub descriptor: Option<String>,
     /// Address of P2SH script wrapping this redeem script (not returned if the script is already a P2SH).

--- a/types/src/v23/wallet/mod.rs
+++ b/types/src/v23/wallet/mod.rs
@@ -62,14 +62,14 @@ pub struct GetTransaction {
     pub fee: Option<f64>,
     /// The number of confirmations.
     pub confirmations: i64,
-    /// Only present if the transaction's only input is a coinbase one. v20 and later only.
+    /// Only present if the transaction's only input is a coinbase one.
     pub generated: Option<bool>,
     /// Whether we consider the outputs of this unconfirmed transaction safe to spend.
     pub trusted: Option<bool>,
     /// The block hash.
     #[serde(rename = "blockhash")]
     pub block_hash: Option<String>,
-    /// The block height containing the transaction. v20 and later only.
+    /// The block height containing the transaction.
     #[serde(rename = "blockheight")]
     pub block_height: Option<i64>,
     /// The index of the transaction in the block that includes it.
@@ -83,18 +83,18 @@ pub struct GetTransaction {
     /// Confirmed transactions that have been detected by the wallet to conflict with this transaction.
     #[serde(rename = "walletconflicts")]
     pub wallet_conflicts: Vec<String>,
-    /// Only if 'category' is 'send'. The txid if this tx was replaced. v23 and later only.
+    /// Only if 'category' is 'send'. The txid if this tx was replaced.
     pub replaced_by_txid: Option<String>,
-    /// Only if 'category' is 'send'. The txid if this tx replaces another. v23 and later only.
+    /// Only if 'category' is 'send'. The txid if this tx replaces another.
     pub replaces_txid: Option<String>,
-    /// If a comment to is associated with the transaction. v23 and later only.
+    /// If a comment to is associated with the transaction.
     pub to: Option<String>,
     /// The transaction time in seconds since epoch (1 Jan 1970 GMT).
     pub time: u32,
     /// The time received in seconds since epoch (1 Jan 1970 GMT).
     #[serde(rename = "timereceived")]
     pub time_received: u32,
-    /// If a comment is associated with the transaction, only present if not empty. v20 to v24 only.
+    /// If a comment is associated with the transaction, only present if not empty.
     pub comment: Option<String>,
     /// Whether this transaction could be replaced due to BIP125 (replace-by-fee);
     /// may be unknown for unconfirmed transactions not in the mempool
@@ -104,7 +104,7 @@ pub struct GetTransaction {
     pub details: Vec<GetTransactionDetail>,
     /// Raw data for transaction.
     pub hex: String,
-    /// The decoded transaction (only present when `verbose` is passed). v19 and later only.
+    /// The decoded transaction (only present when `verbose` is passed).
     pub decoded: Option<Transaction>,
 }
 

--- a/types/src/v24/blockchain/mod.rs
+++ b/types/src/v24/blockchain/mod.rs
@@ -78,7 +78,7 @@ pub struct MempoolEntry {
     /// Virtual transaction size as defined in BIP 141.
     ///
     /// This is different from actual serialized size for witness transactions as witness data is
-    /// discounted. v0.19 and later only.
+    /// discounted.
     pub vsize: i64,
     /// Transaction weight as defined in BIP 141.
     pub weight: i64,
@@ -124,7 +124,7 @@ pub struct MempoolEntry {
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetMempoolInfo {
-    /// True if the mempool is fully loaded. v0.19 and later only.
+    /// True if the mempool is fully loaded.
     pub loaded: bool,
     /// Current transaction count.
     pub size: i64,
@@ -134,8 +134,7 @@ pub struct GetMempoolInfo {
     pub bytes: i64,
     /// Total memory usage for the mempool.
     pub usage: i64,
-    /// Total fees for the mempool in BTC, ignoring modified fees through prioritisetransaction. v23
-    /// and later only.
+    /// Total fees for the mempool in BTC, ignoring modified fees through prioritisetransaction.
     pub total_fee: f64,
     /// Maximum memory usage for the mempool.
     #[serde(rename = "maxmempool")]
@@ -148,14 +147,13 @@ pub struct GetMempoolInfo {
     /// Current minimum relay fee for transactions.
     #[serde(rename = "minrelaytxfee")]
     pub min_relay_tx_fee: f64,
-    /// Minimum fee rate increment for mempool limiting or replacement in BTC/kvB. v24 and later only.
+    /// Minimum fee rate increment for mempool limiting or replacement in BTC/kvB.
     #[serde(rename = "incrementalrelayfee")]
     pub incremental_relay_fee: f64,
-    /// Current number of transactions that haven't passed initial broadcast yet. v21 and later only.
+    /// Current number of transactions that haven't passed initial broadcast yet.
     #[serde(rename = "unbroadcastcount")]
     pub unbroadcast_count: i64,
-    /// True if the mempool accepts RBF without replaceability signaling inspection. v24 and later
-    /// only.
+    /// True if the mempool accepts RBF without replaceability signaling inspection.
     #[serde(rename = "fullrbf")]
     pub full_rbf: bool,
 }

--- a/types/src/v24/network.rs
+++ b/types/src/v24/network.rs
@@ -36,7 +36,7 @@ pub struct PeerInfo {
     pub network: Option<String>,
     /// The services offered.
     pub services: String,
-    /// The services offered, in human-readable form. v0.19 and later only.
+    /// The services offered, in human-readable form.
     #[serde(rename = "servicesnames")]
     pub services_names: Vec<String>,
     /// Whether peer has asked us to relay transactions to it.
@@ -48,9 +48,9 @@ pub struct PeerInfo {
     /// The time in seconds since epoch (Jan 1 1970 GMT) of the last receive.
     #[serde(rename = "lastrecv")]
     pub last_received: i64,
-    /// The UNIX epoch time of the last valid transaction received from this peer. v21 and later only.
+    /// The UNIX epoch time of the last valid transaction received from this peer.
     pub last_transaction: i64,
-    /// The UNIX epoch time of the last block received from this peer. v21 and later only.
+    /// The UNIX epoch time of the last block received from this peer.
     pub last_block: i64,
     /// The total bytes sent.
     #[serde(rename = "bytessent")]
@@ -80,9 +80,9 @@ pub struct PeerInfo {
     pub subversion: String,
     /// Inbound (true) or Outbound (false).
     pub inbound: bool,
-    /// Whether we selected peer as (compact blocks) high-bandwidth peer. v22 and later only.
+    /// Whether we selected peer as (compact blocks) high-bandwidth peer.
     pub bip152_hb_to: bool,
-    /// Whether peer selected us as (compact blocks) high-bandwidth peer. v22 and later only.
+    /// Whether peer selected us as (compact blocks) high-bandwidth peer.
     pub bip152_hb_from: bool,
     /// Whether connection was due to addnode/-connect or if it was an automatic/inbound connection.
     #[serde(rename = "addnode")]

--- a/types/src/v24/wallet/mod.rs
+++ b/types/src/v24/wallet/mod.rs
@@ -36,14 +36,14 @@ pub struct GetTransaction {
     pub fee: Option<f64>,
     /// The number of confirmations.
     pub confirmations: i64,
-    /// Only present if the transaction's only input is a coinbase one. v20 and later only.
+    /// Only present if the transaction's only input is a coinbase one.
     pub generated: Option<bool>,
     /// Whether we consider the outputs of this unconfirmed transaction safe to spend.
     pub trusted: Option<bool>,
     /// The block hash.
     #[serde(rename = "blockhash")]
     pub block_hash: Option<String>,
-    /// The block height containing the transaction. v20 and later only.
+    /// The block height containing the transaction.
     #[serde(rename = "blockheight")]
     pub block_height: Option<i64>,
     /// The index of the transaction in the block that includes it.
@@ -54,37 +54,37 @@ pub struct GetTransaction {
     pub block_time: Option<u32>,
     /// The transaction id.
     pub txid: String,
-    /// The hash of serialized transaction, including witness data. v24 and later only.
+    /// The hash of serialized transaction, including witness data.
     pub wtxid: Option<String>,
     /// Confirmed transactions that have been detected by the wallet to conflict with this transaction.
     #[serde(rename = "walletconflicts")]
     pub wallet_conflicts: Vec<String>,
-    /// Only if 'category' is 'send'. The txid if this tx was replaced. v23 and later only.
+    /// Only if 'category' is 'send'. The txid if this tx was replaced.
     pub replaced_by_txid: Option<String>,
-    /// Only if 'category' is 'send'. The txid if this tx replaces another. v23 and later only.
+    /// Only if 'category' is 'send'. The txid if this tx replaces another.
     pub replaces_txid: Option<String>,
-    /// If a comment to is associated with the transaction. v23 and later only.
+    /// If a comment to is associated with the transaction.
     pub to: Option<String>,
     /// The transaction time in seconds since epoch (1 Jan 1970 GMT).
     pub time: u32,
     /// The time received in seconds since epoch (1 Jan 1970 GMT).
     #[serde(rename = "timereceived")]
     pub time_received: u32,
-    /// If a comment is associated with the transaction, only present if not empty. v20 to v24 only.
+    /// If a comment is associated with the transaction, only present if not empty.
     pub comment: Option<String>,
     /// Whether this transaction could be replaced due to BIP125 (replace-by-fee);
     /// may be unknown for unconfirmed transactions not in the mempool
     #[serde(rename = "bip125-replaceable")]
     pub bip125_replaceable: Bip125Replaceable,
     /// Only if 'category' is 'received'. List of parent descriptors for the output script of this
-    /// coin. v24 and later only.
+    /// coin.
     #[serde(rename = "parent_descs")]
     pub parent_descriptors: Option<Vec<String>>,
     /// Transaction details.
     pub details: Vec<GetTransactionDetail>,
     /// Raw data for transaction.
     pub hex: String,
-    /// The decoded transaction (only present when `verbose` is passed). v19 and later only.
+    /// The decoded transaction (only present when `verbose` is passed).
     pub decoded: Option<Transaction>,
 }
 
@@ -92,7 +92,7 @@ pub struct GetTransaction {
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
 pub struct GetTransactionDetail {
-    /// Only returns true if imported addresses were involved in transaction. v20 and later only.
+    /// Only returns true if imported addresses were involved in transaction.
     #[serde(rename = "involvesWatchonly")]
     pub involves_watch_only: Option<bool>,
     /// DEPRECATED. The account name involved in the transaction, can be "" for the default account.
@@ -116,7 +116,7 @@ pub struct GetTransactionDetail {
     /// Only available for the 'send' category of transactions.
     pub abandoned: Option<bool>,
     /// Only if 'category' is 'received'. List of parent descriptors for the output script of this
-    /// coin. v24 and later only.
+    /// coin.
     #[serde(rename = "parent_descs")]
     pub parent_descriptors: Option<Vec<String>>,
 }
@@ -272,7 +272,7 @@ pub struct ListUnspentItem {
     /// and unconfirmed replacement transactions are considered unsafe and are not eligible for
     /// spending by fundrawtransaction and sendtoaddress.
     pub safe: bool,
-    /// List of parent descriptors for the scriptPubKey of this coin. v24 and later only.
+    /// List of parent descriptors for the scriptPubKey of this coin.
     #[serde(rename = "parent_descs")]
     pub parent_descriptors: Option<Vec<String>>,
 }

--- a/types/src/v25/blockchain/mod.rs
+++ b/types/src/v25/blockchain/mod.rs
@@ -110,10 +110,8 @@ pub struct GetBlockStats {
     #[serde(rename = "utxo_size_inc")]
     pub utxo_size_increase: i32,
     /// The increase/decrease in the number of unspent outputs, not counting unspendables.
-    /// v25 and later only.
     pub utxo_increase_actual: Option<i32>,
     /// The increase/decrease in size for the utxo index, not counting unspendables.
-    /// v25 and later only.
     #[serde(rename = "utxo_size_inc_actual")]
     pub utxo_size_increase_actual: Option<i32>,
 }

--- a/types/src/v25/control.rs
+++ b/types/src/v25/control.rs
@@ -16,13 +16,13 @@ use serde::{Deserialize, Serialize};
 pub struct Logging {
     pub addrman: bool,
     pub bench: bool,
-    pub blockstorage: bool, // v23 and later only
+    pub blockstorage: bool,
     pub cmpctblock: bool,
     pub coindb: bool,
     pub estimatefee: bool,
     pub http: bool,
-    pub i2p: bool, // v23 and later only
-    pub ipc: bool, // v23 and later only
+    pub i2p: bool,
+    pub ipc: bool,
     pub leveldb: bool,
     pub libevent: bool,
     pub mempool: bool,
@@ -34,12 +34,12 @@ pub struct Logging {
     pub rand: bool,
     pub reindex: bool,
     pub rpc: bool,
-    pub scan: bool, // v25 and later only
+    pub scan: bool,
     pub selectcoins: bool,
     pub tor: bool,
-    pub txreconciliation: bool, // v25 and later only
-    pub util: bool,             // v23 to v27 only
-    pub validation: bool,       // v23 and later only
-    pub walletdb: bool,         // v23 and later only
+    pub txreconciliation: bool,
+    pub util: bool,
+    pub validation: bool,
+    pub walletdb: bool,
     pub zmq: bool,
 }

--- a/types/src/v26/blockchain/mod.rs
+++ b/types/src/v26/blockchain/mod.rs
@@ -108,7 +108,6 @@ pub struct GetTxOutSetInfo {
     #[serde(rename = "bogosize")]
     pub bogo_size: i64,
     /// The serialized hash (only present if 'hash_serialized_3' hash_type is chosen).
-    /// v26 and later only.
     pub hash_serialized_3: Option<String>,
     /// The estimated size of the chainstate on disk (not available when coinstatsindex is used).
     pub disk_size: Option<i64>,

--- a/types/src/v26/control.rs
+++ b/types/src/v26/control.rs
@@ -16,13 +16,13 @@ use serde::{Deserialize, Serialize};
 pub struct Logging {
     pub addrman: bool,
     pub bench: bool,
-    pub blockstorage: bool, // v23 and later only
+    pub blockstorage: bool,
     pub cmpctblock: bool,
     pub coindb: bool,
     pub estimatefee: bool,
     pub http: bool,
-    pub i2p: bool, // v23 and later only
-    pub ipc: bool, // v23 and later only
+    pub i2p: bool,
+    pub ipc: bool,
     pub leveldb: bool,
     pub libevent: bool,
     pub mempool: bool,
@@ -34,13 +34,13 @@ pub struct Logging {
     pub rand: bool,
     pub reindex: bool,
     pub rpc: bool,
-    pub scan: bool, // v25 and later only
+    pub scan: bool,
     pub selectcoins: bool,
     pub tor: bool,
-    pub txpackages: bool,       // v26 and later only
-    pub txreconciliation: bool, // v25 and later only
-    pub util: bool,             // v23 to v27 only
-    pub validation: bool,       // v23 and later only
-    pub walletdb: bool,         // v23 and later only
+    pub txpackages: bool,
+    pub txreconciliation: bool,
+    pub util: bool,
+    pub validation: bool,
+    pub walletdb: bool,
     pub zmq: bool,
 }

--- a/types/src/v26/network.rs
+++ b/types/src/v26/network.rs
@@ -155,6 +155,5 @@ pub struct PeerInfo {
     /// v2 (BIP324 encrypted transport protocol).
     pub transport_protocol_type: String,
     /// The session ID for this connection, or "" if there is none ("v2" transport protocol only).
-    /// v26 and later only.
     pub session_id: String,
 }

--- a/types/src/v26/wallet/mod.rs
+++ b/types/src/v26/wallet/mod.rs
@@ -57,7 +57,7 @@ pub struct GetBalances {
     pub mine: GetBalancesMine,
     #[serde(rename = "watchonly")]
     pub watch_only: Option<GetBalancesWatchOnly>,
-    /// Hash and height of the block this information was generated on. v26 and later only.
+    /// Hash and height of the block this information was generated on.
     #[serde(rename = "lastprocessedblock")]
     pub last_processed_block: Option<LastProcessedBlock>,
 }
@@ -81,14 +81,14 @@ pub struct GetTransaction {
     pub fee: Option<f64>,
     /// The number of confirmations.
     pub confirmations: i64,
-    /// Only present if the transaction's only input is a coinbase one. v20 and later only.
+    /// Only present if the transaction's only input is a coinbase one.
     pub generated: Option<bool>,
     /// Whether we consider the outputs of this unconfirmed transaction safe to spend.
     pub trusted: Option<bool>,
     /// The block hash.
     #[serde(rename = "blockhash")]
     pub block_hash: Option<String>,
-    /// The block height containing the transaction. v20 and later only.
+    /// The block height containing the transaction.
     #[serde(rename = "blockheight")]
     pub block_height: Option<i64>,
     /// The index of the transaction in the block that includes it.
@@ -99,16 +99,16 @@ pub struct GetTransaction {
     pub block_time: Option<u32>,
     /// The transaction id.
     pub txid: String,
-    /// The hash of serialized transaction, including witness data. v24 and later only.
+    /// The hash of serialized transaction, including witness data.
     pub wtxid: Option<String>,
     /// Confirmed transactions that have been detected by the wallet to conflict with this transaction.
     #[serde(rename = "walletconflicts")]
     pub wallet_conflicts: Vec<String>,
-    /// Only if 'category' is 'send'. The txid if this tx was replaced. v23 and later only.
+    /// Only if 'category' is 'send'. The txid if this tx was replaced.
     pub replaced_by_txid: Option<String>,
-    /// Only if 'category' is 'send'. The txid if this tx replaces another. v23 and later only.
+    /// Only if 'category' is 'send'. The txid if this tx replaces another.
     pub replaces_txid: Option<String>,
-    /// If a comment to is associated with the transaction. v23 and later only.
+    /// If a comment to is associated with the transaction.
     pub to: Option<String>,
     /// The transaction time in seconds since epoch (1 Jan 1970 GMT).
     pub time: u32,
@@ -122,16 +122,16 @@ pub struct GetTransaction {
     #[serde(rename = "bip125-replaceable")]
     pub bip125_replaceable: Bip125Replaceable,
     /// Only if 'category' is 'received'. List of parent descriptors for the output script of this
-    /// coin. v24 and later only.
+    /// coin.
     #[serde(rename = "parent_descs")]
     pub parent_descriptors: Option<Vec<String>>,
     /// Transaction details.
     pub details: Vec<GetTransactionDetail>,
     /// Raw data for transaction.
     pub hex: String,
-    /// The decoded transaction (only present when `verbose` is passed). v19 and later only.
+    /// The decoded transaction (only present when `verbose` is passed).
     pub decoded: Option<Transaction>,
-    /// Hash and height of the block this information was generated on. v26 and later only.
+    /// Hash and height of the block this information was generated on.
     #[serde(rename = "lastprocessedblock")]
     pub last_processed_block: Option<LastProcessedBlock>,
 }

--- a/types/src/v28/blockchain/mod.rs
+++ b/types/src/v28/blockchain/mod.rs
@@ -33,7 +33,7 @@ pub struct GetBlockchainInfo {
     pub best_block_hash: String,
     /// The current difficulty.
     pub difficulty: f64,
-    /// The block time expressed in UNIX epoch time. v23 and later only.
+    /// The block time expressed in UNIX epoch time.
     pub time: i64,
     /// Median time for the current best block.
     #[serde(rename = "mediantime")]

--- a/types/src/v28/control.rs
+++ b/types/src/v28/control.rs
@@ -16,13 +16,13 @@ use serde::{Deserialize, Serialize};
 pub struct Logging {
     pub addrman: bool,
     pub bench: bool,
-    pub blockstorage: bool, // v23 and later only
+    pub blockstorage: bool,
     pub cmpctblock: bool,
     pub coindb: bool,
     pub estimatefee: bool,
     pub http: bool,
-    pub i2p: bool, // v23 and later only
-    pub ipc: bool, // v23 and later only
+    pub i2p: bool,
+    pub ipc: bool,
     pub leveldb: bool,
     pub libevent: bool,
     pub mempool: bool,
@@ -34,12 +34,12 @@ pub struct Logging {
     pub rand: bool,
     pub reindex: bool,
     pub rpc: bool,
-    pub scan: bool, // v25 and later only
+    pub scan: bool,
     pub selectcoins: bool,
     pub tor: bool,
-    pub txpackages: bool,       // v26 and later only
-    pub txreconciliation: bool, // v25 and later only
-    pub validation: bool,       // v23 and later only
-    pub walletdb: bool,         // v23 and later only
+    pub txpackages: bool,
+    pub txreconciliation: bool,
+    pub validation: bool,
+    pub walletdb: bool,
     pub zmq: bool,
 }

--- a/types/src/v28/network.rs
+++ b/types/src/v28/network.rs
@@ -26,7 +26,7 @@ pub struct GetNetworkInfo {
     /// The services we offer to the network (hex string).
     #[serde(rename = "localservices")]
     pub local_services: String,
-    /// The services we offer to the network. v0.19 and later only.
+    /// The services we offer to the network.
     #[serde(rename = "localservicesnames")]
     pub local_services_names: Vec<String>,
     /// `true` if transaction relay is requested from peers.
@@ -37,9 +37,9 @@ pub struct GetNetworkInfo {
     pub time_offset: isize,
     /// The total number of connections.
     pub connections: usize,
-    /// The number of inbound connections. v21 and later only.
+    /// The number of inbound connections.
     pub connections_in: usize,
-    /// The number of outbound connections. v21 and later only.
+    /// The number of outbound connections.
     pub connections_out: usize,
     /// Whether p2p networking is enabled.
     #[serde(rename = "networkactive")]

--- a/types/src/v28/wallet/mod.rs
+++ b/types/src/v28/wallet/mod.rs
@@ -217,14 +217,14 @@ pub struct GetTransaction {
     pub fee: Option<f64>,
     /// The number of confirmations.
     pub confirmations: i64,
-    /// Only present if the transaction's only input is a coinbase one. v20 and later only.
+    /// Only present if the transaction's only input is a coinbase one.
     pub generated: Option<bool>,
     /// Whether we consider the outputs of this unconfirmed transaction safe to spend.
     pub trusted: Option<bool>,
     /// The block hash.
     #[serde(rename = "blockhash")]
     pub block_hash: Option<String>,
-    /// The block height containing the transaction. v20 and later only.
+    /// The block height containing the transaction.
     #[serde(rename = "blockheight")]
     pub block_height: Option<i64>,
     /// The index of the transaction in the block that includes it.
@@ -235,43 +235,43 @@ pub struct GetTransaction {
     pub block_time: Option<u32>,
     /// The transaction id.
     pub txid: String,
-    /// The hash of serialized transaction, including witness data. v24 and later only.
+    /// The hash of serialized transaction, including witness data.
     pub wtxid: Option<String>,
     /// Confirmed transactions that have been detected by the wallet to conflict with this transaction.
     #[serde(rename = "walletconflicts")]
     pub wallet_conflicts: Vec<String>,
-    /// Only if 'category' is 'send'. The txid if this tx was replaced. v23 and later only.
+    /// Only if 'category' is 'send'. The txid if this tx was replaced.
     pub replaced_by_txid: Option<String>,
-    /// Only if 'category' is 'send'. The txid if this tx replaces another. v23 and later only.
+    /// Only if 'category' is 'send'. The txid if this tx replaces another.
     pub replaces_txid: Option<String>,
     /// Transactions in the mempool that directly conflict with either this transaction or an ancestor
-    /// transaction. v28 and later only.
+    /// transaction.
     #[serde(rename = "mempoolconflicts")]
     pub mempool_conflicts: Option<Vec<String>>,
-    /// If a comment to is associated with the transaction. v23 and later only.
+    /// If a comment to is associated with the transaction.
     pub to: Option<String>,
     /// The transaction time in seconds since epoch (1 Jan 1970 GMT).
     pub time: u32,
     /// The time received in seconds since epoch (1 Jan 1970 GMT).
     #[serde(rename = "timereceived")]
     pub time_received: u32,
-    /// If a comment is associated with the transaction, only present if not empty. v20 to v24 only.
+    /// If a comment is associated with the transaction, only present if not empty.
     pub comment: Option<String>,
     /// Whether this transaction could be replaced due to BIP125 (replace-by-fee);
     /// may be unknown for unconfirmed transactions not in the mempool.
     #[serde(rename = "bip125-replaceable")]
     pub bip125_replaceable: Bip125Replaceable,
     /// Only if 'category' is 'received'. List of parent descriptors for the output script of this
-    /// coin. v24 and later only.
+    /// coin.
     #[serde(rename = "parent_descs")]
     pub parent_descriptors: Option<Vec<String>>,
     /// Transaction details.
     pub details: Vec<GetTransactionDetail>,
     /// Raw data for transaction.
     pub hex: String,
-    /// The decoded transaction (only present when `verbose` is passed). v19 and later only.
+    /// The decoded transaction (only present when `verbose` is passed).
     pub decoded: Option<Transaction>,
-    /// Hash and height of the block this information was generated on. v26 and later only.
+    /// Hash and height of the block this information was generated on.
     #[serde(rename = "lastprocessedblock")]
     pub last_processed_block: Option<LastProcessedBlock>,
 }

--- a/types/src/v29/blockchain/mod.rs
+++ b/types/src/v29/blockchain/mod.rs
@@ -294,7 +294,7 @@ pub struct GetBlockchainInfo {
     pub target: String,
     /// The current difficulty.
     pub difficulty: f64,
-    /// The block time expressed in UNIX epoch time. v23 and later only.
+    /// The block time expressed in UNIX epoch time.
     pub time: i64,
     /// The median block time expressed in UNIX epoch time.
     #[serde(rename = "mediantime")]

--- a/types/src/v30/hidden/mod.rs
+++ b/types/src/v30/hidden/mod.rs
@@ -43,12 +43,10 @@ pub struct GetOrphanTxsVerboseOneEntry {
     pub vsize: u64,
     /// The transaction weight as defined in BIP 141.
     pub weight: u64,
-    /// The entry time into the orphanage expressed in UNIX epoch time
-    /// Only present in v29.
+    /// The entry time into the orphanage expressed in UNIX epoch time.
     #[serde(rename = "entry")]
     pub entry_time: Option<u32>,
-    /// The orphan expiration time expressed in UNIX epoch time
-    /// Only present in v29.
+    /// The orphan expiration time expressed in UNIX epoch time.
     #[serde(rename = "expiration")]
     pub expiration_time: Option<u32>,
     /// List of peer ids that we store this transaction for.
@@ -79,11 +77,9 @@ pub struct GetOrphanTxsVerboseTwoEntry {
     pub weight: u64,
     /// List of peer ids that we store this transaction for.
     pub from: Vec<u64>,
-    /// The entry time into the orphanage expressed in UNIX epoch time
-    /// Only present in v29.
+    /// The entry time into the orphanage expressed in UNIX epoch time.
     pub entry_time: Option<u32>,
-    /// The orphan expiration time expressed in UNIX epoch time
-    /// Only present in v29.
+    /// The orphan expiration time expressed in UNIX epoch time.
     pub expiration_time: Option<u32>,
     /// The serialized, hex-encoded transaction data.
     pub hex: String,


### PR DESCRIPTION
These comments are on types in model to explain the Option. The fields need not be commented in version specific types because if the field exists it exits.

Search through all of types, except for model/* and into.rs files. Remove all comments like `vXY and later only`.

Closes #512 