### PR TITLE
ci: enable debug logging on electrsd jobs

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -192,6 +192,7 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       CARGO_TERM_COLOR: always
+      RUST_LOG: debug
     strategy:
       matrix:
         features: ["bitcoind_22_1,bitcoind_download,legacy,esplora_a33e97e1"]
@@ -207,6 +208,7 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       CARGO_TERM_COLOR: always
+      RUST_LOG: debug
       ELECTRS_EXEC: "/home/runner/.cargo-install/electrs/bin/electrs"
     steps:
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Two CI tests for electrsd (`test-electrs-esplora` and `test-electrs-no-download`) run without `RUST_LOG=debug` set, so any spurious electrsd failure is hard to diagnose from the action logs.

This PR sets `RUST_LOG=debug` uniformly across all electrsd jobs. The only CI change is that it logs more meaningful information on errors.

Note that the third electrsd CI job `test-electrs` has `RUST_LOG: debug` set, meaning the CI job's config is presently inconsistent.