### PR TITLE
Update changelogs

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -4,6 +4,7 @@
   [#388](https://github.com/rust-bitcoin/corepc/pull/388).
 - Bump MSRV to 1.75.0 [#405](https://github.com/rust-bitcoin/corepc/pull/405)
 - Update to use latest `types v0.11.0`.
+- Support a bunch more RPC methods (incl. hidden ones).
 
 # 0.10.0 - 2025-10-07
 

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Bump MSRV to 1.75.0 [#405](https://github.com/rust-bitcoin/corepc/pull/405)
 - Update to use latest `client v0.11.0`.
+- Add support for Bitcoin Core 30.0
 
 # 0.10.1 2025-11-18
 


### PR DESCRIPTION
A while ago we prepped the `v0.11.0` releases but got blocked after releasing `types`. I then forgot all about it.

Some stuff has merge since then. Add a bodgy changelog entry to `node` and `client` (sans links because I'm lazy right now).

We can then release `node` and `client` from this patch.