### PR TITLE
Use consistent capitalization for (Script)PubKey

### DIFF
--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -174,11 +174,11 @@ pub fn compact_size_decode(slice: &mut &[u8]) -> u64 {
 ///
 /// This is used by methods in the blockchain section and in the raw transaction section (i.e raw
 /// transaction and psbt methods). The shape changed in Core v22 but the new shape is fully
-/// backwards compatible so we only provide it not a v0.17 specific type. The `mtype::ScriptPubkey`
+/// backwards compatible so we only provide it not a v0.17 specific type. The `mtype::ScriptPubKey`
 /// mirrors this design (but with concrete `rust-bitcoin` types).
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
-pub struct ScriptPubkey {
+pub struct ScriptPubKey {
     /// Script assembly.
     pub asm: String,
     /// Inferred descriptor for the output. v23 and later only.
@@ -204,9 +204,9 @@ pub struct ScriptPubkey {
     pub addresses: Option<Vec<String>>,
 }
 
-/// Error when converting a `ScriptPubkey` type into the model type.
+/// Error when converting a `ScriptPubKey` type into the model type.
 #[derive(Debug)]
-pub enum ScriptPubkeyError {
+pub enum ScriptPubKeyError {
     /// Conversion of the `hex` field failed.
     Hex(hex::HexToBytesError),
     /// Conversion of the `address` field failed.
@@ -215,7 +215,7 @@ pub enum ScriptPubkeyError {
     Addresses(address::ParseError),
 }
 
-impl fmt::Display for ScriptPubkeyError {
+impl fmt::Display for ScriptPubKeyError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Self::Hex(ref e) => write_err!(f, "conversion of the `hex` field failed"; e),
@@ -227,7 +227,7 @@ impl fmt::Display for ScriptPubkeyError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for ScriptPubkeyError {
+impl std::error::Error for ScriptPubKeyError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match *self {
             Self::Hex(ref e) => Some(e),
@@ -237,7 +237,7 @@ impl std::error::Error for ScriptPubkeyError {
     }
 }
 
-impl ScriptPubkey {
+impl ScriptPubKey {
     fn script_buf(&self) -> Result<ScriptBuf, hex::HexToBytesError> {
         ScriptBuf::from_hex(&self.hex)
     }
@@ -247,8 +247,8 @@ impl ScriptPubkey {
     }
 
     /// Converts version specific type to a version nonspecific, more strongly typed type.
-    pub fn into_model(self) -> Result<model::ScriptPubkey, ScriptPubkeyError> {
-        use ScriptPubkeyError as E;
+    pub fn into_model(self) -> Result<model::ScriptPubKey, ScriptPubKeyError> {
+        use ScriptPubKeyError as E;
 
         let script_pubkey = ScriptBuf::from_hex(&self.hex).map_err(E::Hex)?;
 
@@ -264,7 +264,7 @@ impl ScriptPubkey {
             })
             .transpose()?;
 
-        Ok(model::ScriptPubkey {
+        Ok(model::ScriptPubKey {
             script_pubkey,
             required_signatures: self.required_signatures,
             address,

--- a/types/src/model/blockchain.rs
+++ b/types/src/model/blockchain.rs
@@ -15,7 +15,7 @@ use bitcoin::{
 };
 use serde::{Deserialize, Serialize};
 
-use super::{GetRawTransactionVerbose, ScriptPubkey};
+use super::{GetRawTransactionVerbose, ScriptPubKey};
 
 /// Models the result of JSON-RPC method `dumptxoutset`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
@@ -202,7 +202,7 @@ pub struct GetBlockVerboseThreePrevout {
     /// The value in BTC.
     pub value: Amount,
     /// The script pubkey.
-    pub script_pubkey: ScriptPubkey,
+    pub script_pubkey: ScriptPubKey,
 }
 
 /// Models the result of JSON-RPC method `getblockchaininfo`.
@@ -636,7 +636,7 @@ pub struct SpendActivity {
     /// The vout of the prevout.
     pub prevout_vout: u32,
     /// The prev scriptPubKey.
-    pub prevout_spk: ScriptPubkey,
+    pub prevout_spk: ScriptPubKey,
 }
 
 /// Models a 'receive' activity event. Part of `getdescriptoractivity`
@@ -653,7 +653,7 @@ pub struct ReceiveActivity {
     /// The vout of the receiving output.
     pub vout: u32,
     /// The ScriptPubKey.
-    pub output_spk: ScriptPubkey,
+    pub output_spk: ScriptPubKey,
 }
 
 /// Models the result of JSON-RPC method `getdifficulty`.

--- a/types/src/model/mod.rs
+++ b/types/src/model/mod.rs
@@ -85,7 +85,7 @@ pub use self::{
 /// transaction and psbt methods).
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
-pub struct ScriptPubkey {
+pub struct ScriptPubKey {
     /// The script_pubkey parsed from hex.
     pub script_pubkey: ScriptBuf,
     /// Number of required signatures - deprecated in Core v22.

--- a/types/src/model/raw_transactions.rs
+++ b/types/src/model/raw_transactions.rs
@@ -91,7 +91,7 @@ pub struct DecodeRawTransaction(pub Transaction);
 /// Models the result of JSON-RPC method `decodescript`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct DecodeScript {
-    /// The `scriptPubkey`.
+    /// The `scriptPubKey`.
     pub script_pubkey: Option<ScriptBuf>,
     /// Inferred descriptor for the script. v23 and later only.
     pub descriptor: Option<String>,

--- a/types/src/model/wallet.rs
+++ b/types/src/model/wallet.rs
@@ -171,10 +171,10 @@ pub struct GetAddressInfo {
 pub enum ScriptType {
     /// Non-standard output script type.
     NonStandard,
-    /// Pubkey output script.
-    Pubkey,
-    /// Pubkey hash output script.
-    PubkeyHash,
+    /// PubKey output script.
+    PubKey,
+    /// PubKey hash output script.
+    PubKeyHash,
     /// Script hash output script.
     ScriptHash,
     /// Multisig output script.

--- a/types/src/psbt/error.rs
+++ b/types/src/psbt/error.rs
@@ -92,14 +92,14 @@ pub enum RawTransactionOutputError {
     /// Conversion of the output `value` field failed.
     Value(amount::ParseAmountError),
     /// Conversion of the output `script_pubkey` field failed.
-    ScriptPubkey(hex::HexToBytesError),
+    ScriptPubKey(hex::HexToBytesError),
 }
 
 impl fmt::Display for RawTransactionOutputError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Self::Value(ref e) => write_err!(f, "conversion of the output `value` field failed"; e),
-            Self::ScriptPubkey(ref e) =>
+            Self::ScriptPubKey(ref e) =>
                 write_err!(f, "conversion of the output `script_pubkey` field failed"; e),
         }
     }
@@ -110,7 +110,7 @@ impl std::error::Error for RawTransactionOutputError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match *self {
             Self::Value(ref e) => Some(e),
-            Self::ScriptPubkey(ref e) => Some(e),
+            Self::ScriptPubKey(ref e) => Some(e),
         }
     }
 }
@@ -121,14 +121,14 @@ pub enum WitnessUtxoError {
     /// Conversion of the `amount` field failed.
     Amount(ParseAmountError),
     /// Conversion of the `script_pubkey` field failed.
-    ScriptPubkey(hex::HexToBytesError),
+    ScriptPubKey(hex::HexToBytesError),
 }
 
 impl fmt::Display for WitnessUtxoError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Self::Amount(ref e) => write_err!(f, "conversion of the `amount` field failed"; e),
-            Self::ScriptPubkey(ref e) =>
+            Self::ScriptPubKey(ref e) =>
                 write_err!(f, "conversion of the `script_pubkey` field failed"; e),
         }
     }
@@ -139,7 +139,7 @@ impl std::error::Error for WitnessUtxoError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match *self {
             Self::Amount(ref e) => Some(e),
-            Self::ScriptPubkey(ref e) => Some(e),
+            Self::ScriptPubKey(ref e) => Some(e),
         }
     }
 }
@@ -178,7 +178,7 @@ impl std::error::Error for PartialSignatureError {
 #[derive(Debug)]
 pub enum Bip32DerivError {
     /// Conversion of the pubkey failed.
-    Pubkey(key::ParsePublicKeyError),
+    PubKey(key::ParsePublicKeyError),
     /// Conversion of the `master_fingerprint` field failed.
     MasterFingerprint(hex::HexToArrayError),
     /// Conversion of the `path` field failed.
@@ -188,7 +188,7 @@ pub enum Bip32DerivError {
 impl fmt::Display for Bip32DerivError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Self::Pubkey(ref e) => write_err!(f, "conversion of the pubkey failed"; e),
+            Self::PubKey(ref e) => write_err!(f, "conversion of the pubkey failed"; e),
             Self::MasterFingerprint(ref e) =>
                 write_err!(f, "conversion of the `master_fingerprint` field failed"; e),
             Self::Path(ref e) => write_err!(f, "conversion of the `path` field failed"; e),
@@ -200,7 +200,7 @@ impl fmt::Display for Bip32DerivError {
 impl std::error::Error for Bip32DerivError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match *self {
-            Self::Pubkey(ref e) => Some(e),
+            Self::PubKey(ref e) => Some(e),
             Self::MasterFingerprint(ref e) => Some(e),
             Self::Path(ref e) => Some(e),
         }

--- a/types/src/psbt/mod.rs
+++ b/types/src/psbt/mod.rs
@@ -15,7 +15,7 @@ pub use self::error::{
     Bip32DerivError, PartialSignatureError, RawTransactionError, RawTransactionInputError,
     RawTransactionOutputError, WitnessUtxoError,
 };
-use crate::{ScriptPubkey, ScriptSig};
+use crate::{ScriptPubKey, ScriptSig};
 
 /// Represents a bitcoin transaction.
 ///
@@ -147,7 +147,7 @@ pub struct RawTransactionOutput {
     pub index: u64,
     /// The script pubkey.
     #[serde(rename = "scriptPubKey")]
-    pub script_pubkey: ScriptPubkey,
+    pub script_pubkey: ScriptPubKey,
 }
 
 impl RawTransactionOutput {
@@ -156,7 +156,7 @@ impl RawTransactionOutput {
         use RawTransactionOutputError as E;
 
         let value = Amount::from_btc(self.value).map_err(E::Value)?;
-        let script_pubkey = self.script_pubkey.script_buf().map_err(E::ScriptPubkey)?;
+        let script_pubkey = self.script_pubkey.script_buf().map_err(E::ScriptPubKey)?;
 
         Ok(TxOut { value, script_pubkey })
     }
@@ -171,7 +171,7 @@ pub struct WitnessUtxo {
     pub amount: f64,
     /// The scriptPubKey.
     #[serde(rename = "scriptPubKey")]
-    pub script_pubkey: ScriptPubkey,
+    pub script_pubkey: ScriptPubKey,
 }
 
 impl WitnessUtxo {
@@ -180,7 +180,7 @@ impl WitnessUtxo {
         use WitnessUtxoError as E;
 
         let value = Amount::from_btc(self.amount).map_err(E::Amount)?;
-        let script_pubkey = self.script_pubkey.script_buf().map_err(E::ScriptPubkey)?;
+        let script_pubkey = self.script_pubkey.script_buf().map_err(E::ScriptPubKey)?;
 
         Ok(TxOut { value, script_pubkey })
     }
@@ -295,7 +295,7 @@ pub fn map_into_bip32_derivation(
 
     let mut map = BTreeMap::default();
     for (k, v) in hash_map.iter() {
-        let pubkey = k.parse::<PublicKey>().map_err(E::Pubkey)?;
+        let pubkey = k.parse::<PublicKey>().map_err(E::PubKey)?;
         let fingerprint =
             Fingerprint::from_hex(&v.master_fingerprint).map_err(E::MasterFingerprint)?;
         let path = v.path.parse::<DerivationPath>().map_err(E::Path)?;
@@ -314,7 +314,7 @@ pub fn vec_into_bip32_derivation(
 
     let mut map = BTreeMap::default();
     for deriv in v.iter() {
-        let pubkey = deriv.pubkey.parse::<PublicKey>().map_err(E::Pubkey)?;
+        let pubkey = deriv.pubkey.parse::<PublicKey>().map_err(E::PubKey)?;
         let fingerprint =
             Fingerprint::from_hex(&deriv.master_fingerprint).map_err(E::MasterFingerprint)?;
         let path = deriv.path.parse::<DerivationPath>().map_err(E::Path)?;

--- a/types/src/v17/blockchain/error.rs
+++ b/types/src/v17/blockchain/error.rs
@@ -438,7 +438,7 @@ impl From<ParseAmountError> for GetMempoolInfoError {
 /// Error when converting a `GetTxOut` type into the model type.
 ///
 /// Note that variants in this type are not named in the usual fashion. The `ScriptBuf` and
-/// `Address` variants are named after the functions on [`crate::ScriptPubkey`].
+/// `Address` variants are named after the functions on [`crate::ScriptPubKey`].
 #[derive(Debug)]
 pub enum GetTxOutError {
     /// Conversion of numeric type to expected type failed.
@@ -447,9 +447,9 @@ pub enum GetTxOutError {
     BestBlock(hex::HexToArrayError),
     /// Conversion of the transaction `value` field failed.
     Value(amount::ParseAmountError),
-    /// Conversion of the `ScriptPubkey` hex to a `ScriptBuf` failed.
+    /// Conversion of the `ScriptPubKey` hex to a `ScriptBuf` failed.
     ScriptBuf(hex::HexToBytesError),
-    /// Conversion of the `ScriptPubkey` `address` field failed.
+    /// Conversion of the `ScriptPubKey` `address` field failed.
     Address(address::ParseError),
 }
 
@@ -461,9 +461,9 @@ impl fmt::Display for GetTxOutError {
                 write_err!(f, "conversion of the `beast_block` field failed"; e),
             Self::Value(ref e) => write_err!(f, "conversion of the `value` field failed"; e),
             Self::ScriptBuf(ref e) =>
-                write_err!(f, "conversion of the `ScriptPubkey` hex to a `ScriptBuf` failed"; e),
+                write_err!(f, "conversion of the `ScriptPubKey` hex to a `ScriptBuf` failed"; e),
             Self::Address(ref e) =>
-                write_err!(f, "conversion of the `ScriptPubkey` `address` field failed"; e),
+                write_err!(f, "conversion of the `ScriptPubKey` `address` field failed"; e),
         }
     }
 }

--- a/types/src/v17/blockchain/mod.rs
+++ b/types/src/v17/blockchain/mod.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 
 // TODO: Remove wildcard, use explicit types.
 pub use self::error::*;
-use crate::{model, ScriptPubkey};
+use crate::{model, ScriptPubKey};
 
 /// Result of JSON-RPC method `getbestblockhash`.
 ///
@@ -628,7 +628,7 @@ pub struct GetTxOut {
     pub value: f64,
     /// The script pubkey.
     #[serde(rename = "scriptPubKey")]
-    pub script_pubkey: ScriptPubkey,
+    pub script_pubkey: ScriptPubKey,
     /// Coinbase or not.
     pub coinbase: bool,
 }

--- a/types/src/v17/util/error.rs
+++ b/types/src/v17/util/error.rs
@@ -40,7 +40,7 @@ pub enum ValidateAddressError {
     /// Conversion of the `address` field failed.
     Address(address::ParseError),
     /// Conversion of the `script_pubkey` field failed.
-    ScriptPubkey(hex::HexToBytesError),
+    ScriptPubKey(hex::HexToBytesError),
     /// The `witness_version` field's value was too big for a u8.
     WitnessVersionValue(i64),
     /// Conversion of the `witness_version` field failed.
@@ -55,7 +55,7 @@ impl fmt::Display for ValidateAddressError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Self::Address(ref e) => write!(f, "conversion of the `address` field failed: {}", e),
-            Self::ScriptPubkey(ref e) =>
+            Self::ScriptPubKey(ref e) =>
                 write!(f, "conversion of the `script_pubkey` field failed: {}", e),
             Self::WitnessVersionValue(v) => write!(f, "invalid witness version number: {}", v),
             Self::WitnessVersion(ref e) =>
@@ -76,7 +76,7 @@ impl std::error::Error for ValidateAddressError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match *self {
             Self::Address(ref e) => Some(e),
-            Self::ScriptPubkey(ref e) => Some(e),
+            Self::ScriptPubKey(ref e) => Some(e),
             Self::WitnessVersionValue(_) => None,
             Self::WitnessVersion(ref e) => Some(e),
             Self::WitnessProgramBytes(ref e) => Some(e),

--- a/types/src/v17/util/into.rs
+++ b/types/src/v17/util/into.rs
@@ -48,7 +48,7 @@ impl ValidateAddress {
         use ValidateAddressError as E;
 
         let address = self.address.parse::<Address<_>>().map_err(E::Address)?;
-        let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubkey)?;
+        let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubKey)?;
         let (witness_version, witness_program) = match (self.witness_version, self.witness_program)
         {
             (Some(v), Some(hex)) => {

--- a/types/src/v17/wallet/error.rs
+++ b/types/src/v17/wallet/error.rs
@@ -80,7 +80,7 @@ pub enum GetAddressInfoError {
     /// Conversion of the `address` field failed.
     Address(address::ParseError),
     /// Conversion of the `script_pubkey` field failed.
-    ScriptPubkey(hex::HexToBytesError),
+    ScriptPubKey(hex::HexToBytesError),
     /// The `witness_version` field's value was too big for a u8.
     WitnessVersionValue(i64),
     /// Conversion of the `witness_version` field failed.
@@ -92,9 +92,9 @@ pub enum GetAddressInfoError {
     /// Conversion of the `hex` field failed.
     Hex(hex::HexToBytesError),
     /// Conversion of the `pubkeys` field failed.
-    Pubkeys(key::ParsePublicKeyError),
+    PubKeys(key::ParsePublicKeyError),
     /// Conversion of the `pubkey` field failed.
-    Pubkey(key::ParsePublicKeyError),
+    PubKey(key::ParsePublicKeyError),
     /// Conversion of the `embedded` field failed.
     Embedded(GetAddressInfoEmbeddedError),
     /// Conversion of the `hd_key_path` field failed.
@@ -108,7 +108,7 @@ impl fmt::Display for GetAddressInfoError {
         match *self {
             Self::Numeric(ref e) => write_err!(f, "numeric"; e),
             Self::Address(ref e) => write_err!(f, "conversion of the `address` field failed"; e),
-            Self::ScriptPubkey(ref e) =>
+            Self::ScriptPubKey(ref e) =>
                 write_err!(f, "conversion of the `script_pubkey` field failed"; e),
             Self::WitnessVersionValue(v) => write!(f, "invalid witness version number: {}", v),
             Self::WitnessVersion(ref e) =>
@@ -118,8 +118,8 @@ impl fmt::Display for GetAddressInfoError {
             Self::WitnessProgram(ref e) =>
                 write_err!(f, "conversion of the `witness_program` field failed"; e),
             Self::Hex(ref e) => write_err!(f, "conversion of the `hex` field failed"; e),
-            Self::Pubkeys(ref e) => write_err!(f, "conversion of the `pubkeys` field failed"; e),
-            Self::Pubkey(ref e) => write_err!(f, "conversion of the `pubkey` failed"; e),
+            Self::PubKeys(ref e) => write_err!(f, "conversion of the `pubkeys` field failed"; e),
+            Self::PubKey(ref e) => write_err!(f, "conversion of the `pubkey` failed"; e),
             Self::Embedded(ref e) => write_err!(f, "conversion of the `embedded` field failed"; e),
             Self::HdKeyPath(ref e) =>
                 write_err!(f, "conversion of the `hd_key_path` field failed"; e),
@@ -135,14 +135,14 @@ impl std::error::Error for GetAddressInfoError {
         match *self {
             Self::Numeric(ref e) => Some(e),
             Self::Address(ref e) => Some(e),
-            Self::ScriptPubkey(ref e) => Some(e),
+            Self::ScriptPubKey(ref e) => Some(e),
             Self::WitnessVersionValue(_) => None,
             Self::WitnessVersion(ref e) => Some(e),
             Self::WitnessProgramBytes(ref e) => Some(e),
             Self::WitnessProgram(ref e) => Some(e),
             Self::Hex(ref e) => Some(e),
-            Self::Pubkeys(ref e) => Some(e),
-            Self::Pubkey(ref e) => Some(e),
+            Self::PubKeys(ref e) => Some(e),
+            Self::PubKey(ref e) => Some(e),
             Self::Embedded(ref e) => Some(e),
             Self::HdKeyPath(ref e) => Some(e),
             Self::HdSeedId(ref e) => Some(e),
@@ -162,7 +162,7 @@ pub enum GetAddressInfoEmbeddedError {
     /// Conversion of the `address` field failed.
     Address(address::ParseError),
     /// Conversion of the `script_pubkey` field failed.
-    ScriptPubkey(hex::HexToBytesError),
+    ScriptPubKey(hex::HexToBytesError),
     /// The `witness_version` field's value was too big for a u8.
     WitnessVersionValue(i64),
     /// Conversion of the `witness_version` field failed.
@@ -174,9 +174,9 @@ pub enum GetAddressInfoEmbeddedError {
     /// Conversion of the `hex` field failed.
     Hex(hex::HexToBytesError),
     /// Conversion of the `pubkeys` field failed.
-    Pubkeys(key::ParsePublicKeyError),
+    PubKeys(key::ParsePublicKeyError),
     /// Conversion of the `pubkey` field failed.
-    Pubkey(key::ParsePublicKeyError),
+    PubKey(key::ParsePublicKeyError),
 }
 
 impl fmt::Display for GetAddressInfoEmbeddedError {
@@ -184,7 +184,7 @@ impl fmt::Display for GetAddressInfoEmbeddedError {
         match *self {
             Self::Numeric(ref e) => write_err!(f, "numeric"; e),
             Self::Address(ref e) => write_err!(f, "conversion of the `address` field failed"; e),
-            Self::ScriptPubkey(ref e) =>
+            Self::ScriptPubKey(ref e) =>
                 write_err!(f, "conversion of the `script_pubkey` field failed"; e),
             Self::WitnessVersionValue(v) => write!(f, "invalid witness version number: {}", v),
             Self::WitnessVersion(ref e) =>
@@ -194,8 +194,8 @@ impl fmt::Display for GetAddressInfoEmbeddedError {
             Self::WitnessProgram(ref e) =>
                 write_err!(f, "conversion of the `witness_program` field failed"; e),
             Self::Hex(ref e) => write_err!(f, "conversion of the `hex` field failed"; e),
-            Self::Pubkeys(ref e) => write_err!(f, "conversion of the `pubkeys` field failed"; e),
-            Self::Pubkey(ref e) => write_err!(f, "conversion of the `pubkey` failed"; e),
+            Self::PubKeys(ref e) => write_err!(f, "conversion of the `pubkeys` field failed"; e),
+            Self::PubKey(ref e) => write_err!(f, "conversion of the `pubkey` failed"; e),
         }
     }
 }
@@ -206,14 +206,14 @@ impl std::error::Error for GetAddressInfoEmbeddedError {
         match *self {
             Self::Numeric(ref e) => Some(e),
             Self::Address(ref e) => Some(e),
-            Self::ScriptPubkey(ref e) => Some(e),
+            Self::ScriptPubKey(ref e) => Some(e),
             Self::WitnessVersionValue(_) => None,
             Self::WitnessVersion(ref e) => Some(e),
             Self::WitnessProgramBytes(ref e) => Some(e),
             Self::WitnessProgram(ref e) => Some(e),
             Self::Hex(ref e) => Some(e),
-            Self::Pubkeys(ref e) => Some(e),
-            Self::Pubkey(ref e) => Some(e),
+            Self::PubKeys(ref e) => Some(e),
+            Self::PubKey(ref e) => Some(e),
         }
     }
 }
@@ -550,7 +550,7 @@ pub enum ListUnspentItemError {
     /// Conversion of the `address` field failed.
     Address(address::ParseError),
     /// Conversion of the `script_pubkey` field failed.
-    ScriptPubkey(hex::HexToBytesError),
+    ScriptPubKey(hex::HexToBytesError),
     /// Conversion of the `amount` field failed.
     Amount(ParseAmountError),
     /// Conversion of the `redeem_script` field failed.
@@ -565,7 +565,7 @@ impl fmt::Display for ListUnspentItemError {
             Self::Numeric(ref e) => write_err!(f, "numeric"; e),
             Self::Txid(ref e) => write_err!(f, "conversion of the `txid` field failed"; e),
             Self::Address(ref e) => write_err!(f, "conversion of the `address` field failed"; e),
-            Self::ScriptPubkey(ref e) =>
+            Self::ScriptPubKey(ref e) =>
                 write_err!(f, "conversion of the `script_pubkey` field failed"; e),
             Self::Amount(ref e) => write_err!(f, "conversion of the `amount` field failed"; e),
             Self::RedeemScript(ref e) =>
@@ -582,7 +582,7 @@ impl std::error::Error for ListUnspentItemError {
             Self::Numeric(ref e) => Some(e),
             Self::Txid(ref e) => Some(e),
             Self::Address(ref e) => Some(e),
-            Self::ScriptPubkey(ref e) => Some(e),
+            Self::ScriptPubKey(ref e) => Some(e),
             Self::Amount(ref e) => Some(e),
             Self::RedeemScript(ref e) => Some(e),
             Self::Fee(ref e) => Some(e),

--- a/types/src/v17/wallet/into.rs
+++ b/types/src/v17/wallet/into.rs
@@ -131,7 +131,7 @@ impl GetAddressInfo {
         use GetAddressInfoError as E;
 
         let address = self.address.parse::<Address<_>>().map_err(E::Address)?;
-        let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubkey)?;
+        let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubKey)?;
         let (witness_version, witness_program) = match (self.witness_version, self.witness_program)
         {
             (Some(v), Some(hex)) => {
@@ -159,12 +159,12 @@ impl GetAddressInfo {
                     .iter()
                     .map(|s| s.parse::<PublicKey>())
                     .collect::<Result<Vec<_>, _>>()
-                    .map_err(E::Pubkeys)
+                    .map_err(E::PubKeys)
             })
             .transpose()?;
         let sigs_required =
             self.sigs_required.map(|s| crate::to_u32(s, "sigs_required")).transpose()?;
-        let pubkey = self.pubkey.map(|s| s.parse::<PublicKey>()).transpose().map_err(E::Pubkey)?;
+        let pubkey = self.pubkey.map(|s| s.parse::<PublicKey>()).transpose().map_err(E::PubKey)?;
         let embedded =
             self.embedded.map(|embedded| embedded.into_model()).transpose().map_err(E::Embedded)?;
         let hd_key_path = self
@@ -214,8 +214,8 @@ impl ScriptType {
 
         match self {
             V::NonStandard => M::NonStandard,
-            V::Pubkey => M::Pubkey,
-            V::PubkeyHash => M::PubkeyHash,
+            V::PubKey => M::PubKey,
+            V::PubKeyHash => M::PubKeyHash,
             V::ScriptHash => M::ScriptHash,
             V::Multisig => M::Multisig,
             V::NullData => M::NullData,
@@ -232,7 +232,7 @@ impl GetAddressInfoEmbedded {
         use GetAddressInfoEmbeddedError as E;
 
         let address = self.address.parse::<Address<_>>().map_err(E::Address)?;
-        let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubkey)?;
+        let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubKey)?;
         let (witness_version, witness_program) = match (self.witness_version, self.witness_program)
         {
             (Some(v), Some(hex)) => {
@@ -256,7 +256,7 @@ impl GetAddressInfoEmbedded {
         let pubkeys = None;
         let sigs_required =
             self.sigs_required.map(|s| crate::to_u32(s, "sigs_required")).transpose()?;
-        let pubkey = self.pubkey.map(|s| s.parse::<PublicKey>()).transpose().map_err(E::Pubkey)?;
+        let pubkey = self.pubkey.map(|s| s.parse::<PublicKey>()).transpose().map_err(E::PubKey)?;
         let labels = self.labels.map(|labels| labels.into_iter().map(|label| label.name).collect());
 
         Ok(model::GetAddressInfoEmbedded {
@@ -658,7 +658,7 @@ impl ListUnspentItem {
         let txid = self.txid.parse::<Txid>().map_err(E::Txid)?;
         let vout = crate::to_u32(self.vout, "vout")?;
         let address = self.address.parse::<Address<_>>().map_err(E::Address)?;
-        let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubkey)?;
+        let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubKey)?;
 
         let amount = Amount::from_btc(self.amount).map_err(E::Amount)?;
         let confirmations = crate::to_u32(self.confirmations, "confirmations")?;

--- a/types/src/v17/wallet/mod.rs
+++ b/types/src/v17/wallet/mod.rs
@@ -263,12 +263,12 @@ pub enum ScriptType {
     /// Non-standard output script type.
     #[serde(rename = "nonstandard")]
     NonStandard,
-    /// Pubkey output script.
+    /// PubKey output script.
     #[serde(rename = "pubkey")]
-    Pubkey,
-    /// Pubkey hash output script.
+    PubKey,
+    /// PubKey hash output script.
     #[serde(rename = "pubkeyhash")]
-    PubkeyHash,
+    PubKeyHash,
     /// Script hash output script.
     #[serde(rename = "scripthash")]
     ScriptHash,

--- a/types/src/v18/raw_transactions/error.rs
+++ b/types/src/v18/raw_transactions/error.rs
@@ -44,7 +44,7 @@ impl std::error::Error for AnalyzePsbtError {
 #[derive(Debug)]
 pub enum AnalyzePsbtInputMissingError {
     /// Conversion of the `pubkeys` field failed.
-    Pubkeys(hex::HexToArrayError),
+    PubKeys(hex::HexToArrayError),
     /// Conversion of the `signatures` field failed.
     Signatures(hex::HexToArrayError),
     /// Conversion of the `RedeemScript` field failed.
@@ -56,7 +56,7 @@ pub enum AnalyzePsbtInputMissingError {
 impl fmt::Display for AnalyzePsbtInputMissingError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Self::Pubkeys(ref e) => write_err!(f, "conversion of the `pubkeys` field failed"; e),
+            Self::PubKeys(ref e) => write_err!(f, "conversion of the `pubkeys` field failed"; e),
             Self::Signatures(ref e) =>
                 write_err!(f, "conversion of the `signatures` field failed"; e),
             Self::RedeemScript(ref e) =>
@@ -71,7 +71,7 @@ impl fmt::Display for AnalyzePsbtInputMissingError {
 impl std::error::Error for AnalyzePsbtInputMissingError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match *self {
-            Self::Pubkeys(ref e) => Some(e),
+            Self::PubKeys(ref e) => Some(e),
             Self::Signatures(ref e) => Some(e),
             Self::RedeemScript(ref e) => Some(e),
             Self::WitnessScript(ref e) => Some(e),

--- a/types/src/v18/raw_transactions/into.rs
+++ b/types/src/v18/raw_transactions/into.rs
@@ -65,7 +65,7 @@ impl AnalyzePsbtInputMissing {
                 .iter()
                 .map(|s| s.parse::<hash160::Hash>())
                 .collect::<Result<_, _>>()
-                .map_err(E::Pubkeys)?,
+                .map_err(E::PubKeys)?,
             None => vec![],
         };
         let signatures = match self.signatures {

--- a/types/src/v18/wallet/error.rs
+++ b/types/src/v18/wallet/error.rs
@@ -17,7 +17,7 @@ pub enum GetAddressInfoError {
     /// Conversion of the `address` field failed.
     Address(address::ParseError),
     /// Conversion of the `script_pubkey` field failed.
-    ScriptPubkey(hex::HexToBytesError),
+    ScriptPubKey(hex::HexToBytesError),
     /// The `witness_version` field's value was too big for a u8.
     WitnessVersionValue(i64),
     /// Conversion of the `witness_version` field failed.
@@ -29,9 +29,9 @@ pub enum GetAddressInfoError {
     /// Conversion of the `hex` field failed.
     Hex(hex::HexToBytesError),
     /// Conversion of the `pubkeys` field failed.
-    Pubkeys(key::ParsePublicKeyError),
+    PubKeys(key::ParsePublicKeyError),
     /// Conversion of the `pubkey` field failed.
-    Pubkey(key::ParsePublicKeyError),
+    PubKey(key::ParsePublicKeyError),
     /// Conversion of the `embedded` field failed.
     Embedded(GetAddressInfoEmbeddedError),
     /// Conversion of the `hd_key_path` field failed.
@@ -47,7 +47,7 @@ impl fmt::Display for GetAddressInfoError {
         match *self {
             Self::Numeric(ref e) => write_err!(f, "numeric"; e),
             Self::Address(ref e) => write_err!(f, "conversion of the `address` field failed"; e),
-            Self::ScriptPubkey(ref e) =>
+            Self::ScriptPubKey(ref e) =>
                 write_err!(f, "conversion of the `script_pubkey` field failed"; e),
             Self::WitnessVersionValue(v) => write!(f, "invalid witness version number: {}", v),
             Self::WitnessVersion(ref e) =>
@@ -57,8 +57,8 @@ impl fmt::Display for GetAddressInfoError {
             Self::WitnessProgram(ref e) =>
                 write_err!(f, "conversion of the `witness_program` field failed"; e),
             Self::Hex(ref e) => write_err!(f, "conversion of the `hex` field failed"; e),
-            Self::Pubkeys(ref e) => write_err!(f, "conversion of the `pubkeys` field failed"; e),
-            Self::Pubkey(ref e) => write_err!(f, "conversion of the `pubkey` failed"; e),
+            Self::PubKeys(ref e) => write_err!(f, "conversion of the `pubkeys` field failed"; e),
+            Self::PubKey(ref e) => write_err!(f, "conversion of the `pubkey` failed"; e),
             Self::Embedded(ref e) => write_err!(f, "conversion of the `embedded` field failed"; e),
             Self::HdKeyPath(ref e) =>
                 write_err!(f, "conversion of the `hd_key_path` field failed"; e),
@@ -76,14 +76,14 @@ impl std::error::Error for GetAddressInfoError {
         match *self {
             Self::Numeric(ref e) => Some(e),
             Self::Address(ref e) => Some(e),
-            Self::ScriptPubkey(ref e) => Some(e),
+            Self::ScriptPubKey(ref e) => Some(e),
             Self::WitnessVersionValue(_) => None,
             Self::WitnessVersion(ref e) => Some(e),
             Self::WitnessProgramBytes(ref e) => Some(e),
             Self::WitnessProgram(ref e) => Some(e),
             Self::Hex(ref e) => Some(e),
-            Self::Pubkeys(ref e) => Some(e),
-            Self::Pubkey(ref e) => Some(e),
+            Self::PubKeys(ref e) => Some(e),
+            Self::PubKey(ref e) => Some(e),
             Self::Embedded(ref e) => Some(e),
             Self::HdKeyPath(ref e) => Some(e),
             Self::HdSeedId(ref e) => Some(e),

--- a/types/src/v18/wallet/into.rs
+++ b/types/src/v18/wallet/into.rs
@@ -21,7 +21,7 @@ impl GetAddressInfo {
         use GetAddressInfoError as E;
 
         let address = self.address.parse::<Address<_>>().map_err(E::Address)?;
-        let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubkey)?;
+        let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubKey)?;
         let (witness_version, witness_program) = match (self.witness_version, self.witness_program)
         {
             (Some(v), Some(hex)) => {
@@ -49,12 +49,12 @@ impl GetAddressInfo {
                     .iter()
                     .map(|s| s.parse::<PublicKey>())
                     .collect::<Result<Vec<_>, _>>()
-                    .map_err(E::Pubkeys)
+                    .map_err(E::PubKeys)
             })
             .transpose()?;
         let sigs_required =
             self.sigs_required.map(|s| crate::to_u32(s, "sigs_required")).transpose()?;
-        let pubkey = self.pubkey.map(|s| s.parse::<PublicKey>()).transpose().map_err(E::Pubkey)?;
+        let pubkey = self.pubkey.map(|s| s.parse::<PublicKey>()).transpose().map_err(E::PubKey)?;
         let embedded =
             self.embedded.map(|embedded| embedded.into_model()).transpose().map_err(E::Embedded)?;
         let hd_key_path = self
@@ -107,7 +107,7 @@ impl GetAddressInfoEmbedded {
         use GetAddressInfoEmbeddedError as E;
 
         let address = self.address.parse::<Address<_>>().map_err(E::Address)?;
-        let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubkey)?;
+        let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubKey)?;
         let (witness_version, witness_program) = match (self.witness_version, self.witness_program)
         {
             (Some(v), Some(hex)) => {
@@ -131,7 +131,7 @@ impl GetAddressInfoEmbedded {
         let pubkeys = None;
         let sigs_required =
             self.sigs_required.map(|s| crate::to_u32(s, "sigs_required")).transpose()?;
-        let pubkey = self.pubkey.map(|s| s.parse::<PublicKey>()).transpose().map_err(E::Pubkey)?;
+        let pubkey = self.pubkey.map(|s| s.parse::<PublicKey>()).transpose().map_err(E::PubKey)?;
         let labels = self.labels.map(|labels| labels.into_iter().map(|label| label.name).collect());
 
         Ok(model::GetAddressInfoEmbedded {
@@ -300,7 +300,7 @@ impl ListUnspentItem {
         let txid = self.txid.parse::<Txid>().map_err(E::Txid)?;
         let vout = crate::to_u32(self.vout, "vout")?;
         let address = self.address.parse::<Address<_>>().map_err(E::Address)?;
-        let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubkey)?;
+        let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubKey)?;
 
         let amount = Amount::from_btc(self.amount).map_err(E::Amount)?;
         let confirmations = crate::to_u32(self.confirmations, "confirmations")?;

--- a/types/src/v20/wallet/into.rs
+++ b/types/src/v20/wallet/into.rs
@@ -39,7 +39,7 @@ impl GetAddressInfo {
         use GetAddressInfoError as E;
 
         let address = self.address.parse::<Address<_>>().map_err(E::Address)?;
-        let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubkey)?;
+        let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubKey)?;
         let (witness_version, witness_program) = match (self.witness_version, self.witness_program)
         {
             (Some(v), Some(hex)) => {
@@ -67,12 +67,12 @@ impl GetAddressInfo {
                     .iter()
                     .map(|s| s.parse::<PublicKey>())
                     .collect::<Result<Vec<_>, _>>()
-                    .map_err(E::Pubkeys)
+                    .map_err(E::PubKeys)
             })
             .transpose()?;
         let sigs_required =
             self.sigs_required.map(|s| crate::to_u32(s, "sigs_required")).transpose()?;
-        let pubkey = self.pubkey.map(|s| s.parse::<PublicKey>()).transpose().map_err(E::Pubkey)?;
+        let pubkey = self.pubkey.map(|s| s.parse::<PublicKey>()).transpose().map_err(E::PubKey)?;
         let embedded =
             self.embedded.map(|embedded| embedded.into_model()).transpose().map_err(E::Embedded)?;
         let hd_key_path = self
@@ -124,7 +124,7 @@ impl GetAddressInfoEmbedded {
         use GetAddressInfoEmbeddedError as E;
 
         let address = self.address.parse::<Address<_>>().map_err(E::Address)?;
-        let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubkey)?;
+        let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubKey)?;
         let (witness_version, witness_program) = match (self.witness_version, self.witness_program)
         {
             (Some(v), Some(hex)) => {
@@ -148,7 +148,7 @@ impl GetAddressInfoEmbedded {
         let pubkeys = None;
         let sigs_required =
             self.sigs_required.map(|s| crate::to_u32(s, "sigs_required")).transpose()?;
-        let pubkey = self.pubkey.map(|s| s.parse::<PublicKey>()).transpose().map_err(E::Pubkey)?;
+        let pubkey = self.pubkey.map(|s| s.parse::<PublicKey>()).transpose().map_err(E::PubKey)?;
 
         Ok(model::GetAddressInfoEmbedded {
             address,

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -331,5 +331,5 @@ pub use crate::{
         Send, SendError, SendMany, SendManyVerbose, Softfork, SoftforkType, UnloadWallet,
         UpgradeWallet,
     },
-    ScriptPubkey,
+    ScriptPubKey,
 };

--- a/types/src/v22/wallet/into.rs
+++ b/types/src/v22/wallet/into.rs
@@ -17,7 +17,7 @@ impl GetAddressInfo {
         use GetAddressInfoError as E;
 
         let address = self.address.parse::<Address<_>>().map_err(E::Address)?;
-        let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubkey)?;
+        let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubKey)?;
         let (witness_version, witness_program) = match (self.witness_version, self.witness_program)
         {
             (Some(v), Some(hex)) => {
@@ -45,12 +45,12 @@ impl GetAddressInfo {
                     .iter()
                     .map(|s| s.parse::<PublicKey>())
                     .collect::<Result<Vec<_>, _>>()
-                    .map_err(E::Pubkeys)
+                    .map_err(E::PubKeys)
             })
             .transpose()?;
         let sigs_required =
             self.sigs_required.map(|s| crate::to_u32(s, "sigs_required")).transpose()?;
-        let pubkey = self.pubkey.map(|s| s.parse::<PublicKey>()).transpose().map_err(E::Pubkey)?;
+        let pubkey = self.pubkey.map(|s| s.parse::<PublicKey>()).transpose().map_err(E::PubKey)?;
         let embedded =
             self.embedded.map(|embedded| embedded.into_model()).transpose().map_err(E::Embedded)?;
         let hd_key_path = self
@@ -102,7 +102,7 @@ impl GetAddressInfoEmbedded {
         use GetAddressInfoEmbeddedError as E;
 
         let address = self.address.parse::<Address<_>>().map_err(E::Address)?;
-        let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubkey)?;
+        let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubKey)?;
         let (witness_version, witness_program) = match (self.witness_version, self.witness_program)
         {
             (Some(v), Some(hex)) => {
@@ -126,7 +126,7 @@ impl GetAddressInfoEmbedded {
         let pubkeys = None;
         let sigs_required =
             self.sigs_required.map(|s| crate::to_u32(s, "sigs_required")).transpose()?;
-        let pubkey = self.pubkey.map(|s| s.parse::<PublicKey>()).transpose().map_err(E::Pubkey)?;
+        let pubkey = self.pubkey.map(|s| s.parse::<PublicKey>()).transpose().map_err(E::PubKey)?;
 
         Ok(model::GetAddressInfoEmbedded {
             address,

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -325,6 +325,6 @@ pub use crate::{
         AddConnection, Banned, DescriptorInfo, EnumerateSigners, GetAddressInfo,
         GetAddressInfoEmbedded, GetMempoolInfo, GetNodeAddresses, ListBanned, ListDescriptors,
         MempoolAcceptance, MempoolAcceptanceError, MempoolAcceptanceFees, NodeAddress,
-        ScriptPubkey, Signers, TestMempoolAccept, TestMempoolAcceptError, WalletDisplayAddress,
+        ScriptPubKey, Signers, TestMempoolAccept, TestMempoolAcceptError, WalletDisplayAddress,
     },
 };

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -324,7 +324,7 @@ pub use crate::{
     v22::{
         AddConnection, Banned, DescriptorInfo, EnumerateSigners, GetAddressInfo,
         GetAddressInfoEmbedded, GetNodeAddresses, ListBanned, ListDescriptors, MempoolAcceptance,
-        MempoolAcceptanceError, MempoolAcceptanceFees, NodeAddress, ScriptPubkey, Signers,
+        MempoolAcceptanceError, MempoolAcceptanceFees, NodeAddress, ScriptPubKey, Signers,
         TestMempoolAccept, TestMempoolAcceptError, WalletDisplayAddress,
     },
     v23::{

--- a/types/src/v24/raw_transactions/error.rs
+++ b/types/src/v24/raw_transactions/error.rs
@@ -296,7 +296,7 @@ impl std::error::Error for PsbtOutputError {
 #[derive(Debug)]
 pub enum TaprootScriptPathSigError {
     /// Conversion of the `pubkey` field failed.
-    Pubkey(secp256k1::Error),
+    PubKey(secp256k1::Error),
     /// Conversion of the `leaf_hash` field failed.
     LeafHash(hex::HexToArrayError),
     /// Conversion of the `sig` field failed.
@@ -306,7 +306,7 @@ pub enum TaprootScriptPathSigError {
 impl fmt::Display for TaprootScriptPathSigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Self::Pubkey(ref e) => write_err!(f, "conversion of the `pubkey` field failed"; e),
+            Self::PubKey(ref e) => write_err!(f, "conversion of the `pubkey` field failed"; e),
             Self::LeafHash(ref e) => write_err!(f, "conversion of the `leaf_hash` field failed"; e),
             Self::Sig(ref e) => write_err!(f, "conversion of the `sig` field failed"; e),
         }
@@ -317,7 +317,7 @@ impl fmt::Display for TaprootScriptPathSigError {
 impl std::error::Error for TaprootScriptPathSigError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match *self {
-            Self::Pubkey(ref e) => Some(e),
+            Self::PubKey(ref e) => Some(e),
             Self::LeafHash(ref e) => Some(e),
             Self::Sig(ref e) => Some(e),
         }
@@ -398,7 +398,7 @@ impl std::error::Error for ControlBlocksError {
 #[derive(Debug)]
 pub enum TaprootBip32DerivsError {
     /// Conversion of the `pubkey` field failed.
-    Pubkey(secp256k1::Error),
+    PubKey(secp256k1::Error),
     /// Conversion of the `master_fingerprint` field failed.
     MasterFingerprint(hex::HexToArrayError),
     /// Conversion of the `path` field failed.
@@ -410,7 +410,7 @@ pub enum TaprootBip32DerivsError {
 impl fmt::Display for TaprootBip32DerivsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Self::Pubkey(ref e) => write_err!(f, "conversion of the `pubkey` field failed"; e),
+            Self::PubKey(ref e) => write_err!(f, "conversion of the `pubkey` field failed"; e),
             Self::MasterFingerprint(ref e) =>
                 write_err!(f, "conversion of the `master_fingerprint` field failed"; e),
             Self::Path(ref e) => write_err!(f, "conversion of the `path` field failed"; e),
@@ -424,7 +424,7 @@ impl fmt::Display for TaprootBip32DerivsError {
 impl std::error::Error for TaprootBip32DerivsError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match *self {
-            Self::Pubkey(ref e) => Some(e),
+            Self::PubKey(ref e) => Some(e),
             Self::MasterFingerprint(ref e) => Some(e),
             Self::Path(ref e) => Some(e),
             Self::LeafHashes(ref e) => Some(e),

--- a/types/src/v24/raw_transactions/into.rs
+++ b/types/src/v24/raw_transactions/into.rs
@@ -380,7 +380,7 @@ impl TaprootScriptPathSig {
     {
         use TaprootScriptPathSigError as E;
 
-        let pubkey = self.pubkey.parse::<XOnlyPublicKey>().map_err(E::Pubkey)?;
+        let pubkey = self.pubkey.parse::<XOnlyPublicKey>().map_err(E::PubKey)?;
         let hash = self.leaf_hash.parse::<TapLeafHash>().map_err(E::LeafHash)?;
         let sig = super::taproot::signature_from_str(&self.sig).map_err(E::Sig)?;
 
@@ -429,7 +429,7 @@ impl TaprootBip32Deriv {
     ) -> Result<(XOnlyPublicKey, (Vec<TapLeafHash>, KeySource)), TaprootBip32DerivsError> {
         use TaprootBip32DerivsError as E;
 
-        let pubkey = self.pubkey.parse::<XOnlyPublicKey>().map_err(E::Pubkey)?;
+        let pubkey = self.pubkey.parse::<XOnlyPublicKey>().map_err(E::PubKey)?;
         let fp = Fingerprint::from_hex(&self.master_fingerprint).map_err(E::MasterFingerprint)?;
         let path = self.path.parse::<DerivationPath>().map_err(E::Path)?;
         let hashes = self

--- a/types/src/v24/wallet/into.rs
+++ b/types/src/v24/wallet/into.rs
@@ -219,7 +219,7 @@ impl ListUnspentItem {
         let txid = self.txid.parse::<Txid>().map_err(E::Txid)?;
         let vout = crate::to_u32(self.vout, "vout")?;
         let address = self.address.parse::<Address<_>>().map_err(E::Address)?;
-        let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubkey)?;
+        let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubKey)?;
         let label = self.label.unwrap_or_default();
 
         let amount = Amount::from_btc(self.amount).map_err(E::Amount)?;

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -317,7 +317,7 @@ pub use crate::{
     },
     v22::{
         AddConnection, Banned, EnumerateSigners, GetAddressInfo, GetAddressInfoEmbedded,
-        GetNodeAddresses, ListBanned, NodeAddress, ScriptPubkey, Signers, WalletDisplayAddress,
+        GetNodeAddresses, ListBanned, NodeAddress, ScriptPubKey, Signers, WalletDisplayAddress,
     },
     v23::{
         AddMultisigAddress, Bip9Info, Bip9Statistics, CreateMultisig, DecodeScript,

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -334,7 +334,7 @@ pub use crate::{
     },
     v22::{
         AddConnection, Banned, EnumerateSigners, GetAddressInfo, GetAddressInfoEmbedded,
-        GetNodeAddresses, ListBanned, NodeAddress, ScriptPubkey, Signers, WalletDisplayAddress,
+        GetNodeAddresses, ListBanned, NodeAddress, ScriptPubKey, Signers, WalletDisplayAddress,
     },
     v23::{
         AddMultisigAddress, Bip9Info, Bip9Statistics, CreateMultisig, DecodeScript,

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -307,7 +307,7 @@ pub use crate::{
     },
     v22::{
         AddConnection, Banned, EnumerateSigners, GetAddressInfo, GetAddressInfoEmbedded,
-        GetNodeAddresses, ListBanned, NodeAddress, ScriptPubkey, Signers, WalletDisplayAddress,
+        GetNodeAddresses, ListBanned, NodeAddress, ScriptPubKey, Signers, WalletDisplayAddress,
     },
     v23::{
         AddMultisigAddress, Bip9Info, Bip9Statistics, CreateMultisig, DecodeScript,

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -330,7 +330,7 @@ pub use crate::{
     },
     v22::{
         AddConnection, Banned, EnumerateSigners, GetNodeAddresses, ListBanned, NodeAddress,
-        ScriptPubkey, Signers, WalletDisplayAddress,
+        ScriptPubKey, Signers, WalletDisplayAddress,
     },
     v23::{
         AddMultisigAddress, Bip9Info, Bip9Statistics, CreateMultisig, DecodeScript,

--- a/types/src/v28/wallet/into.rs
+++ b/types/src/v28/wallet/into.rs
@@ -22,7 +22,7 @@ impl GetAddressInfo {
         use GetAddressInfoError as E;
 
         let address = self.address.parse::<Address<_>>().map_err(E::Address)?;
-        let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubkey)?;
+        let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubKey)?;
         let (witness_version, witness_program) = match (self.witness_version, self.witness_program)
         {
             (Some(v), Some(hex)) => {
@@ -50,12 +50,12 @@ impl GetAddressInfo {
                     .iter()
                     .map(|s| s.parse::<PublicKey>())
                     .collect::<Result<Vec<_>, _>>()
-                    .map_err(E::Pubkeys)
+                    .map_err(E::PubKeys)
             })
             .transpose()?;
         let sigs_required =
             self.sigs_required.map(|s| crate::to_u32(s, "sigs_required")).transpose()?;
-        let pubkey = self.pubkey.map(|s| s.parse::<PublicKey>()).transpose().map_err(E::Pubkey)?;
+        let pubkey = self.pubkey.map(|s| s.parse::<PublicKey>()).transpose().map_err(E::PubKey)?;
         let embedded =
             self.embedded.map(|embedded| embedded.into_model()).transpose().map_err(E::Embedded)?;
         let hd_key_path = self
@@ -107,7 +107,7 @@ impl GetAddressInfoEmbedded {
         use GetAddressInfoEmbeddedError as E;
 
         let address = self.address.parse::<Address<_>>().map_err(E::Address)?;
-        let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubkey)?;
+        let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubKey)?;
         let (witness_version, witness_program) = match (self.witness_version, self.witness_program)
         {
             (Some(v), Some(hex)) => {
@@ -131,7 +131,7 @@ impl GetAddressInfoEmbedded {
         let pubkeys = None;
         let sigs_required =
             self.sigs_required.map(|s| crate::to_u32(s, "sigs_required")).transpose()?;
-        let pubkey = self.pubkey.map(|s| s.parse::<PublicKey>()).transpose().map_err(E::Pubkey)?;
+        let pubkey = self.pubkey.map(|s| s.parse::<PublicKey>()).transpose().map_err(E::PubKey)?;
 
         Ok(model::GetAddressInfoEmbedded {
             address,

--- a/types/src/v29/blockchain/error.rs
+++ b/types/src/v29/blockchain/error.rs
@@ -10,7 +10,7 @@ use bitcoin::{address, amount, hex, network};
 use crate::error::write_err;
 use crate::psbt::{RawTransactionInputError, RawTransactionOutputError};
 use crate::v17::GetRawTransactionVerboseError;
-use crate::{NumericError, ScriptPubkeyError};
+use crate::{NumericError, ScriptPubKeyError};
 
 /// Error when converting a `GetBlockVerboseOne` type into the model type.
 #[derive(Debug)]
@@ -165,7 +165,7 @@ pub enum GetBlockVerboseThreeError {
     /// Conversion of a prevout value failed.
     PrevoutValue(amount::ParseAmountError),
     /// Conversion of a prevout script_pubkey failed.
-    PrevoutScriptPubkey(ScriptPubkeyError),
+    PrevoutScriptPubKey(ScriptPubKeyError),
 }
 
 impl fmt::Display for GetBlockVerboseThreeError {
@@ -192,7 +192,7 @@ impl fmt::Display for GetBlockVerboseThreeError {
                 write_err!(f, "conversion of a prevout `height` field failed"; e),
             Self::PrevoutValue(ref e) =>
                 write_err!(f, "conversion of a prevout `value` field failed"; e),
-            Self::PrevoutScriptPubkey(ref e) =>
+            Self::PrevoutScriptPubKey(ref e) =>
                 write_err!(f, "conversion of a prevout `script_pubkey` field failed"; e),
         }
     }
@@ -215,7 +215,7 @@ impl std::error::Error for GetBlockVerboseThreeError {
             Self::Fee(ref e) => Some(e),
             Self::PrevoutHeight(ref e) => Some(e),
             Self::PrevoutValue(ref e) => Some(e),
-            Self::PrevoutScriptPubkey(ref e) => Some(e),
+            Self::PrevoutScriptPubKey(ref e) => Some(e),
         }
     }
 }
@@ -440,9 +440,9 @@ pub enum GetDescriptorActivityError {
     /// if the inner errors are distinct enough, but can be helpful.
     ActivityEntry(Box<GetDescriptorActivityError>), // Use Box to avoid recursive type size issues
     /// Conversion of the `prevout_spk` field failed.
-    PrevoutSpk(ScriptPubkeyError),
+    PrevoutSpk(ScriptPubKeyError),
     /// Conversion of the `output_spk` field failed.
-    OutputSpk(ScriptPubkeyError),
+    OutputSpk(ScriptPubKeyError),
 }
 
 impl fmt::Display for GetDescriptorActivityError {

--- a/types/src/v29/blockchain/into.rs
+++ b/types/src/v29/blockchain/into.rs
@@ -147,7 +147,7 @@ impl GetRawTransactionVerboseWithPrevout {
                         .map_err(E::PrevoutHeight)?;
                     let value = Amount::from_btc(prevout.value).map_err(E::PrevoutValue)?;
                     let script_pubkey =
-                        prevout.script_pubkey.into_model().map_err(E::PrevoutScriptPubkey)?;
+                        prevout.script_pubkey.into_model().map_err(E::PrevoutScriptPubKey)?;
                     Ok::<model::GetBlockVerboseThreePrevout, GetBlockVerboseThreeError>(
                         model::GetBlockVerboseThreePrevout {
                             generated: prevout.generated,

--- a/types/src/v29/blockchain/mod.rs
+++ b/types/src/v29/blockchain/mod.rs
@@ -15,7 +15,7 @@ pub use self::error::{
 };
 use crate::psbt::{RawTransactionInput, RawTransactionOutput};
 use crate::v17::GetRawTransactionVerbose;
-use crate::{model, ScriptPubkey};
+use crate::{model, ScriptPubKey};
 
 /// Result of JSON-RPC method `getblock` with verbosity set to 1.
 #[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
@@ -266,7 +266,7 @@ pub struct GetBlockVerboseThreePrevout {
     pub value: f64,
     /// The script pubkey.
     #[serde(rename = "scriptPubKey")]
-    pub script_pubkey: ScriptPubkey,
+    pub script_pubkey: ScriptPubKey,
 }
 
 /// Result of JSON-RPC method `getblockchaininfo`.
@@ -473,7 +473,7 @@ pub struct SpendActivity {
     /// The vout of the spend.
     pub prevout_vout: u32,
     /// The prev scriptPubKey.
-    pub prevout_spk: ScriptPubkey,
+    pub prevout_spk: ScriptPubKey,
 }
 
 /// Represents a 'receive' activity event. Part of `getdescriptoractivity`.
@@ -495,5 +495,5 @@ pub struct ReceiveActivity {
     /// The vout of the receiving output.
     pub vout: u32,
     /// The ScriptPubKey.
-    pub output_spk: ScriptPubkey,
+    pub output_spk: ScriptPubKey,
 }

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -332,7 +332,7 @@ pub use crate::{
     },
     v22::{
         AddConnection, Banned, EnumerateSigners, GetNodeAddresses, ListBanned, NodeAddress,
-        ScriptPubkey, Signers, WalletDisplayAddress,
+        ScriptPubKey, Signers, WalletDisplayAddress,
     },
     v23::{
         AddMultisigAddress, Bip9Info, Bip9Statistics, CreateMultisig, DecodeScript,

--- a/types/src/v30/mod.rs
+++ b/types/src/v30/mod.rs
@@ -259,7 +259,7 @@ pub use self::{
     mining::{GetMiningInfo, GetMiningInfoError},
     raw_transactions::{
         ControlBlocksError, DecodePsbt, DecodePsbtError, GlobalXpub, GlobalXpubError,
-        Musig2PartialSig, Musig2ParticipantPubkeys, Musig2Pubnonce, Proprietary, PsbtInput,
+        Musig2PartialSig, Musig2ParticipantPubKeys, Musig2Pubnonce, Proprietary, PsbtInput,
         PsbtInputError, PsbtOutput, PsbtOutputError, TaprootBip32Deriv, TaprootBip32DerivsError,
         TaprootLeaf, TaprootLeafError, TaprootScript, TaprootScriptError, TaprootScriptPathSig,
         TaprootScriptPathSigError,
@@ -321,7 +321,7 @@ pub use crate::{
     },
     v22::{
         AddConnection, Banned, EnumerateSigners, GetNodeAddresses, ListBanned, NodeAddress,
-        ScriptPubkey, Signers, WalletDisplayAddress,
+        ScriptPubKey, Signers, WalletDisplayAddress,
     },
     v23::{
         Bip9Info, Bip9Statistics, CreateMultisig, DecodeScript, DecodeScriptError,

--- a/types/src/v30/raw_transactions/error.rs
+++ b/types/src/v30/raw_transactions/error.rs
@@ -296,7 +296,7 @@ impl std::error::Error for PsbtOutputError {
 #[derive(Debug)]
 pub enum TaprootScriptPathSigError {
     /// Conversion of the `pubkey` field failed.
-    Pubkey(secp256k1::Error),
+    PubKey(secp256k1::Error),
     /// Conversion of the `leaf_hash` field failed.
     LeafHash(hex::HexToArrayError),
     /// Conversion of the `sig` field failed.
@@ -306,7 +306,7 @@ pub enum TaprootScriptPathSigError {
 impl fmt::Display for TaprootScriptPathSigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Self::Pubkey(ref e) => write_err!(f, "conversion of the `pubkey` field failed"; e),
+            Self::PubKey(ref e) => write_err!(f, "conversion of the `pubkey` field failed"; e),
             Self::LeafHash(ref e) => write_err!(f, "conversion of the `leaf_hash` field failed"; e),
             Self::Sig(ref e) => write_err!(f, "conversion of the `sig` field failed"; e),
         }
@@ -317,7 +317,7 @@ impl fmt::Display for TaprootScriptPathSigError {
 impl std::error::Error for TaprootScriptPathSigError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match *self {
-            Self::Pubkey(ref e) => Some(e),
+            Self::PubKey(ref e) => Some(e),
             Self::LeafHash(ref e) => Some(e),
             Self::Sig(ref e) => Some(e),
         }
@@ -398,7 +398,7 @@ impl std::error::Error for ControlBlocksError {
 #[derive(Debug)]
 pub enum TaprootBip32DerivsError {
     /// Conversion of the `pubkey` field failed.
-    Pubkey(secp256k1::Error),
+    PubKey(secp256k1::Error),
     /// Conversion of the `master_fingerprint` field failed.
     MasterFingerprint(hex::HexToArrayError),
     /// Conversion of the `path` field failed.
@@ -410,7 +410,7 @@ pub enum TaprootBip32DerivsError {
 impl fmt::Display for TaprootBip32DerivsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Self::Pubkey(ref e) => write_err!(f, "conversion of the `pubkey` field failed"; e),
+            Self::PubKey(ref e) => write_err!(f, "conversion of the `pubkey` field failed"; e),
             Self::MasterFingerprint(ref e) =>
                 write_err!(f, "conversion of the `master_fingerprint` field failed"; e),
             Self::Path(ref e) => write_err!(f, "conversion of the `path` field failed"; e),
@@ -424,7 +424,7 @@ impl fmt::Display for TaprootBip32DerivsError {
 impl std::error::Error for TaprootBip32DerivsError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match *self {
-            Self::Pubkey(ref e) => Some(e),
+            Self::PubKey(ref e) => Some(e),
             Self::MasterFingerprint(ref e) => Some(e),
             Self::Path(ref e) => Some(e),
             Self::LeafHashes(ref e) => Some(e),

--- a/types/src/v30/raw_transactions/into.rs
+++ b/types/src/v30/raw_transactions/into.rs
@@ -380,7 +380,7 @@ impl TaprootScriptPathSig {
     {
         use TaprootScriptPathSigError as E;
 
-        let pubkey = self.pubkey.parse::<XOnlyPublicKey>().map_err(E::Pubkey)?;
+        let pubkey = self.pubkey.parse::<XOnlyPublicKey>().map_err(E::PubKey)?;
         let hash = self.leaf_hash.parse::<TapLeafHash>().map_err(E::LeafHash)?;
         let sig = super::taproot::signature_from_str(&self.sig).map_err(E::Sig)?;
 
@@ -429,7 +429,7 @@ impl TaprootBip32Deriv {
     ) -> Result<(XOnlyPublicKey, (Vec<TapLeafHash>, KeySource)), TaprootBip32DerivsError> {
         use TaprootBip32DerivsError as E;
 
-        let pubkey = self.pubkey.parse::<XOnlyPublicKey>().map_err(E::Pubkey)?;
+        let pubkey = self.pubkey.parse::<XOnlyPublicKey>().map_err(E::PubKey)?;
         let fp = Fingerprint::from_hex(&self.master_fingerprint).map_err(E::MasterFingerprint)?;
         let path = self.path.parse::<DerivationPath>().map_err(E::Path)?;
         let hashes = self

--- a/types/src/v30/raw_transactions/mod.rs
+++ b/types/src/v30/raw_transactions/mod.rs
@@ -124,7 +124,7 @@ pub struct PsbtInput {
     /// The hex-encoded Taproot merkle root.
     pub taproot_merkle_root: Option<String>,
     /// MuSig2 participant public keys.
-    pub musig2_participant_pubkeys: Option<Vec<Musig2ParticipantPubkeys>>,
+    pub musig2_participant_pubkeys: Option<Vec<Musig2ParticipantPubKeys>>,
     /// MuSig2 public nonces.
     pub musig2_pubnonces: Option<Vec<Musig2Pubnonce>>,
     /// MuSig2 partial signatures.
@@ -152,7 +152,7 @@ pub struct PsbtOutput {
     /// BIP32 derivation paths for keys.
     pub taproot_bip32_derivs: Option<Vec<TaprootBip32Deriv>>,
     /// MuSig2 participant public keys.
-    pub musig2_participant_pubkeys: Option<Vec<Musig2ParticipantPubkeys>>,
+    pub musig2_participant_pubkeys: Option<Vec<Musig2ParticipantPubKeys>>,
     /// The output proprietary map.
     pub proprietary: Option<Vec<Proprietary>>,
     /// The unknown global fields.
@@ -214,7 +214,7 @@ pub struct TaprootLeaf {
 /// MuSig2 participant public keys. Part of `decodepsbt`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[cfg_attr(feature = "serde-deny-unknown-fields", serde(deny_unknown_fields))]
-pub struct Musig2ParticipantPubkeys {
+pub struct Musig2ParticipantPubKeys {
     /// The compressed aggregate public key for which the participants create.
     pub aggregate_pubkey: String,
     /// The compressed public keys that are aggregated for aggregate_pubkey.


### PR DESCRIPTION
The capitalization of key in pubkey and scriptpubkey is inconsistent. Core uses a capital K in e.g. scriptPubKey in gettxout, and a capital K is more common in rust-bitcoin.

Search the whole codebase for "Pubkey" and change them all to "PubKey". No changes made where the p is lowercase.

Closes #371