### PR TITLE
Test walletdisplayaddress

### DIFF
--- a/client/src/client_sync/v22/mod.rs
+++ b/client/src/client_sync/v22/mod.rs
@@ -144,6 +144,7 @@ crate::impl_client_v17__add_multisig_address!();
 crate::impl_client_v17__backup_wallet!();
 crate::impl_client_v17__bump_fee!();
 crate::impl_client_v21__create_wallet!();
+crate::impl_client_v22__create_wallet!();
 crate::impl_client_v17__dump_priv_key!();
 crate::impl_client_v17__dump_wallet!();
 crate::impl_client_v17__encrypt_wallet!();

--- a/client/src/client_sync/v22/wallet.rs
+++ b/client/src/client_sync/v22/wallet.rs
@@ -44,3 +44,50 @@ macro_rules! impl_client_v22__wallet_display_address {
         }
     };
 }
+
+/// Implements Bitcoin Core JSON-RPC API method `createwallet`.
+#[macro_export]
+macro_rules! impl_client_v22__create_wallet {
+    () => {
+        impl Client {
+            /// Creates a wallet with external_signer=true.
+            ///
+            /// > createwallet "wallet_name" ( disable_private_keys blank "passphrase" avoid_reuse descriptors load_on_startup external_signer )
+            /// >
+            /// > Creates and loads a new wallet.
+            /// >
+            /// > Arguments:
+            /// > 1. wallet_name             (string, required) The name for the new wallet. If this is a path, the wallet will be created at the path location.
+            /// > 2. disable_private_keys    (boolean, optional, default=false) Disable the possibility of private keys (only watchonlys are possible in this mode).
+            /// > 3. blank                   (boolean, optional, default=false) Create a blank wallet. A blank wallet has no keys or HD seed. One can be set using sethdseed.
+            /// > 4. passphrase              (string, optional) Encrypt the wallet with this passphrase.
+            /// > 5. avoid_reuse             (boolean, optional, default=false) Keep track of coin reuse, and treat dirty and clean coins differently with privacy considerations in mind.
+            /// > 6. descriptors             (boolean, optional, default=true) Create a native descriptor wallet. The wallet will use descriptors internally to handle address creation
+            /// > 7. load_on_startup         (boolean, optional) Save wallet name to persistent settings and load on startup. True to add wallet to startup list, false to remove, null to leave unchanged.
+            /// > 8. external_signer         (boolean, optional, default=false) Use an external signer such as a hardware wallet. Requires -signer to be configured. Wallet creation will fail if keys cannot be fetched. Requires disable_private_keys and descriptors set to true.
+            pub fn create_wallet_external_signer(&self, wallet: &str) -> Result<CreateWallet> {
+                let disable_private_keys = true;
+                let blank = false;
+                let passphrase = String::new();
+                let avoid_reuse = false;
+                let descriptors = true;
+                let load_on_startup = false;
+                let external_signer = true;
+
+                self.call(
+                    "createwallet",
+                    &[
+                        wallet.into(),
+                        disable_private_keys.into(),
+                        blank.into(),
+                        passphrase.into(),
+                        avoid_reuse.into(),
+                        descriptors.into(),
+                        load_on_startup.into(),
+                        external_signer.into(),
+                    ],
+                )
+            }
+        }
+    };
+}

--- a/client/src/client_sync/v23/mod.rs
+++ b/client/src/client_sync/v23/mod.rs
@@ -145,6 +145,7 @@ crate::impl_client_v17__abort_rescan!();
 crate::impl_client_v17__add_multisig_address!();
 crate::impl_client_v17__backup_wallet!();
 crate::impl_client_v17__bump_fee!();
+crate::impl_client_v22__create_wallet!();
 crate::impl_client_v23__create_wallet!();
 crate::impl_client_v17__dump_priv_key!();
 crate::impl_client_v17__dump_wallet!();

--- a/client/src/client_sync/v24/mod.rs
+++ b/client/src/client_sync/v24/mod.rs
@@ -146,6 +146,7 @@ crate::impl_client_v17__abort_rescan!();
 crate::impl_client_v17__add_multisig_address!();
 crate::impl_client_v17__backup_wallet!();
 crate::impl_client_v17__bump_fee!();
