### PR TITLE
ci: add electrsd to labeler job and rename node label to bitcoind

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -27,12 +27,13 @@ jobs:
             );
 
             const filePathsToLabels = {
-              'node/': 'C-node',
+              'bitcoind/': 'C-bitcoind',
               'client/': 'C-client',
+              'electrsd/': 'C-electrsd',
               'integration_test/': 'C-integration-test',
               'jsonrpc/': 'C-jsonrpc',
               'types/': 'C-types',
-              'verify/': 'C-verify'
+              'verify/': 'C-verify',
             };
 
             const labelsToAdd = new Set();


### PR DESCRIPTION
Closes https://github.com/rust-bitcoin/corepc/issues/579

CI missed tagging `electrsd` PRs with `C-electrsd` label.
Renames label node to bitcoind to match recent crate rename.