### PR TITLE
Prepare stack of releases

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoind"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -266,7 +266,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "corepc-client"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "bitcoin",
  "corepc-types",
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-types"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "bitcoin",
  "serde",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoind"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -266,7 +266,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "corepc-client"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "bitcoin",
  "corepc-types",
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-types"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "bitcoin",
  "serde",

--- a/bitcoind/CHANGELOG.md
+++ b/bitcoind/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.39.0 - 2026-05-12
+
+- Update to use latest `corepc-client v0.14.0`.
+- Reap the `bitcoind` process in `Drop` by calling `wait` after shutdown [#585](https://github.com/rust-bitcoin/corepc/pull/585)
+- Extract `libexec/bitcoin-node` and `bin/bitcoin-cli` alongside `bitcoind` [#572](https://github.com/rust-bitcoin/corepc/pull/572)
+- Fix stale `corepc-node` references in the crate documentation [#574](https://github.com/rust-bitcoin/corepc/pull/574)
+
 # 0.38.0 - 2026-04-20
 
 - Update to use latest `bitreq v0.3.5`.

--- a/bitcoind/Cargo.toml
+++ b/bitcoind/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoind"
-version = "0.38.0"
+version = "0.39.0"
 authors = ["Riccardo Casatta <riccardo@casatta.it>", "Tobin C. Harding <me@tobin.cc>"]
 license = "MIT"
 repository = "https://github.com/rust-bitcoin/corepc"
@@ -14,7 +14,7 @@ exclude = ["tests", "contrib"]
 
 [dependencies]
 anyhow = { version = "1.0.66", default-features = false, features = ["std"] }
-corepc-client = { version = "0.13.0", path = "../client", features = ["client-sync"] }
+corepc-client = { version = "0.14.0", path = "../client", features = ["client-sync"] }
 log = { version = "0.4", default-features = false }
 serde_json = { version = "1.0.117", default-features = false }
 tempfile = { version = "3", default-features = false }

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.14.0 - 2026-05-12
+
+- Update to use latest `corepc-types v0.13.0`.
+
 # 0.13.0 - 2026-04-20
 
 - Update to use latest `jsonrpc v0.20.0`.

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-client"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Tobin C. Harding <me@tobin.cc>", "Jamil Lambert <Jamil.Lambert@proton.me>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/corepc"
@@ -29,7 +29,7 @@ bitcoin = { version = "0.32.0", default-features = false, features = ["std", "se
 log = "0.4"
 serde = { version = "1.0.103", default-features = false, features = [ "derive", "alloc" ] }
 serde_json = { version = "1.0.117" }
-types = { package = "corepc-types", version = "0.12.0", path = "../types", default-features = false, features = ["std"] }
+types = { package = "corepc-types", version = "0.13.0", path = "../types", default-features = false, features = ["std"] }
 
 jsonrpc = { version = "0.20.0", path = "../jsonrpc", features = ["bitreq_http"], optional = true }
 

--- a/electrsd/CHANGELOG.md
+++ b/electrsd/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.39.0 - 2026-05-12
+
+- Update to use latest `bitcoind v0.39.0` and `corepc-client v0.14.0`.
+- Fix the `bitcoind_23_2` feature to select the matching `bitcoind` feature [#573](https://github.com/rust-bitcoin/corepc/pull/573)
+
 # 0.38.1 - 2026-05-01
 
 - Fix typo in manifest `documentation` field.

--- a/electrsd/Cargo.toml
+++ b/electrsd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "electrsd"
-version = "0.38.1"
+version = "0.39.0"
 authors = ["Riccardo Casatta <riccardo@casatta.it>"]
 description = "Utility to run a regtest electrs process, useful in integration testing environment"
 repository = "https://github.com/rust-bitcoin/corepc"
@@ -12,8 +12,8 @@ categories = ["cryptography::cryptocurrencies", "development-tools::testing"]
 exclude = ["tests", "contrib"]
 
 [dependencies]
-bitcoind = { version = "0.38.0", path = "../bitcoind" }
-corepc-client = { version = "0.13.0", path = "../client" }
+bitcoind = { version = "0.39.0", path = "../bitcoind" }
+corepc-client = { version = "0.14.0", path = "../client" }
 electrum-client = { version = "0.24.0", default-features = false }
 log = { version = "0.4" }
 

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -63,9 +63,9 @@ TODO = []                       # This is a dirty hack while writing the tests.
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false, features = ["std", "serde"] }
 env_logger = "0.9.0"
-bitcoind = { package = "bitcoind", version = "0.38.0", path = "../bitcoind", default-features = false }
+bitcoind = { package = "bitcoind", version = "0.39.0", path = "../bitcoind", default-features = false }
 rand = "0.8.5"
 # Just so we can enable the feature.
-types = { package = "corepc-types", version = "0.12.0", path = "../types", features = ["serde-deny-unknown-fields"] }
+types = { package = "corepc-types", version = "0.13.0", path = "../types", features = ["serde-deny-unknown-fields"] }
 
 [dev-dependencies]

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.13.0 - 2026-05-12
+
+- Change `model::GetBlockchainInfo::prune_target_size` from `u32` to `u64` [#547](https://github.com/rust-bitcoin/corepc/pull/547)
+
 # 0.12.0 - 2026-04-13
 
 - Update `GetBlockStats` fields to be optional [#534](https://github.com/rust-bitcoin/corepc/pull/534)

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-types"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Tobin C. Harding <me@tobin.cc>", "Jamil Lambert <Jamil.Lambert@proton.me>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/corepc"


### PR DESCRIPTION
To prepare for the releases of bitcoind, client, electrsd and types:

- Update the changelogs (written by an LLM then minor wording fix by me).
- Bump the versions and update the dependencies versions.
- Update the lock files.