### PR TITLE
test: make explicit returned stdlib types in tests

### DIFF
--- a/integration_test/tests/blockchain.rs
+++ b/integration_test/tests/blockchain.rs
@@ -585,7 +585,7 @@ fn blockchain__get_tx_out_proof() {
     let (_address, tx) = node.create_mined_transaction();
     let txid = tx.compute_txid();
 
-    let _ = node.client.get_tx_out_proof(&[txid]).expect("gettxoutproof");
+    let _: String = node.client.get_tx_out_proof(&[txid]).expect("gettxoutproof");
 }
 
 #[test]

--- a/integration_test/tests/control.rs
+++ b/integration_test/tests/control.rs
@@ -23,7 +23,7 @@ fn control__get_rpc_info() {
 #[test]
 fn control__help() {
     let node = BitcoinD::with_wallet(Wallet::None, &[]);
-    let _ = node.client.help().unwrap();
+    let _: String = node.client.help().unwrap();
 }
 
 #[test]
@@ -35,11 +35,11 @@ fn control__logging() {
 #[test]
 fn control__stop() {
     let node = BitcoinD::with_wallet(Wallet::None, &[]);
-    let _ = node.client.stop().unwrap();
+    let _: String = node.client.stop().unwrap();
 }
 
 #[test]
 fn control__uptime() {
     let node = BitcoinD::with_wallet(Wallet::None, &[]);
-    let _ = node.client.uptime().unwrap();
+    let _: u32 = node.client.uptime().unwrap();
 }


### PR DESCRIPTION
Fixes #600

No more primitive return types in tests
```
$  grep -rn 'let _ = .*node\.client' . --exclude-dir=target | awk -F'node.client.' '{print $2}' | awk -F'(' '{print $1}' | sort -u | xargs -I {} grep -rnE 'fn[[:space:]]+{}' .  --exclude-dir=target
./client/src/client_sync/v17/hidden.rs:20:            pub fn estimate_raw_fee(&self, conf_target: u32) -> Result<EstimateRawFee> {
./client/src/client_sync/v17/generating.rs:17:            pub fn generate_to_address(
./client/src/client_sync/v26/mining.rs:17:            pub fn get_prioritised_transactions(&self) -> Result<GetPrioritisedTransactions> {
./client/src/client_sync/v18/control.rs:15:            pub fn get_rpc_info(&self) -> Result<GetRpcInfo> { self.call("getrpcinfo", &[]) }
./client/src/client_sync/v17/wallet.rs:180:            pub fn new_address(&self) -> Result<bitcoin::Address> {
./client/src/client_sync/v17/wallet.rs:187:            pub fn new_address_with_type(&self, ty: AddressType) -> Result<bitcoin::Address> {
./client/src/client_sync/v17/wallet.rs:195:            pub fn new_address_with_label(
./client/src/client_sync/v17/wallet.rs:195:            pub fn new_address_with_label(
./client/src/client_sync/v17/wallet.rs:187:            pub fn new_address_with_type(&self, ty: AddressType) -> Result<bitcoin::Address> {
./client/src/client_sync/v17/raw_transactions.rs:180:            pub fn send_raw_transaction(
./client/src/client_sync/v17/wallet.rs:579:            pub fn send_to_address(
./client/src/client_sync/v17/wallet.rs:589:            pub fn send_to_address_rbf(
$
```