### PR TITLE
electrsd: set default features for bitreq

### DIFF
--- a/electrsd/Cargo.toml
+++ b/electrsd/Cargo.toml
@@ -29,9 +29,7 @@ zip = { version = "0.6", default-features = false, optional = true, features = [
   "bzip2",
   "deflate",
 ] }
-bitreq = { version = "0.3.5", path = "../bitreq", default-features = false, optional = true, features = [
-  "https",
-] }
+bitreq = { version = "0.3.5", path = "../bitreq", optional = true, features = ["https"] }
 
 [features]
 legacy = []


### PR DESCRIPTION
If and only if the download feature is set, bitreq is required. In that case the bitreq std feature is needed, so we enable default-features for bitreq to set the std feature. No other bitreq feature is enabled.