### PR TITLE
Fix `getnetworkhashps` return type in docs

### DIFF
--- a/integration_test/tests/mining.rs
+++ b/integration_test/tests/mining.rs
@@ -60,7 +60,7 @@ fn mining__get_mining_info() {
 fn mining__get_network_hash_ps() {
     let node = BitcoinD::with_wallet(Wallet::Default, &[]);
     node.fund_wallet();
-    let _ = node.client.get_network_hash_ps().expect("rpc");
+    let _: f64 = node.client.get_network_hash_ps().expect("rpc");
 }
 
 #[test]

--- a/types/src/v17/mod.rs
+++ b/types/src/v17/mod.rs
@@ -83,7 +83,7 @@
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
 //! | getblocktemplate                   | version + model |                                        |
 //! | getmininginfo                      | version + model |                                        |
-//! | getnetworkhashps                   | returns boolean |                                        |
+//! | getnetworkhashps                   | returns numeric |                                        |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
 //!

--- a/types/src/v18/mod.rs
+++ b/types/src/v18/mod.rs
@@ -84,7 +84,7 @@
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
 //! | getblocktemplate                   | version + model |                                        |
 //! | getmininginfo                      | version + model |                                        |
-//! | getnetworkhashps                   | returns boolean |                                        |
+//! | getnetworkhashps                   | returns numeric |                                        |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
 //! | submitheader                       | returns nothing |                                        |

--- a/types/src/v19/mod.rs
+++ b/types/src/v19/mod.rs
@@ -84,7 +84,7 @@
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
 //! | getblocktemplate                   | version + model |                                        |
 //! | getmininginfo                      | version + model |                                        |
-//! | getnetworkhashps                   | returns boolean |                                        |
+//! | getnetworkhashps                   | returns numeric |                                        |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
 //! | submitheader                       | returns nothing |                                        |

--- a/types/src/v20/mod.rs
+++ b/types/src/v20/mod.rs
@@ -85,7 +85,7 @@
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
 //! | getblocktemplate                   | version + model |                                        |
 //! | getmininginfo                      | version + model |                                        |
-//! | getnetworkhashps                   | returns boolean |                                        |
+//! | getnetworkhashps                   | returns numeric |                                        |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
 //! | submitheader                       | returns nothing |                                        |

--- a/types/src/v21/mod.rs
+++ b/types/src/v21/mod.rs
@@ -86,7 +86,7 @@
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
 //! | getblocktemplate                   | version + model |                                        |
 //! | getmininginfo                      | version + model |                                        |
-//! | getnetworkhashps                   | returns boolean |                                        |
+//! | getnetworkhashps                   | returns numeric |                                        |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
 //! | submitheader                       | returns nothing |                                        |

--- a/types/src/v22/mod.rs
+++ b/types/src/v22/mod.rs
@@ -86,7 +86,7 @@
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
 //! | getblocktemplate                   | version + model |                                        |
 //! | getmininginfo                      | version + model |                                        |
-//! | getnetworkhashps                   | returns boolean |                                        |
+//! | getnetworkhashps                   | returns numeric |                                        |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
 //! | submitheader                       | returns nothing |                                        |

--- a/types/src/v23/mod.rs
+++ b/types/src/v23/mod.rs
@@ -77,7 +77,7 @@
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
 //! | getblocktemplate                   | version + model |                                        |
 //! | getmininginfo                      | version + model |                                        |
-//! | getnetworkhashps                   | returns boolean |                                        |
+//! | getnetworkhashps                   | returns numeric |                                        |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
 //! | submitheader                       | returns nothing |                                        |

--- a/types/src/v24/mod.rs
+++ b/types/src/v24/mod.rs
@@ -78,7 +78,7 @@
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
 //! | getblocktemplate                   | version + model |                                        |
 //! | getmininginfo                      | version + model |                                        |
-//! | getnetworkhashps                   | returns boolean |                                        |
+//! | getnetworkhashps                   | returns numeric |                                        |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
 //! | submitheader                       | returns nothing |                                        |

--- a/types/src/v25/mod.rs
+++ b/types/src/v25/mod.rs
@@ -79,7 +79,7 @@
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
 //! | getblocktemplate                   | version + model |                                        |
 //! | getmininginfo                      | version + model |                                        |
-//! | getnetworkhashps                   | returns boolean |                                        |
+//! | getnetworkhashps                   | returns numeric |                                        |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |
 //! | submitheader                       | returns nothing |                                        |

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -83,7 +83,7 @@
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
 //! | getblocktemplate                   | version + model |                                        |
 //! | getmininginfo                      | version + model |                                        |
-//! | getnetworkhashps                   | returns boolean |                                        |
+//! | getnetworkhashps                   | returns numeric |                                        |
 //! | getprioritisedtransactions         | version + model |                                        |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |

--- a/types/src/v27/mod.rs
+++ b/types/src/v27/mod.rs
@@ -83,7 +83,7 @@
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
 //! | getblocktemplate                   | version + model |                                        |
 //! | getmininginfo                      | version + model |                                        |
-//! | getnetworkhashps                   | returns boolean |                                        |
+//! | getnetworkhashps                   | returns numeric |                                        |
 //! | getprioritisedtransactions         | version + model |                                        |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |

--- a/types/src/v28/mod.rs
+++ b/types/src/v28/mod.rs
@@ -83,7 +83,7 @@
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
 //! | getblocktemplate                   | version + model |                                        |
 //! | getmininginfo                      | version + model |                                        |
-//! | getnetworkhashps                   | returns boolean |                                        |
+//! | getnetworkhashps                   | returns numeric |                                        |
 //! | getprioritisedtransactions         | version + model |                                        |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |

--- a/types/src/v29/mod.rs
+++ b/types/src/v29/mod.rs
@@ -84,7 +84,7 @@
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
 //! | getblocktemplate                   | version + model |                                        |
 //! | getmininginfo                      | version + model |                                        |
-//! | getnetworkhashps                   | returns boolean |                                        |
+//! | getnetworkhashps                   | returns numeric |                                        |
 //! | getprioritisedtransactions         | version + model |                                        |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |

--- a/types/src/v30/mod.rs
+++ b/types/src/v30/mod.rs
@@ -87,7 +87,7 @@
 //! |:-----------------------------------|:---------------:|:--------------------------------------:|
 //! | getblocktemplate                   | version + model |                                        |
 //! | getmininginfo                      | version + model |                                        |
-//! | getnetworkhashps                   | returns boolean |                                        |
+//! | getnetworkhashps                   | returns numeric |                                        |
 //! | getprioritisedtransactions         | version + model |                                        |
 //! | prioritisetransaction              | returns boolean |                                        |
 //! | submitblock                        | returns nothing |                                        |

--- a/verify/src/method/v18.rs
+++ b/verify/src/method/v18.rs
@@ -48,7 +48,7 @@ pub const METHODS: &[Method] = &[
     // mining
     Method::new_modelled("getblocktemplate", "GetBlockTemplate", "get_block_template"),
     Method::new_modelled("getmininginfo", "GetMiningInfo", "get_mining_info"),
-    Method::new_nothing("getnetworkhashps", "get_network_hashes_per_second"),
+    Method::new_numeric("getnetworkhashps", "get_network_hashes_per_second"),
     Method::new_bool("prioritisetransaction", "prioritise_transaction"),
     Method::new_nothing("submitblock", "submit_block"),
     Method::new_nothing("submitheader", "submit_header"),

--- a/verify/src/method/v19.rs
+++ b/verify/src/method/v19.rs
@@ -48,7 +48,7 @@ pub const METHODS: &[Method] = &[
     // mining
     Method::new_modelled("getblocktemplate", "GetBlockTemplate", "get_block_template"),
     Method::new_modelled("getmininginfo", "GetMiningInfo", "get_mining_info"),
-    Method::new_nothing("getnetworkhashps", "get_network_hashes_per_second"),
+    Method::new_numeric("getnetworkhashps", "get_network_hashes_per_second"),
     Method::new_bool("prioritisetransaction", "prioritise_transaction"),
     Method::new_nothing("submitblock", "submit_block"),
     Method::new_nothing("submitheader", "submit_header"),

--- a/verify/src/method/v20.rs
+++ b/verify/src/method/v20.rs
@@ -49,7 +49,7 @@ pub const METHODS: &[Method] = &[
     // mining
     Method::new_modelled("getblocktemplate", "GetBlockTemplate", "get_block_template"),
     Method::new_modelled("getmininginfo", "GetMiningInfo", "get_mining_info"),
-    Method::new_nothing("getnetworkhashps", "get_network_hashes_per_second"),
+    Method::new_numeric("getnetworkhashps", "get_network_hashes_per_second"),
     Method::new_bool("prioritisetransaction", "prioritise_transaction"),
     Method::new_nothing("submitblock", "submit_block"),
     Method::new_nothing("submitheader", "submit_header"),

--- a/verify/src/method/v21.rs
+++ b/verify/src/method/v21.rs
@@ -50,7 +50,7 @@ pub const METHODS: &[Method] = &[
     // mining
     Method::new_modelled("getblocktemplate", "GetBlockTemplate", "get_block_template"),
     Method::new_modelled("getmininginfo", "GetMiningInfo", "get_mining_info"),
-    Method::new_nothing("getnetworkhashps", "get_network_hashes_per_second"),
+    Method::new_numeric("getnetworkhashps", "get_network_hashes_per_second"),
     Method::new_bool("prioritisetransaction", "prioritise_transaction"),
     Method::new_nothing("submitblock", "submit_block"),
     Method::new_nothing("submitheader", "submit_header"),

--- a/verify/src/method/v22.rs
+++ b/verify/src/method/v22.rs
@@ -50,7 +50,7 @@ pub const METHODS: &[Method] = &[
     // mining
     Method::new_modelled("getblocktemplate", "GetBlockTemplate", "get_block_template"),
     Method::new_modelled("getmininginfo", "GetMiningInfo", "get_mining_info"),
-    Method::new_nothing("getnetworkhashps", "get_network_hashes_per_second"),
+    Method::new_numeric("getnetworkhashps", "get_network_hashes_per_second"),
     Method::new_bool("prioritisetransaction", "prioritise_transaction"),
     Method::new_nothing("submitblock", "submit_block"),
     Method::new_nothing("submitheader", "submit_header"),

--- a/verify/src/method/v23.rs
+++ b/verify/src/method/v23.rs
@@ -48,7 +48,7 @@ pub const METHODS: &[Method] = &[
     // mining
     Method::new_modelled("getblocktemplate", "GetBlockTemplate", "get_block_template"),
     Method::new_modelled("getmininginfo", "GetMiningInfo", "get_mining_info"),
-    Method::new_nothing("getnetworkhashps", "get_network_hashes_per_second"),
+    Method::new_numeric("getnetworkhashps", "get_network_hashes_per_second"),
     Method::new_bool("prioritisetransaction", "prioritise_transaction"),
     Method::new_nothing("submitblock", "submit_block"),
     Method::new_nothing("submitheader", "submit_header"),

--- a/verify/src/method/v24.rs
+++ b/verify/src/method/v24.rs
@@ -49,7 +49,7 @@ pub const METHODS: &[Method] = &[
     // mining
     Method::new_modelled("getblocktemplate", "GetBlockTemplate", "get_block_template"),
     Method::new_modelled("getmininginfo", "GetMiningInfo", "get_mining_info"),
-    Method::new_nothing("getnetworkhashps", "get_network_hashes_per_second"),
+    Method::new_numeric("getnetworkhashps", "get_network_hashes_per_second"),
     Method::new_bool("prioritisetransaction", "prioritise_transaction"),
     Method::new_nothing("submitblock", "submit_block"),
     Method::new_nothing("submitheader", "submit_header"),

--- a/verify/src/method/v25.rs
+++ b/verify/src/method/v25.rs
@@ -50,7 +50,7 @@ pub const METHODS: &[Method] = &[
     // mining
     Method::new_modelled("getblocktemplate", "GetBlockTemplate", "get_block_template"),
     Method::new_modelled("getmininginfo", "GetMiningInfo", "get_mining_info"),
-    Method::new_nothing("getnetworkhashps", "get_network_hashes_per_second"),
+    Method::new_numeric("getnetworkhashps", "get_network_hashes_per_second"),
     Method::new_bool("prioritisetransaction", "prioritise_transaction"),
     Method::new_nothing("submitblock", "submit_block"),
     Method::new_nothing("submitheader", "submit_header"),

--- a/verify/src/method/v26.rs
+++ b/verify/src/method/v26.rs
@@ -54,7 +54,7 @@ pub const METHODS: &[Method] = &[
     // mining
     Method::new_modelled("getblocktemplate", "GetBlockTemplate", "get_block_template"),
     Method::new_modelled("getmininginfo", "GetMiningInfo", "get_mining_info"),
-    Method::new_nothing("getnetworkhashps", "get_network_hashes_per_second"),
+    Method::new_numeric("getnetworkhashps", "get_network_hashes_per_second"),
     Method::new_modelled(
         "getprioritisedtransactions",
         "GetPrioritisedTransactions",

--- a/verify/src/method/v27.rs
+++ b/verify/src/method/v27.rs
@@ -54,7 +54,7 @@ pub const METHODS: &[Method] = &[
     // mining
     Method::new_modelled("getblocktemplate", "GetBlockTemplate", "get_block_template"),
     Method::new_modelled("getmininginfo", "GetMiningInfo", "get_mining_info"),
-    Method::new_nothing("getnetworkhashps", "get_network_hashes_per_second"),
+    Method::new_numeric("getnetworkhashps", "get_network_hashes_per_second"),
     Method::new_modelled(
         "getprioritisedtransactions",
         "GetPrioritisedTransactions",

--- a/verify/src/method/v28.rs
+++ b/verify/src/method/v28.rs
@@ -54,7 +54,7 @@ pub const METHODS: &[Method] = &[
     // mining
     Method::new_modelled("getblocktemplate", "GetBlockTemplate", "get_block_template"),
     Method::new_modelled("getmininginfo", "GetMiningInfo", "get_mining_info"),
-    Method::new_nothing("getnetworkhashps", "get_network_hashes_per_second"),
+    Method::new_numeric("getnetworkhashps", "get_network_hashes_per_second"),
     Method::new_modelled(
         "getprioritisedtransactions",
         "GetPrioritisedTransactions",

--- a/verify/src/method/v29.rs
+++ b/verify/src/method/v29.rs
@@ -59,7 +59,7 @@ pub const METHODS: &[Method] = &[
     // mining
     Method::new_modelled("getblocktemplate", "GetBlockTemplate", "get_block_template"),
     Method::new_modelled("getmininginfo", "GetMiningInfo", "get_mining_info"),
-    Method::new_nothing("getnetworkhashps", "get_network_hashes_per_second"),
+    Method::new_numeric("getnetworkhashps", "get_network_hashes_per_second"),
     Method::new_modelled(
         "getprioritisedtransactions",
         "GetPrioritisedTransactions",

--- a/verify/src/method/v30.rs
+++ b/verify/src/method/v30.rs
@@ -62,7 +62,7 @@ pub const METHODS: &[Method] = &[
     // mining
     Method::new_modelled("getblocktemplate", "GetBlockTemplate", "get_block_template"),
     Method::new_modelled("getmininginfo", "GetMiningInfo", "get_mining_info"),
-    Method::new_nothing("getnetworkhashps", "get_network_hashes_per_second"),
+    Method::new_numeric("getnetworkhashps", "get_network_hashes_per_second"),
     Method::new_modelled(
         "getprioritisedtransactions",
         "GetPrioritisedTransactions",


### PR DESCRIPTION
`getnetworkhashps` returns an `f64` but was marked as returning a `bool` in the `types` table, and returning nothing in `verify`.

Fix them both to be `f64`.

Update the test to specify the return type.