### PR TITLE
Prepare stack of releases

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -238,7 +238,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "corepc-client"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bitcoin",
  "corepc-types",
@@ -250,7 +250,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-node"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-types"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bitcoin",
  "serde",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -238,7 +238,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "corepc-client"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bitcoin",
  "corepc-types",
@@ -250,7 +250,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-node"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-types"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bitcoin",
  "serde",

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.12.0 - 2026-04-13
+
+- Upgrade to latest `corepc-types v0.12.0`.
+
 # 0.11.0 - 2026-04-09
 
 - Add support for Bitcoin Core 30.0 [#387](https://github.com/rust-bitcoin/corepc/pull/387),

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.11.0 - 2025-11-18
+# 0.11.0 - 2026-04-09
 
 - Add support for Bitcoin Core 30.0 [#387](https://github.com/rust-bitcoin/corepc/pull/387),
   [#388](https://github.com/rust-bitcoin/corepc/pull/388).

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-client"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Tobin C. Harding <me@tobin.cc>", "Jamil Lambert <Jamil.Lambert@proton.me>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/corepc"
@@ -25,7 +25,7 @@ bitcoin = { version = "0.32.0", default-features = false, features = ["std", "se
 log = "0.4"
 serde = { version = "1.0.103", default-features = false, features = [ "derive", "alloc" ] }
 serde_json = { version = "1.0.117" }
-types = { package = "corepc-types", version = "0.11.0", path = "../types", default-features = false, features = ["std"] }
+types = { package = "corepc-types", version = "0.12.0", path = "../types", default-features = false, features = ["std"] }
 
 jsonrpc = { version = "0.19.0", path = "../jsonrpc", features = ["bitreq_http"], optional = true }
 

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -63,10 +63,10 @@ TODO = []                       # This is a dirty hack while writing the tests.
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false, features = ["std", "serde"] }
 env_logger = "0.9.0"
-node = { package = "corepc-node", version = "0.11.0", path = "../node", default-features = false }
+node = { package = "corepc-node", version = "0.12.0", path = "../node", default-features = false }
 rand = "0.8.5"
 # Just so we can enable the feature.
-types = { package = "corepc-types", version = "0.11.0", path = "../types", features = ["serde-deny-unknown-fields"] }
+types = { package = "corepc-types", version = "0.12.0", path = "../types", features = ["serde-deny-unknown-fields"] }
 
 [dev-dependencies]
 

--- a/node/CHANGELOG.md
+++ b/node/CHANGELOG.md
@@ -1,8 +1,17 @@
-# 0.11.0 - 2025-11-18
+# 0.12.0 - 2026-04-13
 
 - Bump MSRV to 1.75.0 [#405](https://github.com/rust-bitcoin/corepc/pull/405)
-- Update to use latest `client v0.11.0`.
+- Update to use latest `client v0.12.0`.
 - Add support for Bitcoin Core 30.0
+
+# 0.11.0 - 2025-11-18
+
+**NON-EXISTENT**
+
+Turns out we prepped this release then forgot to pull the trigger
+because of a fix that had to be done upstream.
+
+Just bump straight to `v0.12.0` to stay in sync with the other corepc crates.
 
 # 0.10.1 2025-11-18
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-node"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Riccardo Casatta <riccardo@casatta.it>", "Tobin C. Harding <me@tobin.cc>"]
 license = "MIT"
 repository = "https://github.com/rust-bitcoin/corepc"
@@ -14,7 +14,7 @@ exclude = ["tests", "contrib"]
 
 [dependencies]
 anyhow = { version = "1.0.66", default-features = false, features = ["std"] }
-corepc-client = { version = "0.11.0", path = "../client", features = ["client-sync"] }
+corepc-client = { version = "0.12.0", path = "../client", features = ["client-sync"] }
 log = { version = "0.4", default-features = false }
 serde_json = { version = "1.0.117", default-features = false }
 tempfile = { version = "3", default-features = false }

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 0.12.0 - 2026-04-13
+
+- Update `GetBlockStats` fields to be optional [#534](https://github.com/rust-bitcoin/corepc/pull/534)
+- Model `merkle_root` as `TxMerkleNode` [#519](https://github.com/rust-bitcoin/corepc/pull/519)
+- Add `getblock` verbosity 2/3 support for v29 onward [#485](https://github.com/rust-bitcoin/corepc/pull/485)
+- Implement `scantxoutset` method and test [#428](https://github.com/rust-bitcoin/corepc/pull/428)
+- Implement hidden methods:
+  - [#432](https://github.com/rust-bitcoin/corepc/pull/432)
+  - [#433](https://github.com/rust-bitcoin/corepc/pull/433)
+  - [#435](https://github.com/rust-bitcoin/corepc/pull/435)
+  - [#439](https://github.com/rust-bitcoin/corepc/pull/439)
+
 # 0.11.0 - 2025-11-18
 
 - Add support for Bitcoin Core 30.0 [#387](https://github.com/rust-bitcoin/corepc/pull/387),

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-types"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Tobin C. Harding <me@tobin.cc>", "Jamil Lambert <Jamil.Lambert@proton.me>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/corepc"


### PR DESCRIPTION
After releasing `corepc-types 0.11.0` there was a fix that had to be done to `jsonrpc`. I then forgot to release `client` and `node`.
    
Yesterday I released `client v0.11.0` but then when attempting the `node v0.11.0` release found it was broken because we did a bunch of API additions (and breaks) since `types` was released.
    
- Bump `types` to `v0.12.0`
- Bump `client` to  `v0.12.0`
- Bump `node` straight to `v0.12.0` skipping `v0.11.0` so it's version number stays in sync with the other two.

FTR there is no need to yank `client 0.11.0` because it is functional and harmless.
