### PR TITLE
docs: fix stale corepc-node references

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -27,7 +27,7 @@ jobs:
             );
 
             const filePathsToLabels = {
-              'node/': 'C-node',
+              'bitcoind/': 'C-bitcoind',
               'client/': 'C-client',
               'integration_test/': 'C-integration-test',
               'jsonrpc/': 'C-jsonrpc',

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ integration testing.
 - `bitreq/`: [`bitreq`](https://crates.io/crates/bitreq): Simple, minimal-dependency HTTP client, with optional features for proxies, async, and https.
 - `client/`: [`corepc-client`](https://crates.io/crates/corepc-client): A blocking JSON-RPC client used to test `corepc-types`.
 - `contrib/`: Contains scripts including one to run local regtest `bitcoind` nodes using versions specified in the config file. A template config file and bitcoind aliases are in the subdirectory `templates/`
-- `integration_test/`: Integration tests that use `corepc-client` and `corepc-node` to test `corepc-types`.
+- `integration_test/`: Integration tests that use `corepc-client` and `bitcoind` to test `corepc-types`.
 - `jsonrpc/`: [`jsonrpc`](https://crates.io/crates/jsonrpc): Rudimentary support for sending JSONRPC 2.0 requests and receiving responses.
-- `node/`: [`corepc-node`](https://crates.io/crates/corepc-node): Runs `bitcoind` regtest nodes.
+- `bitcoind/`: [`bitcoind`](https://crates.io/crates/bitcoind): Runs `bitcoind` regtest nodes.
 - `types/`: [`corepc-types`](https://crates.io/crates/corepc-types): Rust types returned by the JSON-RPC API of Bitcoin Core.
 - `verify/`: Provides a tool to help verify the rest of the repository.
 

--- a/bitcoind/README.md
+++ b/bitcoind/README.md
@@ -8,7 +8,7 @@ When the auto-download feature is enabled, starting a regtest node is as simple 
 // the download feature must be enabled with a specific version, for example `25_1` or `24_0_1`
 #[cfg(feature = "download")]
 {
-  let node = corepc_node::Node::from_downloaded().unwrap();
+  let node = bitcoind::BitcoinD::from_downloaded().unwrap();
   assert_eq!(0, node.client.get_blockchain_info().unwrap().blocks);
 }
 ```
@@ -22,19 +22,19 @@ When you don't use the auto-download feature you have the following options:
 * provide the `bitcoind` executable via the `BITCOIND_EXE` env var
 
 ```rust
-if let Ok(exe_path) = corepc_node::exe_path() {
-  let node = corepc_node::BitcoinD::new(exe_path).unwrap();
+if let Ok(exe_path) = bitcoind::exe_path() {
+  let node = bitcoind::BitcoinD::new(exe_path).unwrap();
   assert_eq!(0, node.client.get_blockchain_info().unwrap().blocks);
 }
 ```
 
 Startup options could be configured via the [`Conf`] struct using [`BitcoinD::with_conf`] or
-`Node::from_downloaded_with_conf`
+`BitcoinD::from_downloaded_with_conf`
 
 ## Features
 
   * Waits until bitcoind daemon becomes ready to accept RPC commands
-  * `node` uses a temporary directory as datadir. You can specify the root of your temp
+  * `bitcoind` uses a temporary directory as datadir. You can specify the root of your temp
     directories so that you have the node's datadir in a RAM disk (eg `/dev/shm`)
   * Free ports are requested from the OS. Since you can't reserve the given port, a low probability
     race condition is still possible, for this reason the process attempts spawning 3 times with

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -1,8 +1,8 @@
 # Integration testing
 
 This crate is used to run tests against all the supported versions of
-Core. It runs Core by using `corepc-node` with the `download` feature
-enabled. However `node` allows setting the environment variable
+Core. It runs Core by using `bitcoind` with the `download` feature
+enabled. However `bitcoind` allows setting the environment variable
 `BITCOIND_EXE` to override downloading the Core executable. E.g. 
 
 `BITCOIND_EXE=/opt/bitcoin-28.0/bin/bitcoind cargo test --features=28_0`


### PR DESCRIPTION
Follow up from https://github.com/rust-bitcoin/corepc/pull/573#issuecomment-4356931123

Continues `corepc-node` to `bitcoind` rename.

This updates stale documentation references that were missed in earlier changes. It fixes the top level crate listing, the `bitcoind` crate README examples and text, the `bitcoind/contrib/extra_tests.sh` comments, and the `integration_test` README.
