### PR TITLE
Bump `rustls-webpki` to patched version in lock files

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -947,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -947,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/bitreq/Cargo.toml
+++ b/bitreq/Cargo.toml
@@ -24,7 +24,7 @@ base64 = { version = "0.22", default-features = false, features = ["alloc"], opt
 rustls = { version = "0.23.38", default-features = false, features = ["ring", "std", "tls12"], optional = true }
 rustls-native-certs = { version = "0.8.3", default-features = false, optional = true }
 webpki-roots = { version = "1.0.7", default-features = false, optional = true }
-rustls-webpki = { version = "0.103.12", default-features = false, optional = true }
+rustls-webpki = { version = "0.103.13", default-features = false, optional = true }
 
 # For native-tls-based TLS:
 native-tls = { version = "0.2", default-features = false, optional = true }


### PR DESCRIPTION
Fixes #567.

[RUSTSEC-2026-0104](https://rustsec.org/advisories/RUSTSEC-2026-0104.html) reports a reachable DoS panic in `rustls-webpki` versions prior to `0.103.13` when parsing a CRL whose `IssuingDistributionPoint.onlySomeReasons` extension contains a syntactically valid empty `BIT STRING`. Bumping the pinned version in both checked-in lock files to `0.103.13` addresses the advisory.

~~I suggest we leave this one open for another day to check if the cronjob will actually open an issue tonight.~~