+crate::impl_client_v22__create_wallet!();
 crate::impl_client_v23__create_wallet!();
 crate::impl_client_v17__dump_priv_key!();
 crate::impl_client_v17__dump_wallet!();

--- a/client/src/client_sync/v25/mod.rs
+++ b/client/src/client_sync/v25/mod.rs
@@ -147,6 +147,7 @@ crate::impl_client_v17__abort_rescan!();
 crate::impl_client_v17__add_multisig_address!();
 crate::impl_client_v17__backup_wallet!();
 crate::impl_client_v17__bump_fee!();
+crate::impl_client_v22__create_wallet!();
 crate::impl_client_v23__create_wallet!();
 crate::impl_client_v17__dump_priv_key!();
 crate::impl_client_v17__dump_wallet!();

--- a/client/src/client_sync/v26/mod.rs
+++ b/client/src/client_sync/v26/mod.rs
@@ -158,6 +158,7 @@ crate::impl_client_v17__abort_rescan!();
 crate::impl_client_v17__add_multisig_address!();
 crate::impl_client_v17__backup_wallet!();
 crate::impl_client_v17__bump_fee!();
+crate::impl_client_v22__create_wallet!();
 crate::impl_client_v23__create_wallet!();
 crate::impl_client_v17__dump_priv_key!();
 crate::impl_client_v17__dump_wallet!();

--- a/client/src/client_sync/v27/mod.rs
+++ b/client/src/client_sync/v27/mod.rs
@@ -154,6 +154,7 @@ crate::impl_client_v17__abort_rescan!();
 crate::impl_client_v17__add_multisig_address!();
 crate::impl_client_v17__backup_wallet!();
 crate::impl_client_v17__bump_fee!();
+crate::impl_client_v22__create_wallet!();
 crate::impl_client_v23__create_wallet!();
 crate::impl_client_v17__dump_priv_key!();
 crate::impl_client_v17__dump_wallet!();

--- a/client/src/client_sync/v28/mod.rs
+++ b/client/src/client_sync/v28/mod.rs
@@ -155,6 +155,7 @@ crate::impl_client_v17__abort_rescan!();
 crate::impl_client_v17__add_multisig_address!();
 crate::impl_client_v17__backup_wallet!();
 crate::impl_client_v17__bump_fee!();
+crate::impl_client_v22__create_wallet!();
 crate::impl_client_v23__create_wallet!();
 crate::impl_client_v28__create_wallet_descriptor!();
 crate::impl_client_v17__dump_priv_key!();

--- a/client/src/client_sync/v29/mod.rs
+++ b/client/src/client_sync/v29/mod.rs
@@ -162,6 +162,7 @@ crate::impl_client_v17__abort_rescan!();
 crate::impl_client_v17__add_multisig_address!();
 crate::impl_client_v17__backup_wallet!();
 crate::impl_client_v17__bump_fee!();
+crate::impl_client_v22__create_wallet!();
 crate::impl_client_v23__create_wallet!();
 crate::impl_client_v28__create_wallet_descriptor!();
 crate::impl_client_v17__dump_priv_key!();

--- a/client/src/client_sync/v30/mod.rs
+++ b/client/src/client_sync/v30/mod.rs
@@ -159,6 +159,7 @@ crate::impl_client_v17__abandon_transaction!();
 crate::impl_client_v17__abort_rescan!();
 crate::impl_client_v17__backup_wallet!();
 crate::impl_client_v17__bump_fee!();
+crate::impl_client_v22__create_wallet!();
 crate::impl_client_v23__create_wallet!();
 crate::impl_client_v28__create_wallet_descriptor!();
 crate::impl_client_v17__encrypt_wallet!();

--- a/integration_test/tests/signer.rs
+++ b/integration_test/tests/signer.rs
@@ -5,6 +5,8 @@
 #![allow(non_snake_case)] // Test names intentionally use double underscore.
 #![allow(unused_imports)] // Because of feature gated tests.
 
+use bitcoin::address::{NetworkUnchecked, ParseError};
+use bitcoin::Address;
 use integration_test::{Node, NodeExt as _, Wallet};
 use node::vtype::*;
 use node::{mtype, Input, Output}; // All the version specific types.
