### PR TITLE
Release tracking PR: bitcoind, bitreq, client, electrsd and jsonrpc

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoind"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -165,7 +165,7 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitreq"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "base64 0.22.1",
  "log",
@@ -266,7 +266,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "corepc-client"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "bitcoin",
  "corepc-types",
@@ -566,7 +566,7 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jsonrpc"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "base64 0.22.1",
  "bitreq",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoind"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -165,7 +165,7 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitreq"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "base64 0.22.1",
  "log",
@@ -266,7 +266,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "corepc-client"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "bitcoin",
  "corepc-types",
@@ -566,7 +566,7 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jsonrpc"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "base64 0.22.1",
  "bitreq",

--- a/bitcoind/CHANGELOG.md
+++ b/bitcoind/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 0.38.0 - 2026-04-20
+
+- Update to use latest `bitreq v0.3.5`.
+- Update to use latest `corepc-client v0.13.0`.
+
+# 0.37.0 - 2026-04-16
+
+This release continues the `corepc-node` history under the restored `bitcoind`
+crate name. The rename back to `bitcoind` happened in
+[#542](https://github.com/rust-bitcoin/corepc/pull/542).
+Version `0.37.0` was chosen to continue past the older standalone `bitcoind`
+crate releases that existed before this repository.
+
+- Add support for Bitcoin Core 30.2 [#542](https://github.com/rust-bitcoin/corepc/pull/542)
+
 # 0.12.0 - 2026-04-13
 
 - Bump MSRV to 1.75.0 [#405](https://github.com/rust-bitcoin/corepc/pull/405)

--- a/bitcoind/Cargo.toml
+++ b/bitcoind/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoind"
-version = "0.37.0"
+version = "0.38.0"
 authors = ["Riccardo Casatta <riccardo@casatta.it>", "Tobin C. Harding <me@tobin.cc>"]
 license = "MIT"
 repository = "https://github.com/rust-bitcoin/corepc"
@@ -14,7 +14,7 @@ exclude = ["tests", "contrib"]
 
 [dependencies]
 anyhow = { version = "1.0.66", default-features = false, features = ["std"] }
-corepc-client = { version = "0.12.0", path = "../client", features = ["client-sync"] }
+corepc-client = { version = "0.13.0", path = "../client", features = ["client-sync"] }
 log = { version = "0.4", default-features = false }
 serde_json = { version = "1.0.117", default-features = false }
 tempfile = { version = "3", default-features = false }
@@ -27,7 +27,7 @@ env_logger = { version = "0.9.3", default-features = false }
 anyhow = { version = "1.0.66", optional = true }
 bitcoin_hashes = { version = ">= 0.13, <= 0.14", optional = true }
 flate2 = { version = "1.0", optional = true }
-bitreq = { version = "0.3.0", path = "../bitreq", features = ["https"], optional = true }
+bitreq = { version = "0.3.5", path = "../bitreq", features = ["https"], optional = true }
 tar = { version = "0.4", optional = true }
 zip = { version = "0.6.6", default-features = false, features = ["bzip2", "deflate"], optional = true }
 

--- a/bitreq/CHANGELOG.md
+++ b/bitreq/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.3.5 - 2026-04-20
+
+* Fix `tokio-rustls` feature gating for async rustls support [#563](https://github.com/rust-bitcoin/corepc/pull/563)
+* Bump `rustls` and related crates to latest versions to pick up recent fixes [#556](https://github.com/rust-bitcoin/corepc/pull/556)
+* Derive `Hash` for `Url` so it can be used in hashed collections [#550](https://github.com/rust-bitcoin/corepc/pull/550)
+
+# 0.3.4 - 2026-02-18
+
+* Miscellaneous crate housekeeping [#504](https://github.com/rust-bitcoin/corepc/pull/504)
+
 # 0.3.3 - 2026-02-12
 
 * Make `Url::append_query_pairs` and `preserve_fragment_from` public methods [#500](https://github.com/rust-bitcoin/corepc/pull/500)

--- a/bitreq/Cargo.toml
+++ b/bitreq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitreq"
-version = "0.3.4"
+version = "0.3.5"
 authors = ["Jens Pitkanen <jens@neon.moe>", "Tobin C. Harding <me@tobin.cc>", "Matt Corallo", "Elias Rohrer <dev@tnull.de>"]
 description = "Simple, minimal-dependency HTTP client"
 documentation = "https://docs.rs/bitreq"

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.13.0 - 2026-04-20
+
+- Update to use latest `jsonrpc v0.20.0`.
+
 # 0.12.0 - 2026-04-13
 
 - Upgrade to latest `corepc-types v0.12.0`.

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-client"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Tobin C. Harding <me@tobin.cc>", "Jamil Lambert <Jamil.Lambert@proton.me>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/corepc"
@@ -31,6 +31,6 @@ serde = { version = "1.0.103", default-features = false, features = [ "derive", 
 serde_json = { version = "1.0.117" }
 types = { package = "corepc-types", version = "0.12.0", path = "../types", default-features = false, features = ["std"] }
 
-jsonrpc = { version = "0.19.0", path = "../jsonrpc", features = ["bitreq_http"], optional = true }
+jsonrpc = { version = "0.20.0", path = "../jsonrpc", features = ["bitreq_http"], optional = true }
 
 [dev-dependencies]

--- a/electrsd/CHANGELOG.md
+++ b/electrsd/CHANGELOG.md
@@ -1,0 +1,12 @@
+# 0.38.0 - 2026-04-20
+
+- Update to latest `bitcoind v0.38.0`, optional `bitreq v0.3.5`, and
+  `corepc-client v0.13.0`.
+- Separate Bitcoin Core binary downloading into a dedicated `bitcoind_download`
+  feature [#559](https://github.com/rust-bitcoin/corepc/pull/559).
+
+# 0.37.0 - 2026-04-16
+
+- Import `electrsd` into the `corepc` repository [#542](https://github.com/rust-bitcoin/corepc/pull/542)
+- Add support for Bitcoin Core 30.2 [#542](https://github.com/rust-bitcoin/corepc/pull/542)
+- Update to `corepc-client v0.12.0` and the restored `bitcoind v0.37.0` crate [#542](https://github.com/rust-bitcoin/corepc/pull/542)

--- a/electrsd/Cargo.toml
+++ b/electrsd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "electrsd"
-version = "0.37.0"
+version = "0.38.0"
 authors = ["Riccardo Casatta <riccardo@casatta.it>"]
 description = "Utility to run a regtest electrs process, useful in integration testing environment"
 repository = "https://github.com/rust-bitcoin/corepc"
@@ -12,8 +12,8 @@ categories = ["cryptography::cryptocurrencies", "development-tools::testing"]
 exclude = ["tests", "contrib"]
 
 [dependencies]
-bitcoind = { version = "0.37.0", path = "../bitcoind" }
-corepc-client = { version = "0.12.0", path = "../client" }
+bitcoind = { version = "0.38.0", path = "../bitcoind" }
+corepc-client = { version = "0.13.0", path = "../client" }
 electrum-client = { version = "0.24.0", default-features = false }
 log = { version = "0.4" }
 
@@ -29,7 +29,7 @@ zip = { version = "0.6", default-features = false, optional = true, features = [
   "bzip2",
   "deflate",
 ] }
-bitreq = { version = "0.3.4", path = "../bitreq", default-features = false, optional = true, features = [
+bitreq = { version = "0.3.5", path = "../bitreq", default-features = false, optional = true, features = [
   "https",
 ] }
 

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -63,7 +63,7 @@ TODO = []                       # This is a dirty hack while writing the tests.
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false, features = ["std", "serde"] }
 env_logger = "0.9.0"
-bitcoind = { package = "bitcoind", version = "0.37.0", path = "../bitcoind", default-features = false }
+bitcoind = { package = "bitcoind", version = "0.38.0", path = "../bitcoind", default-features = false }
 rand = "0.8.5"
 # Just so we can enable the feature.
 types = { package = "corepc-types", version = "0.12.0", path = "../types", features = ["serde-deny-unknown-fields"] }

--- a/jsonrpc/CHANGELOG.md
+++ b/jsonrpc/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.20.0 - 2026-04-20
+
+* Add async support [#558](https://github.com/rust-bitcoin/corepc/pull/558)
+* Update to use latest `bitreq v0.3.5`.
+* This is a semver-breaking release because `jsonrpc v0.19.0` was released
+  against `bitreq v0.2.0`, and `bitreq::Error` is part of the public API via
+  `Error::Bitreq`.
+
 # 0.19.0 - 2025-10-31
 
 * Depend on `bitreq` [399](https://github.com/rust-bitcoin/corepc/pull/399)

--- a/jsonrpc/Cargo.toml
+++ b/jsonrpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpc"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/corepc/"
@@ -38,7 +38,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = [ "raw_value" ] }
 
 base64 = { version = "0.22.1", optional = true }
-bitreq = { version = "0.3.0", path = "../bitreq", features = ["json-using-serde"], optional = true }
+bitreq = { version = "0.3.5", path = "../bitreq", features = ["json-using-serde"], optional = true }
 socks = { version = "0.3.4", optional = true}
 
 [dev-dependencies]


### PR DESCRIPTION
To prepare for the releases of bitcoind, bitreq, client, electrsd and jsonrpc:

- Update the changelogs. This includes some missing changelog entries for the previous release.
- Bump the versions and update the dependencies versions.
- Update the lock files.