### PR TITLE
Model `merkle_root` as `TxMerkleNode`

### DIFF
--- a/types/src/model/blockchain.rs
+++ b/types/src/model/blockchain.rs
@@ -60,7 +60,7 @@ pub struct GetBlockVerboseOne {
     /// The block version.
     pub version: block::Version,
     /// The merkle root.
-    pub merkle_root: String,
+    pub merkle_root: TxMerkleNode,
     /// The transaction ids.
     pub tx: Vec<Txid>,
     /// The block time expressed in UNIX epoch time.
@@ -103,7 +103,7 @@ pub struct GetBlockVerboseTwo {
     /// The block version.
     pub version: block::Version,
     /// The merkle root.
-    pub merkle_root: String,
+    pub merkle_root: TxMerkleNode,
     /// The transactions.
     pub tx: Vec<GetBlockVerboseTwoTransaction>,
     /// The block time expressed in UNIX epoch time.
@@ -155,7 +155,7 @@ pub struct GetBlockVerboseThree {
     /// The block version.
     pub version: block::Version,
     /// The merkle root.
-    pub merkle_root: String,
+    pub merkle_root: TxMerkleNode,
     /// The transactions.
     pub tx: Vec<GetBlockVerboseThreeTransaction>,
     /// The block time expressed in UNIX epoch time.

--- a/types/src/v17/blockchain/error.rs
+++ b/types/src/v17/blockchain/error.rs
@@ -17,6 +17,8 @@ pub enum GetBlockVerboseOneError {
     Numeric(NumericError),
     /// Conversion of the transaction `hash` field failed.
     Hash(hex::HexToArrayError),
+    /// Conversion of the transaction `merkle_root` field failed.
+    MerkleRoot(hex::HexToArrayError),
     /// Conversion of the transaction `hex` field failed.
     Tx(encode::FromHexError),
     /// Conversion of the transaction `bits` field failed.
@@ -34,6 +36,8 @@ impl fmt::Display for GetBlockVerboseOneError {
         match *self {
             Self::Numeric(ref e) => write_err!(f, "numeric"; e),
             Self::Hash(ref e) => write_err!(f, "conversion of the `hash` field failed"; e),
+            Self::MerkleRoot(ref e) =>
+                write_err!(f, "conversion of the `merkle_root` field failed"; e),
             Self::Tx(ref e) => write_err!(f, "conversion of the `tx` field failed"; e),
             Self::Bits(ref e) => write_err!(f, "conversion of the `bits` field failed"; e),
             Self::ChainWork(ref e) =>
@@ -52,6 +56,7 @@ impl std::error::Error for GetBlockVerboseOneError {
         match *self {
             Self::Numeric(ref e) => Some(e),
             Self::Hash(ref e) => Some(e),
+            Self::MerkleRoot(ref e) => Some(e),
             Self::Tx(ref e) => Some(e),
             Self::Bits(ref e) => Some(e),
             Self::ChainWork(ref e) => Some(e),

--- a/types/src/v17/blockchain/into.rs
+++ b/types/src/v17/blockchain/into.rs
@@ -42,6 +42,7 @@ impl GetBlockVerboseOne {
             self.stripped_size.map(|size| crate::to_u32(size, "stripped_size")).transpose()?;
         let weight = Weight::from_wu(self.weight);
         let version = block::Version::from_consensus(self.version);
+        let merkle_root = self.merkle_root.parse::<TxMerkleNode>().map_err(E::MerkleRoot)?;
         let tx = self
             .tx
             .iter()
@@ -69,7 +70,7 @@ impl GetBlockVerboseOne {
             weight,
             height: crate::to_u32(self.height, "height")?,
             version,
-            merkle_root: self.merkle_root, // TODO: Use hash, which one depends on segwit or not.
+            merkle_root,
             tx,
             time: crate::to_u32(self.time, "time")?,
             median_time,

--- a/types/src/v29/blockchain/error.rs
+++ b/types/src/v29/blockchain/error.rs
@@ -19,6 +19,8 @@ pub enum GetBlockVerboseOneError {
     Numeric(NumericError),
     /// Conversion of the transaction `hash` field failed.
     Hash(hex::HexToArrayError),
+    /// Conversion of the transaction `merkle_root` field failed.
+    MerkleRoot(hex::HexToArrayError),
     /// Conversion of the transaction `hex` field failed.
     Tx(encode::FromHexError),
     /// Conversion of the transaction `bits` field failed.
@@ -38,6 +40,8 @@ impl fmt::Display for GetBlockVerboseOneError {
         match *self {
             Self::Numeric(ref e) => write_err!(f, "numeric"; e),
             Self::Hash(ref e) => write_err!(f, "conversion of the `hash` field failed"; e),
+            Self::MerkleRoot(ref e) =>
+                write_err!(f, "conversion of the `merkle_root` field failed"; e),
             Self::Tx(ref e) => write_err!(f, "conversion of the `tx` field failed"; e),
             Self::Bits(ref e) => write_err!(f, "conversion of the `bits` field failed"; e),
             Self::Target(ref e) => write_err!(f, "conversion of the `target` field failed"; e),
@@ -57,6 +61,7 @@ impl std::error::Error for GetBlockVerboseOneError {
         match *self {
             Self::Numeric(ref e) => Some(e),
             Self::Hash(ref e) => Some(e),
+            Self::MerkleRoot(ref e) => Some(e),
             Self::Tx(ref e) => Some(e),
             Self::Bits(ref e) => Some(e),
             Self::Target(ref e) => Some(e),
@@ -78,6 +83,8 @@ pub enum GetBlockVerboseTwoError {
     Numeric(NumericError),
     /// Conversion of the transaction `hash` field failed.
     Hash(hex::HexToArrayError),
+    /// Conversion of the transaction `merkle_root` field failed.
+    MerkleRoot(hex::HexToArrayError),
     /// Conversion of the transaction `bits` field failed.
     Bits(UnprefixedHexError),
     /// Conversion of the `target` field failed.
@@ -99,6 +106,8 @@ impl fmt::Display for GetBlockVerboseTwoError {
         match *self {
             Self::Numeric(ref e) => write_err!(f, "numeric"; e),
             Self::Hash(ref e) => write_err!(f, "conversion of the `hash` field failed"; e),
+            Self::MerkleRoot(ref e) =>
+                write_err!(f, "conversion of the `merkle_root` field failed"; e),
             Self::Bits(ref e) => write_err!(f, "conversion of the `bits` field failed"; e),
             Self::Target(ref e) => write_err!(f, "conversion of the `target` field failed"; e),
             Self::ChainWork(ref e) =>
@@ -120,6 +129,7 @@ impl std::error::Error for GetBlockVerboseTwoError {
         match *self {
             Self::Numeric(ref e) => Some(e),
             Self::Hash(ref e) => Some(e),
+            Self::MerkleRoot(ref e) => Some(e),
             Self::Bits(ref e) => Some(e),
             Self::Target(ref e) => Some(e),
             Self::ChainWork(ref e) => Some(e),
@@ -142,6 +152,8 @@ pub enum GetBlockVerboseThreeError {
     Numeric(NumericError),
     /// Conversion of the transaction `hash` field failed.
     Hash(hex::HexToArrayError),
+    /// Conversion of the transaction `merkle_root` field failed.
+    MerkleRoot(hex::HexToArrayError),
     /// Conversion of the transaction `bits` field failed.
     Bits(UnprefixedHexError),
     /// Conversion of the `target` field failed.
@@ -173,6 +185,8 @@ impl fmt::Display for GetBlockVerboseThreeError {
         match *self {
             Self::Numeric(ref e) => write_err!(f, "numeric"; e),
             Self::Hash(ref e) => write_err!(f, "conversion of the `hash` field failed"; e),
+            Self::MerkleRoot(ref e) =>
+                write_err!(f, "conversion of the `merkle_root` field failed"; e),
             Self::Bits(ref e) => write_err!(f, "conversion of the `bits` field failed"; e),
             Self::Target(ref e) => write_err!(f, "conversion of the `target` field failed"; e),
             Self::ChainWork(ref e) =>
@@ -204,6 +218,7 @@ impl std::error::Error for GetBlockVerboseThreeError {
         match *self {
             Self::Numeric(ref e) => Some(e),
             Self::Hash(ref e) => Some(e),
+            Self::MerkleRoot(ref e) => Some(e),
             Self::Bits(ref e) => Some(e),
             Self::Target(ref e) => Some(e),
             Self::ChainWork(ref e) => Some(e),

--- a/types/src/v29/blockchain/into.rs
+++ b/types/src/v29/blockchain/into.rs
@@ -23,6 +23,7 @@ impl GetBlockVerboseOne {
             self.stripped_size.map(|size| crate::to_u32(size, "stripped_size")).transpose()?;
         let weight = Weight::from_wu(self.weight);
         let version = block::Version::from_consensus(self.version);
+        let merkle_root = self.merkle_root.parse::<TxMerkleNode>().map_err(E::MerkleRoot)?;
         let tx = self
             .tx
             .iter()
@@ -51,7 +52,7 @@ impl GetBlockVerboseOne {
             weight,
             height: crate::to_u32(self.height, "height")?,
             version,
-            merkle_root: self.merkle_root, // TODO: Use hash, which one depends on segwit or not.
+            merkle_root,
             tx,
             time: crate::to_u32(self.time, "time")?,
             median_time,
@@ -77,6 +78,7 @@ impl GetBlockVerboseTwo {
             self.stripped_size.map(|size| crate::to_u32(size, "stripped_size")).transpose()?;
         let weight = Weight::from_wu(self.weight);
         let version = block::Version::from_consensus(self.version);
+        let merkle_root = self.merkle_root.parse::<TxMerkleNode>().map_err(E::MerkleRoot)?;
         let tx = self
             .tx
             .into_iter()
@@ -109,7 +111,7 @@ impl GetBlockVerboseTwo {
             weight,
             height: crate::to_u32(self.height, "height")?,
             version,
-            merkle_root: self.merkle_root, // TODO: Use hash, which one depends on segwit or not.
+            merkle_root,
             tx,
             time: crate::to_u32(self.time, "time")?,
             median_time,
@@ -202,6 +204,7 @@ impl GetBlockVerboseThree {
             self.stripped_size.map(|size| crate::to_u32(size, "stripped_size")).transpose()?;
         let weight = Weight::from_wu(self.weight);
         let version = block::Version::from_consensus(self.version);
+        let merkle_root = self.merkle_root.parse::<TxMerkleNode>().map_err(E::MerkleRoot)?;
         let tx = self
             .tx
             .into_iter()
@@ -234,7 +237,7 @@ impl GetBlockVerboseThree {
             weight,
             height: crate::to_u32(self.height, "height")?,
             version,
-            merkle_root: self.merkle_root, // TODO: Use hash, which one depends on segwit or not.
+            merkle_root,
             tx,
             time: crate::to_u32(self.time, "time")?,
             median_time,


### PR DESCRIPTION
Some of the modelled types used a `String` for `merkle_root`. But it has a rust-bitcoin type `TxMerkleNode`.

Change them all to `TxMerkleNode`, and update the `into_model()` functions.