@@ -32,4 +34,53 @@ fn signer__enumerate_signers() {
     let first_tx = json.signers.first().expect("no signers found");
 
     assert_eq!(first_tx.fingerprint, "deadbeef");
+}
+
+#[test]
+#[cfg(unix)]
+#[cfg(not(feature = "v21_and_below"))]
+fn signer__wallet_display_address__modelled() {
+    use std::os::unix::fs::PermissionsExt;
+
+    // MOCK address and xpub from Bitcoin Core's `wallet_signer.py`.
+    let address = "bcrt1qm90ugl4d48jv8n6e5t9ln6t9zlpm5th68x4f8g";
+    let xpub = "tpubD6NzVbkrYhZ4WaWSyoBvQwbpLkojyoTZPRsgXELWz3Popb3qkjcJyJUGLnL4qHHoQvao8ESaAstxYSnhyswJ76uZPStJRJCTKvosUCJZL5B";
+
+    // Mock signer script that handles `enumerate`, `getdescriptors`, and
+    // `displayaddress` sub-commands — the three commands bitcoind invokes when
+    // creating an external-signer wallet and then displaying an address.
+    let script_path = integration_test::random_tmp_file();
+    let script_body = format!(
+        r#"#!/bin/sh
+CMD=""
+while [ $# -gt 0 ]; do
+    case "$1" in enumerate|getdescriptors|displayaddress) CMD="$1" ;; esac
+    shift
+done
+case "$CMD" in
+    enumerate)     echo '[{{"fingerprint":"00000001","type":"trezor","model":"trezor_t"}}]' ;;
+    getdescriptors) echo '{{"receive":["wpkh([00000001/84h/1h/0h]{xpub}/0/*)"],"internal":[]}}' ;;
+    displayaddress) echo '{{"address":"{address}"}}' ;;
+    *)             echo '{{"error":"unknown command"}}'; exit 1 ;;
+esac
+"#
+    );
+    std::fs::write(&script_path, script_body).expect("write signer script");
+    std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+
+    let signer_arg = format!("-signer={}", script_path.to_str().unwrap());
+    let node = Node::with_wallet(Wallet::None, &[&signer_arg]);
+
+    let _: CreateWallet = node
+        .client
+        .create_wallet_external_signer("hww")
+        .expect("createwallet with external signer");
+
+    let json: WalletDisplayAddress =
+        node.client.wallet_display_address(address).expect("walletdisplayaddress");
+
+    let address: Address<NetworkUnchecked> = address.parse().unwrap();
+    let model: Result<mtype::WalletDisplayAddress, ParseError> = json.into_model();
+    let model = model.unwrap();
+    assert_eq!(model.address, address);
 }

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -225,7 +225,7 @@
 //! | unloadwallet                       | returns nothing |                                        |
 //! | upgradewallet                      | version         |                                        |
 //! | walletcreatefundedpsbt             | version + model |                                        |
-//! | walletdisplayaddress               | version + model | UNTESTED                               |
+//! | walletdisplayaddress               | version + model |                                        |
 //! | walletlock                         | returns nothing |                                        |
 //! | walletpassphrase                   | returns nothing |                                        |
 //! | walletpassphrasechange             | returns nothing |                                        |

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -218,7 +218,7 @@
 //! | unloadwallet                       | returns nothing |                                        |
 //! | upgradewallet                      | version         |                                        |
 //! | walletcreatefundedpsbt             | version + model |                                        |
-//! | walletdisplayaddress               | version + model | UNTESTED                               |
+//! | walletdisplayaddress               | version + model |                                        |
 //! | walletlock                         | returns nothing |                                        |
 //! | walletpassphrase                   | returns nothing |                                        |
 //! | walletpassphrasechange             | returns nothing |                                        |

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -222,7 +222,7 @@
 //! | unloadwallet                       | returns nothing |                                        |
 //! | upgradewallet                      | version         |                                        |
 //! | walletcreatefundedpsbt             | version + model |                                        |
