### PR TITLE
Release tracking PR: `electrsd 0.38.1`

### DIFF
--- a/electrsd/CHANGELOG.md
+++ b/electrsd/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.38.1 - 2026-05-01
+
+- Fix typo in manifest `documentation` field.
+- Fix stale documented way to depend on this crate.
+
 # 0.38.0 - 2026-04-20
 
 - Update to latest `bitcoind v0.38.0`, optional `bitreq v0.3.5`, and

--- a/electrsd/Cargo.toml
+++ b/electrsd/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "electrsd"
-version = "0.38.0"
+version = "0.38.1"
 authors = ["Riccardo Casatta <riccardo@casatta.it>"]
 description = "Utility to run a regtest electrs process, useful in integration testing environment"
 repository = "https://github.com/rust-bitcoin/corepc"
-documentation = "https://docs.rs/elecrtsd/"
+documentation = "https://docs.rs/electrsd/"
 license = "MIT"
 edition = "2021"
 rust-version = "1.75.0"

--- a/electrsd/README.md
+++ b/electrsd/README.md
@@ -18,7 +18,7 @@ assert_eq!(header.height, 0);
 In your project Cargo.toml, activate the following features
 
 ```yml
-electrsd = { version= "0.23", features = ["corepc-node_23_1", "electrs_0_9_1"] }
+electrsd = { version= "0.23", features = ["bitcoind_30_2", "bitcoin_download", "electrs_0_9_1"] }
 ```
 
 Then use it:


### PR DESCRIPTION
We released a typo in the `electrsd` manifest. Requires release to push the changes to crates.io

Fix the typo, bump the version number, and add a changelog entry.