### PR TITLE
bitreq: Fix tokio-rustls feature gate

### DIFF
--- a/bitreq/src/connection.rs
+++ b/bitreq/src/connection.rs
@@ -158,13 +158,13 @@ impl Write for HttpStream {
     }
 }
 
-#[cfg(feature = "tokio-rustls")]
+#[cfg(any(feature = "async-https-rustls", feature = "async-https-rustls-probe"))]
 type AsyncSecuredStream = rustls_stream::AsyncSecuredStream;
 
 #[cfg(feature = "async")]
 pub(crate) enum AsyncHttpStream {
     Unsecured(AsyncTcpStream),
-    #[cfg(feature = "tokio-rustls")]
+    #[cfg(any(feature = "async-https-rustls", feature = "async-https-rustls-probe"))]
     Secured(Box<AsyncSecuredStream>),
 }
 
@@ -177,7 +177,7 @@ impl AsyncRead for AsyncHttpStream {
     ) -> Poll<io::Result<()>> {
         match &mut *self {
             AsyncHttpStream::Unsecured(inner) => Pin::new(inner).poll_read(cx, buf),
-            #[cfg(feature = "tokio-rustls")]
+            #[cfg(any(feature = "async-https-rustls", feature = "async-https-rustls-probe"))]
             AsyncHttpStream::Secured(inner) => Pin::new(inner).poll_read(cx, buf),
         }
     }
@@ -192,7 +192,7 @@ impl AsyncWrite for AsyncHttpStream {
     ) -> Poll<io::Result<usize>> {
         match &mut *self {
             AsyncHttpStream::Unsecured(inner) => Pin::new(inner).poll_write(cx, buf),
-            #[cfg(feature = "tokio-rustls")]
+            #[cfg(any(feature = "async-https-rustls", feature = "async-https-rustls-probe"))]
             AsyncHttpStream::Secured(inner) => Pin::new(inner).poll_write(cx, buf),
         }
     }
@@ -200,7 +200,7 @@ impl AsyncWrite for AsyncHttpStream {
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         match &mut *self {
             AsyncHttpStream::Unsecured(inner) => Pin::new(inner).poll_flush(cx),
-            #[cfg(feature = "tokio-rustls")]
+            #[cfg(any(feature = "async-https-rustls", feature = "async-https-rustls-probe"))]
             AsyncHttpStream::Secured(inner) => Pin::new(inner).poll_flush(cx),
         }
     }
@@ -208,7 +208,7 @@ impl AsyncWrite for AsyncHttpStream {
     fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         match &mut *self {
             AsyncHttpStream::Unsecured(inner) => Pin::new(inner).poll_shutdown(cx),
-            #[cfg(feature = "tokio-rustls")]
+            #[cfg(any(feature = "async-https-rustls", feature = "async-https-rustls-probe"))]
             AsyncHttpStream::Secured(inner) => Pin::new(inner).poll_shutdown(cx),
         }
     }
@@ -271,9 +271,12 @@ impl AsyncConnection {
             let socket = Self::connect(params).await?;
 
             if params.https {
-                #[cfg(not(feature = "tokio-rustls"))]
+                #[cfg(not(any(
+                    feature = "async-https-rustls",
+                    feature = "async-https-rustls-probe"
+                )))]
                 return Err(Error::HttpsFeatureNotEnabled);
-                #[cfg(feature = "tokio-rustls")]
+                #[cfg(any(feature = "async-https-rustls", feature = "async-https-rustls-probe"))]
                 rustls_stream::wrap_async_stream(socket, params.host).await
             } else {
                 Ok(AsyncHttpStream::Unsecured(socket))

--- a/bitreq/src/connection/rustls_stream.rs
+++ b/bitreq/src/connection/rustls_stream.rs
@@ -15,12 +15,12 @@ use rustls::pki_types::ServerName;
 use rustls::{self, ClientConfig, ClientConnection, RootCertStore, StreamOwned};
 #[cfg(all(feature = "native-tls", not(feature = "rustls"), feature = "tokio-native-tls"))]
 use tokio_native_tls::TlsConnector as AsyncTlsConnector;
-#[cfg(feature = "tokio-rustls")]
+#[cfg(any(feature = "async-https-rustls", feature = "async-https-rustls-probe"))]
 use tokio_rustls::{client::TlsStream, TlsConnector};
 #[cfg(feature = "rustls-webpki")]
 use webpki_roots::TLS_SERVER_ROOTS;
 
-#[cfg(feature = "tokio-rustls")]
+#[cfg(any(feature = "async-https-rustls", feature = "async-https-rustls-probe"))]
 use super::{AsyncHttpStream, AsyncTcpStream};
 #[cfg(all(feature = "native-tls", not(feature = "rustls"), feature = "tokio-native-tls"))]
 use super::{AsyncHttpStream, AsyncTcpStream};
@@ -66,10 +66,10 @@ pub(super) fn wrap_stream(tcp: TcpStream, host: &str) -> Result<SecuredStream, E
 
 // Async rustls TLS implementation
 
-#[cfg(all(feature = "rustls", feature = "tokio-rustls"))]
+#[cfg(any(feature = "async-https-rustls", feature = "async-https-rustls-probe"))]
 pub type AsyncSecuredStream = TlsStream<tokio::net::TcpStream>;
 
-#[cfg(all(feature = "rustls", feature = "tokio-rustls"))]
+#[cfg(any(feature = "async-https-rustls", feature = "async-https-rustls-probe"))]
 pub(super) async fn wrap_async_stream(
     tcp: AsyncTcpStream,
     host: &str,


### PR DESCRIPTION
The code was gated on the dependency instead of the feature alias which
enables other required dependencies. This caused a build failure when
both `std` and `tokio-rustls` features were enabled and not the other
required dependencies.

Change the feature gate to the feature alias instead of the dependency.