### PR TITLE
Remove rust-version from workspace manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,6 @@
 members = [ "bitreq", "client", "fuzz", "jsonrpc", "node", "types"]
 exclude = ["integration_test", "verify"]
 resolver = "2"
-rust-version = "1.75.0"
 
 [patch.crates-io.corepc-client]
 path = "client"


### PR DESCRIPTION
During the `cargo rbmt` re-write of CI we accidentally added `rust-version` to the workspace manifest. This is a per-crate setting and doesn't live here.

This does show up on master but as a warning not an error

```bash
just lint
$REPO_DIR/contrib/lint-verify.sh
++ git rev-parse --show-toplevel
+ REPO_DIR=/home/tobin/build/corepc
++ cat ./nightly-version
+ cargo +nightly-2025-09-12 clippy --manifest-path /home/tobin/build/corepc/verify/Cargo.toml --config ./rustfmt.toml --all-targets --all-features -- --deny warnings
warning: unused manifest key: workspace.rust-version
```