### PR TITLE
Fix a couple of CI failues

### DIFF
--- a/bitreq/src/connection/rustls_stream.rs
+++ b/bitreq/src/connection/rustls_stream.rs
@@ -17,7 +17,7 @@ use rustls::{self, ClientConfig, ClientConnection, RootCertStore, StreamOwned};
 use tokio_native_tls::TlsConnector as AsyncTlsConnector;
 #[cfg(any(feature = "async-https-rustls", feature = "async-https-rustls-probe"))]
 use tokio_rustls::{client::TlsStream, TlsConnector};
-#[cfg(feature = "rustls-webpki")]
+#[cfg(feature = "webpki-roots")]
 use webpki_roots::TLS_SERVER_ROOTS;
 
 #[cfg(any(feature = "async-https-rustls", feature = "async-https-rustls-probe"))]
@@ -41,7 +41,7 @@ fn build_client_config() -> Arc<ClientConfig> {
         let _ = root_certificates.add(cert);
     }
 
-    #[cfg(feature = "rustls-webpki")]
+    #[cfg(feature = "webpki-roots")]
     root_certificates.extend(TLS_SERVER_ROOTS.iter().cloned());
 
     let config =

--- a/bitreq/tests/url_properties.rs
+++ b/bitreq/tests/url_properties.rs
@@ -333,7 +333,7 @@ proptest! {
         ctrl_char in 0u8..32u8,
         suffix in "[a-z]{0,10}"
     ) {
-        if ctrl_char.is_ascii_whitespace() && suffix.is_empty() {
+        if char::from(ctrl_char).is_whitespace() && suffix.is_empty() {
             return Ok(());
         }
         let invalid_url = format!("{}{}{}", prefix, ctrl_char as char, suffix);


### PR DESCRIPTION
Now that CI uses rbmt, random combinations of features are tested in CI. This causes CI failures on PRs unrelated to the PR changes, often due to feature gates.

Fix two that came up recently.