-//! | walletdisplayaddress               | version + model | UNTESTED                               |
+//! | walletdisplayaddress               | version + model |                                        |
 //! | walletlock                         | returns nothing |                                        |
 //! | walletpassphrase                   | returns nothing |                                        |
 //! | walletpassphrasechange             | returns nothing |                                        |

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -223,7 +223,7 @@
 //! | unloadwallet                       | returns nothing |                                        |
 //! | upgradewallet                      | version         |                                        |
 //! | walletcreatefundedpsbt             | version + model |                                        |
-//! | walletdisplayaddress               | version + model | UNTESTED                               |
+//! | walletdisplayaddress               | version + model |                                        |
 //! | walletlock                         | returns nothing |                                        |
 //! | walletpassphrase                   | returns nothing |                                        |
 //! | walletpassphrasechange             | returns nothing |                                        |

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -231,7 +231,7 @@
 //! | unloadwallet                       | returns nothing |                                        |
 //! | upgradewallet                      | version         |                                        |
 //! | walletcreatefundedpsbt             | version + model |                                        |
-//! | walletdisplayaddress               | version + model | UNTESTED                               |
+//! | walletdisplayaddress               | version + model |                                        |
 //! | walletlock                         | returns nothing |                                        |
 //! | walletpassphrase                   | returns nothing |                                        |
 //! | walletpassphrasechange             | returns nothing |                                        |

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -231,7 +231,7 @@
 //! | unloadwallet                       | returns nothing |                                        |
 //! | upgradewallet                      | version         |                                        |
 //! | walletcreatefundedpsbt             | version + model |                                        |
-//! | walletdisplayaddress               | version + model | UNTESTED                               |
+//! | walletdisplayaddress               | version + model |                                        |
 //! | walletlock                         | returns nothing |                                        |
 //! | walletpassphrase                   | returns nothing |                                        |
 //! | walletpassphrasechange             | returns nothing |                                        |

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -233,7 +233,7 @@
 //! | unloadwallet                       | returns nothing |                                        |
 //! | upgradewallet                      | version         |                                        |
 //! | walletcreatefundedpsbt             | version + model |                                        |
-//! | walletdisplayaddress               | version + model | UNTESTED                               |
+//! | walletdisplayaddress               | version + model |                                        |
 //! | walletlock                         | returns nothing |                                        |
 //! | walletpassphrase                   | returns nothing |                                        |
 //! | walletpassphrasechange             | returns nothing |                                        |

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -234,7 +234,7 @@
 //! | unloadwallet                       | returns nothing |                                        |
 //! | upgradewallet                      | version         |                                        |
 //! | walletcreatefundedpsbt             | version + model |                                        |
-//! | walletdisplayaddress               | version + model | UNTESTED                               |
+//! | walletdisplayaddress               | version + model |                                        |
 //! | walletlock                         | returns nothing |                                        |
 //! | walletpassphrase                   | returns nothing |                                        |
 //! | walletpassphrasechange             | returns nothing |                                        |

--- a/types/src/v30/mod.rs
+++ b/types/src/v30/mod.rs
@@ -225,7 +225,7 @@
 //! | simulaterawtransaction             | version + model |                                        |
 //! | unloadwallet                       | returns nothing |                                        |
 //! | walletcreatefundedpsbt             | version + model |                                        |
-//! | walletdisplayaddress               | version + model | UNTESTED                               |
+//! | walletdisplayaddress               | version + model |                                        |
 //! | walletlock                         | returns nothing |                                        |
 //! | walletpassphrase                   | returns nothing |                                        |
 //! | walletpassphrasechange             | returns nothing |                                        |


### PR DESCRIPTION
`signer__wallet_display_address` tests `walletdisplayaddress` RPC call mocking an external signer.

The test mocks a Hardware Wallet (HWW) interaction by:
1. Creating a temporary shell script that acts as an external signer.
2. Handling the 'enumerate', 'getdescriptors', and 'displayaddress' commands expected by Bitcoin Core.
3. Spawning a node with the `-signer` argument pointing to this mock.
4. Creating a descriptor-based wallet with `external_signer` enabled.
5. Asserting that calling `wallet_display_address` returns the expected address from the mock signer.

Heavily Inspired by [wallet_signer.py](https://github.com/bitcoin/bitcoin/blob/master/test/functional/wallet_signer.py)