### PR TITLE
bitcoind: call wait in drop to reap process

### DIFF
--- a/bitcoind/src/lib.rs
+++ b/bitcoind/src/lib.rs
@@ -573,10 +573,13 @@ impl BitcoinD {
 
 impl Drop for BitcoinD {
     fn drop(&mut self) {
+        // Frist attempt graceful shutdown for persistent directories,
+        // always fallback to force kill and wait for process to be reaped.
         if let DataDir::Persistent(_) = self.work_dir {
             let _ = self.stop();
         }
         let _ = self.process.kill();
+        let _ = self.process.wait();
     }
 }
 


### PR DESCRIPTION
Over in [rust-psbt we are seeing integration test failures](https://git.rust-bitcoin.org/rust-bitcoin/rust-psbt/actions/runs/58/jobs/8/attempt/1) which result in a CI runner spinning for hours, even though the test failed in a minute. Setting aside why the test failed (looks bitcoind related but dunno what), I am wondering if we should have a stronger guarantee in the drop to clean up the process. I looked back in the [old archive for the original impl reasoning](https://github.com/rust-bitcoin/bitcoind/pull/52) and don't see much.

I could also see this being a big no-no in a Drop impl, but for a high level thing like the bitcoind process maybe better than not?