### PR TITLE
Derive `Hash` for `Url`

### DIFF
--- a/bitreq/src/url.rs
+++ b/bitreq/src/url.rs
@@ -59,7 +59,7 @@ impl std::error::Error for ParseError {}
 ///
 /// **Note:** This type currently only supports encoded URLs. IDNs or non-ASCII URLs must be
 /// properly punycoded/%-encoded prior to parsing.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct Url {
     /// The full serialized URL string.
     serialization: String,


### PR DESCRIPTION
This is a nice-to-have, especially when you'd like to use a `Url` as a key in a `HashMap`.