### PR TITLE
Use snake case for block hash parameters

### DIFF
--- a/client/src/client_sync/v17/hidden.rs
+++ b/client/src/client_sync/v17/hidden.rs
@@ -82,8 +82,8 @@ macro_rules! impl_client_v17__sync_with_validation_interface_queue {
 macro_rules! impl_client_v17__reconsider_block {
     () => {
         impl Client {
-            pub fn reconsider_block(&self, blockhash: bitcoin::BlockHash) -> Result<()> {
-                self.call("reconsiderblock", &[into_json(blockhash)?])
+            pub fn reconsider_block(&self, block_hash: bitcoin::BlockHash) -> Result<()> {
+                self.call("reconsiderblock", &[into_json(block_hash)?])
             }
         }
     };

--- a/client/src/client_sync/v23/blockchain.rs
+++ b/client/src/client_sync/v23/blockchain.rs
@@ -14,8 +14,9 @@
 macro_rules! impl_client_v23__get_block_from_peer {
     () => {
         impl Client {
-            pub fn get_block_from_peer(&self, blockhash: BlockHash, peer_id: u32) -> Result<()> {
-                match self.call("getblockfrompeer", &[into_json(blockhash)?, into_json(peer_id)?]) {
+            pub fn get_block_from_peer(&self, block_hash: BlockHash, peer_id: u32) -> Result<()> {
+                match self.call("getblockfrompeer", &[into_json(block_hash)?, into_json(peer_id)?])
+                {
                     Ok(serde_json::Value::Object(ref map)) if map.is_empty() => Ok(()),
                     Ok(res) => Err(Error::Returned(res.to_string())),
                     Err(err) => Err(err.into()),
@@ -36,8 +37,8 @@ macro_rules! impl_client_v23__get_deployment_info {
             }
 
             /// Query deployment info at the given block hash.
-            pub fn get_deployment_info(&self, blockhash: &BlockHash) -> Result<GetDeploymentInfo> {
-                self.call("getdeploymentinfo", &[into_json(blockhash)?])
+            pub fn get_deployment_info(&self, block_hash: &BlockHash) -> Result<GetDeploymentInfo> {
+                self.call("getdeploymentinfo", &[into_json(block_hash)?])
             }
         }
     };


### PR DESCRIPTION
Closes #462.

This renames corepc-owned Rust parameter identifiers from `blockhash` to `block_hash`.

Left unchanged:
- Bitcoin Core RPC method/argument names such as `"blockhash"`;
- serde wire-format renames;
- external `bitcoin::block::Header::prev_blockhash` fields.

Verified with:
- `cargo +nightly-2025-09-12 fmt --all --check`
- `cargo check --manifest-path client/Cargo.toml --all-targets --all-features`