### PR TITLE
initializing the default crypto provider for electrsd

### DIFF
--- a/bitcoind/build.rs
+++ b/bitcoind/build.rs
@@ -14,6 +14,7 @@ mod download {
 
     use anyhow::Context;
     use bitcoin_hashes::{sha256, Hash};
+    use bitreq::rustls::crypto::{ring, CryptoProvider};
     use flate2::read::GzDecoder;
     use tar::Archive;
 
@@ -79,6 +80,9 @@ mod download {
             return Ok(());
         }
         let out_dir = PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
+
+        // specify the default crypto provider for rustls
+        let _ = CryptoProvider::install_default(ring::default_provider());
 
         let bitcoin_exe_home = download_dir(&out_dir);
         std::fs::create_dir_all(&bitcoin_exe_home)

--- a/bitreq/src/lib.rs
+++ b/bitreq/src/lib.rs
@@ -272,4 +272,6 @@ pub use proxy::*;
 pub use request::*;
 #[cfg(feature = "std")]
 pub use response::{Response, ResponseLazy};
+#[cfg(feature = "https-rustls")]
+pub use rustls;
 pub use url::{ParseError as UrlParseError, Url};

--- a/electrsd/build.rs
+++ b/electrsd/build.rs
@@ -14,6 +14,7 @@ mod download {
     use std::os::unix::fs::PermissionsExt;
     use std::path::Path;
     use std::str::FromStr;
+    use bitreq::rustls::crypto::{CryptoProvider, ring};
 
     include!("src/versions.rs");
 
@@ -35,6 +36,9 @@ mod download {
         if std::env::var_os("ELECTRSD_SKIP_DOWNLOAD").is_some() {
             return;
         }
+
+        // specify the default crypto provider for rustls
+        let _ = CryptoProvider::install_default(ring::default_provider());
 
         if !HAS_FEATURE {
             return;


### PR DESCRIPTION
When I want to use electrsd v39 in bdk-reserves (https://github.com/bitcoindevkit/bdk-reserves/pull/42), I ran into errors about the rustls default crypto provider not being initialized.