### PR TITLE
Change the type of prune_target_size field in model::GetBlockchainInfo from u32 to u64

### DIFF
--- a/integration_test/tests/blockchain.rs
+++ b/integration_test/tests/blockchain.rs
@@ -206,7 +206,7 @@ fn blockchain__get_block__modelled() {
 
 #[test]
 fn blockchain__get_blockchain_info__modelled() {
-    let node = Node::with_wallet(Wallet::None, &[]);
+    let node = Node::with_wallet(Wallet::None, &["-prune=10000"]);
 
     let json: GetBlockchainInfo = node.client.get_blockchain_info().expect("rpc");
     let model: Result<mtype::GetBlockchainInfo, GetBlockchainInfoError> = json.into_model();

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -63,6 +63,11 @@ pub fn to_u32(value: i64, field: &str) -> Result<u32, NumericError> {
     u32::try_from(value).map_err(|_| NumericError::Overflow { value, field: field.to_owned() })
 }
 
+/// Converts an `i64` numeric type to a `u64`.
+pub fn to_u64(value: i64, field: &str) -> Result<u64, NumericError> {
+    u64::try_from(value).map_err(|_| NumericError::Negative { value, field: field.to_owned() })
+}
+
 /// Error converting an `i64` to a `u32`.
 ///
 /// If we expect a numeric value to sanely fit inside a `u32` we use that type in the `model`

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -68,11 +68,11 @@ pub fn to_u64(value: i64, field: &str) -> Result<u64, NumericError> {
     u64::try_from(value).map_err(|_| NumericError::Negative { value, field: field.to_owned() })
 }
 
-/// Error converting an `i64` to a `u32`.
+/// Error converting an `i64` to a `u32` or `u64`.
 ///
-/// If we expect a numeric value to sanely fit inside a `u32` we use that type in the `model`
-/// module, this requires converting the `i64` returned by the JSONRPC API into a `u32`, if our
-/// expectations are not met this error will be encountered.
+/// The JSONRPC API returns `i64` values. If these values match our expectations, then
+/// we convert them to either `u32` or `u64`, depending on the JSONRPC field. If our
+/// expectations are not met, this error is returned.
 #[derive(Debug)]
 pub enum NumericError {
     /// Expected an unsigned numeric value however the value was negative.

--- a/types/src/model/blockchain.rs
+++ b/types/src/model/blockchain.rs
@@ -241,7 +241,7 @@ pub struct GetBlockchainInfo {
     /// Whether automatic pruning is enabled (only present if pruning is enabled).
     pub automatic_pruning: Option<bool>,
     /// The target size used by pruning (only present if automatic pruning is enabled).
-    pub prune_target_size: Option<u32>,
+    pub prune_target_size: Option<u64>,
     /// Status of softforks in progress, maps softfork name -> [`Softfork`] (empty from v29 onwards).
     pub softforks: BTreeMap<String, Softfork>,
     /// The block challenge (aka. block script)

--- a/types/src/v17/blockchain/into.rs
+++ b/types/src/v17/blockchain/into.rs
@@ -98,7 +98,7 @@ impl GetBlockchainInfo {
         let prune_height =
             self.prune_height.map(|h| crate::to_u32(h, "prune_height")).transpose()?;
         let prune_target_size =
-            self.prune_target_size.map(|h| crate::to_u32(h, "prune_target_size")).transpose()?;
+            self.prune_target_size.map(|h| crate::to_u64(h, "prune_target_size")).transpose()?;
         let softforks = BTreeMap::new(); // TODO: Handle softforks stuff.
 
         Ok(model::GetBlockchainInfo {

--- a/types/src/v19/blockchain/into.rs
+++ b/types/src/v19/blockchain/into.rs
@@ -29,7 +29,7 @@ impl GetBlockchainInfo {
         let prune_height =
             self.prune_height.map(|h| crate::to_u32(h, "prune_height")).transpose()?;
         let prune_target_size =
-            self.prune_target_size.map(|h| crate::to_u32(h, "prune_target_size")).transpose()?;
+            self.prune_target_size.map(|h| crate::to_u64(h, "prune_target_size")).transpose()?;
         let softforks = BTreeMap::new(); // TODO: Handle softforks stuff.
 
         Ok(model::GetBlockchainInfo {

--- a/types/src/v21/blockchain/into.rs
+++ b/types/src/v21/blockchain/into.rs
@@ -24,7 +24,7 @@ impl GetBlockchainInfo {
         let prune_height =
             self.prune_height.map(|h| crate::to_u32(h, "prune_height")).transpose()?;
         let prune_target_size =
-            self.prune_target_size.map(|h| crate::to_u32(h, "prune_target_size")).transpose()?;
+            self.prune_target_size.map(|h| crate::to_u64(h, "prune_target_size")).transpose()?;
         let softforks = BTreeMap::new(); // TODO: Handle softforks stuff.
 
         Ok(model::GetBlockchainInfo {

--- a/types/src/v23/blockchain/into.rs
+++ b/types/src/v23/blockchain/into.rs
@@ -25,7 +25,7 @@ impl GetBlockchainInfo {
         let prune_height =
             self.prune_height.map(|h| crate::to_u32(h, "prune_height")).transpose()?;
         let prune_target_size =
-            self.prune_target_size.map(|h| crate::to_u32(h, "prune_target_size")).transpose()?;
+            self.prune_target_size.map(|h| crate::to_u64(h, "prune_target_size")).transpose()?;
         let softforks = BTreeMap::new(); // TODO: Handle softforks stuff.
 
         Ok(model::GetBlockchainInfo {

--- a/types/src/v28/blockchain/into.rs
+++ b/types/src/v28/blockchain/into.rs
@@ -23,7 +23,7 @@ impl GetBlockchainInfo {
         let prune_height =
             self.prune_height.map(|h| crate::to_u32(h, "prune_height")).transpose()?;
         let prune_target_size =
-            self.prune_target_size.map(|h| crate::to_u32(h, "prune_target_size")).transpose()?;
+            self.prune_target_size.map(|h| crate::to_u64(h, "prune_target_size")).transpose()?;
         let softforks = BTreeMap::new(); // TODO: Handle softforks stuff.
 
         Ok(model::GetBlockchainInfo {

--- a/types/src/v29/blockchain/into.rs
+++ b/types/src/v29/blockchain/into.rs
@@ -267,7 +267,7 @@ impl GetBlockchainInfo {
         let prune_height =
             self.prune_height.map(|h| crate::to_u32(h, "prune_height")).transpose()?;
         let prune_target_size =
-            self.prune_target_size.map(|h| crate::to_u32(h, "prune_target_size")).transpose()?;
+            self.prune_target_size.map(|h| crate::to_u64(h, "prune_target_size")).transpose()?;
         let signet_challenge =
             self.signet_challenge.as_ref().map(|s| ScriptBuf::from_hex(s)).transpose()?;
 


### PR DESCRIPTION
Solves https://github.com/rust-bitcoin/corepc/issues/544

## Manual testing

**Before:**

Run `git checkout 26e3998a283091abeed33a44a8176ec62c15c4d8` (the commit that introduced the integration test). Then:
```
cd integration_test/
cargo test --release --features <bitcoind_version>
```

Example: `cargo test --release --features 28_1`.

This test should fail in the commit it was introduced.

**After:**

Checkout back to the branch and run the same test again. Now, the test should succeed.