### PR TITLE
Update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,9 +2,12 @@
 *       @tcharding
 
 # Owners for specific directories
-/bitreq/        @oleonardolima @TheBlueMatt @tnull
-/client/        @jamillambert
-/jsonrpc/       @apoelstra
-/node/          @RCasatta
-/types/         @jamillambert
+/bitcoind/          @tcharding @jamillambert @RCasatta
+/bitreq/            @TheBlueMatt @tnull @oleonardolima 
+/client/            @tcharding @jamillambert
+/electrsd/          @RCasatta @tcharding @jamillambert
+/integration_test/  @tcharding @jamillambert
+/jsonrpc/           @apoelstra @tcharding @jamillambert
+/types/             @tcharding @jamillambert
+/verify/            @tcharding @jamillambert
 


### PR DESCRIPTION
A few things going on here:

- Implying Jamil as 2IC in all crates except `bitreq`.
- Leaving RCassatta and apoelstra at the head of the list for their respective crates out of respect but Jamil and I are doing the maintenance work [0].
- Add `integration_test` and `verify` for completeness.

Note `bitreq` lists owners who are doing reviews but I'm still responsible for the doing the merging and releasing. We need an additional owner on crates.io for `bitreq` because of bus factor.

For `bitcoind` and `electrsd` RCasatta has already ack'd this in public on #542. For `jsonrpc` this PR needs ack from apoelstra to publicly ack what he told me in private.

Onwards and upwards team!