### PR TITLE
Bitreq: Deps: bump `rustls` to version 0.23

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -173,7 +173,7 @@ dependencies = [
  "proptest",
  "rustls",
  "rustls-native-certs",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "serde",
  "serde_json",
  "tiny_http",
@@ -808,13 +808,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
- "ring",
- "rustls-webpki",
- "sct",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki 0.103.10",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -839,12 +841,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -861,16 +883,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -993,6 +1005,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1093,9 +1111,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
@@ -1349,6 +1367,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zip"

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -173,7 +173,7 @@ dependencies = [
  "proptest",
  "rustls",
  "rustls-native-certs",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "serde",
  "serde_json",
  "tiny_http",
@@ -808,13 +808,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
- "ring",
- "rustls-webpki",
- "sct",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki 0.103.10",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -839,12 +841,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -861,16 +883,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -993,6 +1005,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1093,9 +1111,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
@@ -1349,6 +1367,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zip"

--- a/bitreq/Cargo.toml
+++ b/bitreq/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = { version = "1.0.0", default-features = false, features = ["std"], 
 base64 = { version = "0.22", default-features = false, features = ["alloc"], optional = true }
 
 # For rustls-based TLS:
-rustls = { version = "0.23.37", default-features = false, optional = true }
+rustls = { version = "0.23.37", default-features = false, features = ["ring", "std"], optional = true }
 rustls-native-certs = { version = "0.6.1", default-features = false, optional = true }
 webpki-roots = { version = "0.25.2", default-features = false, optional = true }
 rustls-webpki = { version = "0.101.0", default-features = false, optional = true }

--- a/bitreq/Cargo.toml
+++ b/bitreq/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = { version = "1.0.0", default-features = false, features = ["std"], 
 base64 = { version = "0.22", default-features = false, features = ["alloc"], optional = true }
 
 # For rustls-based TLS:
-rustls = { version = "0.21.1", default-features = false, optional = true }
+rustls = { version = "0.23.37", default-features = false, optional = true }
 rustls-native-certs = { version = "0.6.1", default-features = false, optional = true }
 webpki-roots = { version = "0.25.2", default-features = false, optional = true }
 rustls-webpki = { version = "0.101.0", default-features = false, optional = true }
@@ -31,7 +31,7 @@ native-tls = { version = "0.2", default-features = false, optional = true }
 
 # For the async feature:
 tokio = { version = "1.0", default-features = false, features = ["rt", "net", "io-util", "time", "sync"], optional = true }
-tokio-rustls = { version = "0.24", default-features = false, optional = true }
+tokio-rustls = { version = "0.26", default-features = false, optional = true }
 tokio-native-tls = { version = "0.3", default-features = false, optional = true }
 
 log = { version = "0.4.0", default-features = false, optional = true }

--- a/bitreq/src/connection/rustls_stream.rs
+++ b/bitreq/src/connection/rustls_stream.rs
@@ -12,7 +12,11 @@ use std::sync::OnceLock;
 #[cfg(all(feature = "native-tls", not(feature = "rustls")))]
 use native_tls::{HandshakeError, TlsConnector, TlsStream};
 #[cfg(feature = "rustls")]
-use rustls::{self, ClientConfig, ClientConnection, RootCertStore, ServerName, StreamOwned};
+use rustls::{
+    self,
+    pki_types::{ServerName, TrustAnchor},
+    ClientConfig, ClientConnection, RootCertStore, StreamOwned,
+};
 #[cfg(all(feature = "native-tls", not(feature = "rustls"), feature = "tokio-native-tls"))]
 use tokio_native_tls::TlsConnector as AsyncTlsConnector;
 #[cfg(feature = "tokio-rustls")]
@@ -42,24 +46,19 @@ fn build_client_config() -> Arc<ClientConfig> {
         for root_cert in os_roots {
             // Ignore erroneous OS certificates, there's nothing
             // to do differently in that situation anyways.
-            let _ = root_certificates.add(&rustls::Certificate(root_cert.0));
+            let _ = root_certificates.add(root_cert.0.into());
         }
     }
 
     #[cfg(feature = "rustls-webpki")]
-    #[allow(deprecated)] // Need to use add_server_trust_anchors to compile with rustls 0.21.1
-    root_certificates.add_server_trust_anchors(TLS_SERVER_ROOTS.iter().map(|ta| {
-        rustls::OwnedTrustAnchor::from_subject_spki_name_constraints(
-            ta.subject,
-            ta.spki,
-            ta.name_constraints,
-        )
+    root_certificates.extend(TLS_SERVER_ROOTS.iter().map(|ta| TrustAnchor {
+        subject: ta.subject.into(),
+        subject_public_key_info: ta.spki.into(),
+        name_constraints: ta.name_constraints.map(Into::into),
     }));
 
-    let config = ClientConfig::builder()
-        .with_safe_defaults()
-        .with_root_certificates(root_certificates)
-        .with_no_client_auth();
+    let config =
+        ClientConfig::builder().with_root_certificates(root_certificates).with_no_client_auth();
     Arc::new(config)
 }
 
@@ -71,8 +70,9 @@ pub(super) fn wrap_stream(tcp: TcpStream, host: &str) -> Result<SecuredStream, E
         Ok(result) => result,
         Err(err) => return Err(Error::IoError(io::Error::new(io::ErrorKind::Other, err))),
     };
-    let sess = ClientConnection::new(CONFIG.get_or_init(build_client_config).clone(), dns_name)
-        .map_err(Error::RustlsCreateConnection)?;
+    let sess =
+        ClientConnection::new(CONFIG.get_or_init(build_client_config).clone(), dns_name.to_owned())
+            .map_err(Error::RustlsCreateConnection)?;
 
     #[cfg(feature = "log")]
     log::trace!("Establishing TLS session to {host}.");
@@ -101,7 +101,7 @@ pub(super) async fn wrap_async_stream(
     #[cfg(feature = "log")]
     log::trace!("Establishing TLS session to {host}.");
 
-    let tls = connector.connect(dns_name, tcp).await.map_err(Error::IoError)?;
+    let tls = connector.connect(dns_name.to_owned(), tcp).await.map_err(Error::IoError)?;
 
     Ok(AsyncHttpStream::Secured(Box::new(tls)))
 }


### PR DESCRIPTION
This PR bumps `bitreq`'s rustls version to 0.23, mainly to allow dependents to ship with newer versions of rustls without pulling separate versions.