### PR TITLE
tests: add curated list of client test invariants from Bitcoin Core

### DIFF
--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -33,3 +33,8 @@ alias test28='BITCOIND_EXE=/opt/bitcoin-28.2/bin/bitcoind cargo test --features=
 alias test29='BITCOIND_EXE=/opt/bitcoin-29.0/bin/bitcoind cargo test --features=29_0'
 alias test30='BITCOIND_EXE=/opt/bitcoin-30.2/bin/bitcoind cargo test --features=30_2'
 ```
+
+## Bitcoin Core Tests
+
+Tests derived from Bitcoin Core's `test/functional/` folder live in
+`tests/` alongside the modelled tests, with a `_core` filename suffix.

--- a/integration_test/tests/blockchain_core.rs
+++ b/integration_test/tests/blockchain_core.rs
@@ -1,0 +1,421 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Tests derived from Bitcoin Core rpc_blockchain.py, rpc_getchaintips.py,
+//! rpc_txoutproof.py, rpc_scantxoutset.py, rpc_gettxspendingprevout.py,
+//! rpc_dumptxoutset.py and rpc_getblockstats.py
+
+use bitcoind::mtype;
+use bitcoind::vtype::*;
+use integration_test::{BitcoinD, BitcoinDExt as _, Wallet};
+
+#[test]
+fn get_blockchain_info_pruned_node_has_prune_fields() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &["-prune=550"]);
+    node.fund_wallet();
+    let out: GetBlockchainInfo = node.client.get_blockchain_info().unwrap();
+
+    assert!(out.pruned);
+    assert!(out.prune_height.is_some());
+    assert!(out.automatic_pruning.is_some());
+    assert!(out.prune_target_size.is_some());
+}
+
+#[test]
+fn get_chain_tx_stats_default_window_has_optional_fields() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    let addr = node.client.new_address().unwrap();
+    node.client.generate_to_address(200, &addr).unwrap();
+
+    let json: GetChainTxStats = node.client.get_chain_tx_stats().unwrap();
+    let stats: mtype::GetChainTxStats = json.into_model().unwrap();
+
+    #[cfg(not(feature = "v18_and_below"))]
+    assert!(stats.window_final_block_height.is_some());
+    assert!(stats.window_tx_count.is_some());
+    assert!(stats.window_interval.is_some());
+    assert!(stats.tx_rate.is_some());
+}
+
+#[test]
+fn get_chain_tx_stats_pinned_to_block1_has_no_window_fields() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    let addr = node.client.new_address().unwrap();
+    node.client.generate_to_address(200, &addr).unwrap();
+
+    let b1 = node.client.get_block_hash(1).unwrap().block_hash().unwrap();
+
+    let json: GetChainTxStats = node
+        .client
+        .call(
+            "getchaintxstats",
+            &[bitcoind::serde_json::Value::Null, bitcoind::serde_json::json!(b1.to_string())],
+        )
+        .unwrap();
+    let stats: mtype::GetChainTxStats = json.into_model().unwrap();
+
+    assert!(stats.window_tx_count.is_none());
+    assert!(stats.window_interval.is_none());
+    assert!(stats.tx_rate.is_none());
+}
+
+#[test]
+fn get_tx_out_set_info_after_mining() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+
+    let height = node.client.get_block_count().unwrap().0;
+    let json: GetTxOutSetInfo = node.client.get_tx_out_set_info().unwrap();
+
+    assert_eq!(json.height, height as i64);
+    #[cfg(not(feature = "v25_and_below"))]
+    assert!(json.transactions.is_some());
+    #[cfg(all(not(feature = "v25_and_below"), feature = "v28_and_below"))]
+    assert!(json.disk_size.is_some());
+}
+
+#[test]
+fn get_tx_out_set_info_at_genesis() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+    let b1 = node.client.get_block_hash(1).unwrap().block_hash().unwrap();
+    node.client.invalidate_block(b1).unwrap();
+
+    let json: GetTxOutSetInfo = node.client.get_tx_out_set_info().unwrap();
+
+    assert_eq!(json.height, 0);
+    #[cfg(not(feature = "v25_and_below"))]
+    assert!(json.hash_serialized_3.is_some());
+}
+
+#[test]
+#[cfg(not(feature = "v25_and_below"))]
+fn get_tx_out_set_info_muhash() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+
+    let json: GetTxOutSetInfo =
+        node.client.call("gettxoutsetinfo", &[bitcoind::serde_json::json!("muhash")]).unwrap();
+
+    assert!(json.muhash.is_some());
+}
+
+#[test]
+fn get_tx_out_coinbase_fields() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+
+    let best = node.client.best_block_hash().unwrap();
+    let block = node.client.get_block(best).unwrap();
+    let coinbase = block.txdata[0].compute_txid();
+
+    let json: GetTxOut = node.client.get_tx_out(coinbase, 0).unwrap();
+
+    assert_eq!(json.confirmations, 1);
+    assert!(json.coinbase);
+    assert_eq!(json.best_block, best.to_string());
+}
+
+#[test]
+fn get_block_header_verbose_fields() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+
+    let best = node.client.best_block_hash().unwrap();
+    let height = node.client.get_block_count().unwrap().0;
+    let prev = node.client.get_block_hash(height - 1).unwrap().block_hash().unwrap();
+
+    let json: GetBlockHeaderVerbose = node.client.get_block_header_verbose(&best).unwrap();
+
+    assert_eq!(json.hash, best.to_string());
+    assert_eq!(json.confirmations, 1);
+    assert_eq!(json.height, height as i64);
+    assert_eq!(json.previous_block_hash.as_deref(), Some(prev.to_string().as_str()));
+}
+
+#[test]
+fn get_block_hash_at_tip_matches_best() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+
+    let best = node.client.best_block_hash().unwrap();
+    let height = node.client.get_block_count().unwrap().0;
+    let at_height = node.client.get_block_hash(height).unwrap().block_hash().unwrap();
+
+    assert_eq!(at_height, best);
+}
+
+#[test]
+fn get_block_verbose_one_tx_count_matches_n_tx() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+    node.create_mined_transaction();
+    let hash = node.client.best_block_hash().unwrap();
+
+    let json: GetBlockVerboseOne = node.client.get_block_verbose_one(hash).unwrap();
+
+    assert_eq!(json.tx.len(), json.n_tx as usize);
+    assert!(json.previous_block_hash.is_some());
+}
+
+#[test]
+fn get_chain_tips_active_tip_matches_best() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+
+    let best = node.client.best_block_hash().unwrap();
+    let height = node.client.get_block_count().unwrap().0;
+    let json: GetChainTips = node.client.get_chain_tips().unwrap();
+
+    let tip = json.0.iter().find(|t| t.status == ChainTipsStatus::Active).unwrap();
+    assert_eq!(tip.hash, best.to_string());
+    assert_eq!(tip.height, height as i64);
+    assert_eq!(tip.branch_length, 0);
+}
+
+#[test]
+fn get_mempool_entry_height_and_no_parents() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+    let (_, txid) = node.create_mempool_transaction();
+
+    let height = node.client.get_block_count().unwrap().0;
+    let json: GetMempoolEntry = node.client.get_mempool_entry(txid).unwrap();
+
+    assert_eq!(json.0.height, height as i64);
+    assert!(json.0.depends.is_empty());
+}
+
+#[test]
+fn verify_tx_out_proof_round_trips_txid() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+    let (_, tx) = node.create_mined_transaction();
+    let txid = tx.compute_txid();
+
+    let proof = node.client.get_tx_out_proof(&[txid]).unwrap();
+    let json: VerifyTxOutProof = node.client.verify_tx_out_proof(&proof).unwrap();
+
+    assert_eq!(json.0[0], txid.to_string());
+}
+
+#[test]
+#[cfg(not(feature = "v18_and_below"))]
+fn scan_tx_out_set_best_block_matches_tip() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+
+    let best = node.client.best_block_hash().unwrap();
+    let height = node.client.get_block_count().unwrap().0;
+
+    let desc = "pkh(0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)";
+    let json: ScanTxOutSetStart = node.client.scan_tx_out_set_start(&[desc]).unwrap();
+
+    assert_eq!(json.best_block, best.to_string());
+    assert_eq!(json.height, height);
+}
+
+#[test]
+#[cfg(not(feature = "v22_and_below"))]
+fn get_deployment_info_genesis_vs_tip() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+
+    let genesis = node.client.get_block_hash(0).unwrap().block_hash().unwrap();
+    let tip = node.client.best_block_hash().unwrap();
+
+    let g: GetDeploymentInfo = node.client.get_deployment_info(&genesis).unwrap();
+    let t: GetDeploymentInfo = node.client.get_deployment_info_tip().unwrap();
+
+    assert_eq!(g.hash, genesis.to_string());
+    assert_eq!(g.height, 0);
+    assert_eq!(t.hash, tip.to_string());
+}
+
+#[test]
+#[cfg(not(feature = "v23_and_below"))]
+fn get_tx_spending_prevout_for_unspent_output() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+    let (_, txid) = node.create_mempool_transaction();
+
+    let outpoints = vec![bitcoin::OutPoint { txid, vout: 0 }];
+    let json: GetTxSpendingPrevout = node.client.get_tx_spending_prevout(&outpoints).unwrap();
+
+    assert_eq!(json.0.len(), 1);
+    assert_eq!(json.0[0].txid, txid.to_string());
+    assert_eq!(json.0[0].vout, 0);
+    assert!(json.0[0].spending_txid.is_none());
+}
+
+#[test]
+#[cfg(not(feature = "v28_and_below"))]
+fn get_block_verbose_two_non_coinbase_has_fee() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+    let (_, mined) = node.create_mined_transaction();
+    let hash = node.client.best_block_hash().unwrap();
+
+    let json: GetBlockVerboseTwo = node.client.get_block_verbose_two(hash).unwrap();
+
+    let mined_id = mined.compute_txid().to_string();
+    let entry = json.tx.iter().find(|t| t.transaction.txid == mined_id).unwrap();
+    assert!(entry.fee.is_some());
+}
+
+#[test]
+#[cfg(not(feature = "v28_and_below"))]
+fn get_block_verbose_three_non_coinbase_has_prevouts() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+    let (_, mined) = node.create_mined_transaction();
+    let hash = node.client.best_block_hash().unwrap();
+
+    let json: GetBlockVerboseThree = node.client.get_block_verbose_three(hash).unwrap();
+
+    let mined_id = mined.compute_txid().to_string();
+    let entry = json.tx.iter().find(|t| t.transaction.txid == mined_id).unwrap();
+
+    assert!(entry.transaction.inputs.iter().any(|v| v.prevout.is_some()));
+}
+
+#[test]
+fn get_mempool_entry_spent_by_contains_child() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+    let (_, parent) = node.create_mempool_transaction();
+    let child = create_child_spending_parent(&node, parent);
+
+    let json: GetMempoolEntry = node.client.get_mempool_entry(parent).unwrap();
+
+    assert!(json.0.spent_by.iter().any(|t| *t == child.to_string()));
+}
+
+#[test]
+#[cfg(not(feature = "v20_and_below"))]
+fn get_raw_mempool_sequence_includes_tx() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+    let (_, txid) = node.create_mempool_transaction();
+
+    let json: GetRawMempoolSequence = node.client.get_raw_mempool_sequence().unwrap();
+
+    assert!(json.txids.iter().any(|t| *t == txid.to_string()));
+    assert!(json.mempool_sequence > 0);
+}
+
+#[test]
+fn get_mempool_ancestors_verbose_keyed_by_parent_txid() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+    let (_, parent) = node.create_mempool_transaction();
+    let child = create_child_spending_parent(&node, parent);
+
+    let json: GetMempoolAncestorsVerbose =
+        node.client.get_mempool_ancestors_verbose(child).unwrap();
+
+    assert!(json.0.contains_key(&parent.to_string()));
+}
+
+#[test]
+fn get_block_verbose_one_stripped_size_le_size() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+    node.create_mined_transaction();
+    let best = node.client.best_block_hash().unwrap();
+
+    let json: GetBlockVerboseOne = node.client.get_block_verbose_one(best).unwrap();
+
+    assert!(json.stripped_size.is_some());
+    assert!(json.stripped_size.unwrap() <= json.size);
+}
+
+#[test]
+fn get_block_verbose_one_next_block_hash_some_for_non_tip() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+
+    let b1 = node.client.get_block_hash(1).unwrap().block_hash().unwrap();
+    let json: GetBlockVerboseOne = node.client.get_block_verbose_one(b1).unwrap();
+
+    assert!(json.next_block_hash.is_some());
+}
+
+#[test]
+fn get_chain_tips_after_invalidate_block_has_stale_tip() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+
+    let tip = node.client.best_block_hash().unwrap();
+    node.client.invalidate_block(tip).unwrap();
+    node.mine_a_block();
+
+    let json: GetChainTips = node.client.get_chain_tips().unwrap();
+
+    let stale = json.0.iter().find(|t| t.status == ChainTipsStatus::Invalid).unwrap();
+    assert_eq!(stale.branch_length, 1);
+}
+
+#[test]
+#[cfg(not(feature = "v25_and_below"))]
+fn dump_tx_out_set_fields_consistent() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+
+    let temp = integration_test::random_tmp_file();
+    let path = temp.to_str().unwrap();
+
+    #[cfg(feature = "v28_and_below")]
+    let json: DumpTxOutSet = node.client.dump_tx_out_set(path).unwrap();
+    #[cfg(not(feature = "v28_and_below"))]
+    let json: DumpTxOutSet = node.client.dump_tx_out_set(path, "latest").unwrap();
+
+    let tip = node.client.get_block_count().unwrap().0;
+
+    assert_eq!(json.base_height, tip as i64);
+    assert!(json.n_chain_tx > 0);
+    assert!(!json.tx_out_set_hash.is_empty());
+}
+
+#[test]
+#[cfg(not(feature = "v24_and_below"))]
+fn get_block_stats_genesis_utxo_fields() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+
+    let json: GetBlockStats = node.client.get_block_stats_by_height(0, None).unwrap();
+
+    assert_eq!(json.utxo_increase, Some(1));
+    assert!(json.utxo_size_increase.is_some());
+}
+
+#[test]
+#[cfg(not(feature = "v24_and_below"))]
+fn get_block_stats_v25_actual_utxo_fields() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+    let tip = node.client.get_block_count().unwrap().0;
+
+    let json: GetBlockStats = node.client.get_block_stats_by_height(tip as u32, None).unwrap();
+
+    assert!(json.utxo_increase_actual.is_some());
+    assert!(json.utxo_size_increase_actual.is_some());
+}
+
+fn create_child_spending_parent(node: &BitcoinD, parent: bitcoin::Txid) -> bitcoin::Txid {
+    use bitcoind::{Input, Output};
+    let inputs = vec![Input { txid: parent, vout: 0, sequence: None }];
+    let addr = node.client.new_address().unwrap();
+    let outputs = vec![Output::new(addr, bitcoin::Amount::from_sat(100_000))];
+
+    let raw: CreateRawTransaction = node.client.create_raw_transaction(&inputs, &outputs).unwrap();
+    let unsigned = raw.transaction().unwrap();
+
+    let funded: FundRawTransaction = node.client.fund_raw_transaction(&unsigned).unwrap();
+    let funded_tx = funded.transaction().unwrap();
+
+    let signed: SignRawTransaction =
+        node.client.sign_raw_transaction_with_wallet(&funded_tx).unwrap();
+    let model = signed.into_model().unwrap();
+    let child = model.tx.compute_txid();
+    node.client.send_raw_transaction(&model.tx).unwrap();
+    child
+}

--- a/integration_test/tests/control_core.rs
+++ b/integration_test/tests/control_core.rs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Tests derived from Bitcoin Core rpc_misc.py and rpc_uptime.py
+
+use bitcoind::vtype::*;
+use integration_test::{BitcoinD, BitcoinDExt as _, Wallet};
+
+#[test]
+fn get_memory_info_has_locked_key() {
+    let node = BitcoinD::with_wallet(Wallet::None, &[]);
+    let json: GetMemoryInfoStats = node.client.get_memory_info().unwrap();
+
+    assert!(json.0.contains_key("locked"));
+
+    let locked = &json.0["locked"];
+    assert_eq!(locked.used + locked.free, locked.total);
+}
+
+#[test]
+#[cfg(not(feature = "v18_and_below"))]
+fn get_rpc_info_active_commands_contains_self() {
+    let node = BitcoinD::with_wallet(Wallet::None, &[]);
+
+    let json: GetRpcInfo = node.client.get_rpc_info().unwrap();
+
+    assert!(!json.active_commands.is_empty());
+    assert!(json.active_commands.iter().any(|c| c.method == "getrpcinfo"));
+}
+
+#[test]
+#[cfg(not(feature = "v20_and_below"))]
+fn get_index_info_has_txindex() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &["-txindex"]);
+    node.fund_wallet();
+
+    let height = node.client.get_block_count().unwrap().0;
+    let json: GetIndexInfo = node.client.get_index_info().unwrap();
+
+    let txindex = json.0.get("txindex").unwrap();
+    assert!(txindex.best_block_height <= height as u32);
+}

--- a/integration_test/tests/mining_core.rs
+++ b/integration_test/tests/mining_core.rs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Tests derived from Bitcoin Core mining_basic.py, rpc_generate.py
+
+#[cfg(not(feature = "v25_and_below"))]
+use bitcoin::SignedAmount;
+use bitcoind::vtype::*;
+use bitcoind::{TemplateRequest, TemplateRules};
+use integration_test::{BitcoinD, BitcoinDExt as _, Wallet};
+
+#[test]
+#[cfg(not(feature = "v25_and_below"))]
+fn get_prioritised_transactions_round_trips_fee_delta() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+    let (_, txid) = node.create_mempool_transaction();
+
+    let fee_delta = SignedAmount::from_sat(10_000);
+    node.client.prioritise_transaction(&txid, fee_delta).unwrap();
+
+    let json: GetPrioritisedTransactions = node.client.get_prioritised_transactions().unwrap();
+
+    let entry = json.0.get(&txid.to_string()).unwrap();
+    assert_eq!(entry.fee_delta, fee_delta.to_sat());
+}
+
+#[test]
+fn generate_to_address_hash_matches_best_block() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    let addr = node.client.new_address().unwrap();
+
+    let json: GenerateToAddress = node.client.generate_to_address(1, &addr).unwrap();
+    let hashes = json.into_model().unwrap();
+
+    assert_eq!(hashes.0[0], node.client.best_block_hash().unwrap());
+}
+
+#[test]
+#[cfg(not(feature = "v20_and_below"))]
+fn generate_block_with_empty_tx_list() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    let addr = node.client.new_address().unwrap();
+
+    #[cfg(feature = "v24_and_below")]
+    let json: GenerateBlock = node.client.generate_block(&addr.to_string(), &[]).unwrap();
+
+    #[cfg(not(feature = "v24_and_below"))]
+    let json: GenerateBlock = node.client.generate_block(&addr.to_string(), &[], true).unwrap();
+
+    let block_hash: bitcoin::BlockHash = json.hash.parse().unwrap();
+    assert_eq!(block_hash, node.client.best_block_hash().unwrap());
+}
+
+#[test]
+fn get_block_template_has_optional_fields() {
+    let (node1, _node2, _node3) = integration_test::three_node_network();
+    node1.fund_wallet();
+
+    #[cfg(feature = "v28_and_below")]
+    let options = TemplateRequest { rules: vec![TemplateRules::Segwit] };
+    #[cfg(not(feature = "v28_and_below"))]
+    let options = TemplateRequest {
+        rules: vec![TemplateRules::Segwit],
+        mode: Some("template".to_string()),
+        ..Default::default()
+    };
+
+    let json: GetBlockTemplate = node1.client.get_block_template(&options).unwrap();
+
+    assert!(json.long_poll_id.is_some());
+    assert!(json.default_witness_commitment.is_some());
+}
+
+#[test]
+fn get_block_template_includes_mempool_tx() {
+    let (node1, _node2, _node3) = integration_test::three_node_network();
+    node1.fund_wallet();
+    let (_, txid) = node1.create_mempool_transaction();
+
+    #[cfg(feature = "v28_and_below")]
+    let options = TemplateRequest { rules: vec![TemplateRules::Segwit] };
+    #[cfg(not(feature = "v28_and_below"))]
+    let options = TemplateRequest {
+        rules: vec![TemplateRules::Segwit],
+        mode: Some("template".to_string()),
+        ..Default::default()
+    };
+
+    let json: GetBlockTemplate = node1.client.get_block_template(&options).unwrap();
+
+    assert!(json.transactions.iter().any(|t| t.txid == txid.to_string()));
+}

--- a/integration_test/tests/network_core.rs
+++ b/integration_test/tests/network_core.rs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Tests derived from Bitcoin Core's rpc_net.py and rpc_setban.py
+
+use bitcoind::vtype::*;
+use bitcoind::AddNodeCommand;
+#[cfg(not(feature = "v21_and_below"))]
+use bitcoind::SetBanCommand;
+use integration_test::{BitcoinD, BitcoinDExt as _, Wallet};
+
+#[test]
+#[cfg(not(feature = "v20_and_below"))]
+fn get_peer_info_has_connection_type() {
+    let (node1, _node2, _node3) = integration_test::three_node_network();
+
+    let json: GetPeerInfo = node1.client.get_peer_info().unwrap();
+    let peer = json.0.first().unwrap();
+
+    assert!(peer.connection_type.is_some());
+}
+
+#[test]
+fn get_net_totals_time_millis_is_non_zero() {
+    let node = BitcoinD::with_wallet(Wallet::None, &[]);
+
+    let json: GetNetTotals = node.client.get_net_totals().unwrap();
+
+    assert!(json.time_millis > 0);
+}
+
+#[test]
+#[cfg(not(feature = "v20_and_below"))]
+fn get_peer_info_bytes_per_msg_non_empty() {
+    let (node1, _node2, _node3) = integration_test::three_node_network();
+
+    let json: GetPeerInfo = node1.client.get_peer_info().unwrap();
+    let peer = json.0.first().unwrap();
+
+    assert!(!peer.bytes_sent_per_message.is_empty());
+    assert!(!peer.bytes_received_per_message.is_empty());
+}
+
+#[test]
+#[cfg(not(feature = "v22_and_below"))]
+fn get_peer_info_synced_blocks_le_headers() {
+    let (node1, _node2, _node3) = integration_test::three_node_network();
+
+    let json: GetPeerInfo = node1.client.get_peer_info().unwrap();
+    let peer = json.0.first().unwrap();
+
+    assert!(peer.starting_height.is_some());
+    let headers = peer.synced_headers.unwrap();
+    let blocks = peer.synced_blocks.unwrap();
+    assert!(blocks <= headers);
+}
+
+#[test]
+#[cfg(not(feature = "v18_and_below"))]
+fn get_network_info_local_services_names_non_empty() {
+    let node = BitcoinD::with_wallet(Wallet::None, &[]);
+
+    let json: GetNetworkInfo = node.client.get_network_info().unwrap();
+
+    assert!(!json.local_services_names.is_empty());
+}
+
+#[test]
+#[cfg(not(feature = "v20_and_below"))]
+fn get_network_info_connections_sum_matches_total() {
+    let (node1, _node2, _node3) = integration_test::three_node_network();
+
+    let json: GetNetworkInfo = node1.client.get_network_info().unwrap();
+
+    assert_eq!(json.connections_in + json.connections_out, json.connections);
+    assert!(json.connections > 0);
+}
+
+#[test]
+#[cfg(not(feature = "v21_and_below"))]
+fn list_banned_duration_matches_until_minus_created() {
+    let node = BitcoinD::with_wallet(Wallet::None, &[]);
+    let target = "192.0.2.88/32";
+    node.client.set_ban(target, SetBanCommand::Add).unwrap();
+
+    let json: ListBanned = node.client.list_banned().unwrap();
+    let entry = json.0.iter().find(|e| e.address == target).unwrap();
+
+    assert_eq!(entry.banned_until, entry.ban_created + entry.ban_duration);
+
+    node.client.set_ban(target, SetBanCommand::Remove).unwrap();
+}
+
+#[test]
+fn get_added_node_info_round_trips_added_node() {
+    let node = BitcoinD::with_wallet(Wallet::None, &[]);
+
+    let target = "192.0.2.99:18444";
+    node.client.add_node(target, AddNodeCommand::Add).unwrap();
+
+    let json: GetAddedNodeInfo = node.client.get_added_node_info().unwrap();
+    let entry = json.0.iter().find(|n| n.added_node == target).unwrap();
+    assert_eq!(entry.added_node, target);
+}

--- a/integration_test/tests/raw_transactions_core.rs
+++ b/integration_test/tests/raw_transactions_core.rs
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Tests derived from Bitcoin Core's rpc_rawtransaction.py, rpc_psbt.py and rpc_decodescript.py
+
+#[cfg(not(feature = "v17"))]
+use bitcoin::Amount;
+#[cfg(not(feature = "v21_and_below"))]
+use bitcoin::PublicKey;
+use bitcoind::vtype::*;
+#[cfg(not(feature = "v17"))]
+use bitcoind::{Input, Output};
+use integration_test::{BitcoinD, BitcoinDExt as _, Wallet};
+
+#[test]
+fn get_raw_transaction_verbose_mined_has_block_hash() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &["-txindex"]);
+    node.fund_wallet();
+    let (_, tx) = node.create_mined_transaction();
+
+    let json: GetRawTransactionVerbose =
+        node.client.get_raw_transaction_verbose(tx.compute_txid()).unwrap();
+
+    assert!(json.block_hash.is_some());
+}
+
+#[test]
+#[cfg(not(feature = "v20_and_below"))]
+fn test_mempool_accept_allowed_has_optional_fields() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+
+    let signed = build_and_sign_unbroadcast_tx(&node);
+
+    let json: TestMempoolAccept =
+        node.client.test_mempool_accept(std::slice::from_ref(&signed)).unwrap();
+
+    let res = &json.0[0];
+    assert!(res.allowed);
+    assert!(res.vsize.is_some());
+    assert!(res.fees.is_some());
+}
+
+#[test]
+#[cfg(not(feature = "v21_and_below"))]
+fn test_mempool_accept_rejected_has_reason() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &["-txindex"]);
+    node.fund_wallet();
+
+    let (_, txid) = node.create_mempool_transaction();
+    let tx = node.client.get_raw_transaction(txid).unwrap().transaction().unwrap();
+
+    let json: TestMempoolAccept =
+        node.client.test_mempool_accept(std::slice::from_ref(&tx)).unwrap();
+
+    let res = &json.0[0];
+    assert!(!res.allowed);
+    assert!(res.reject_reason.is_some());
+}
+
+#[test]
+#[cfg(not(feature = "v17"))]
+fn analyze_psbt_has_estimates_after_wallet_process() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+
+    let psbt = build_psbt(&node);
+    let processed: WalletProcessPsbt = node.client.wallet_process_psbt(&psbt).unwrap();
+
+    let parsed: bitcoin::Psbt = processed.psbt.parse().unwrap();
+    let json: AnalyzePsbt = node.client.analyze_psbt(&parsed).unwrap();
+
+    assert!(json.estimated_vsize.is_some());
+    assert!(json.estimated_fee_rate.is_some());
+    assert!(json.fee.is_some());
+}
+
+#[test]
+#[cfg(not(feature = "v19_and_below"))]
+fn decode_psbt_has_witness_utxo_after_utxo_update() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+
+    let psbt = build_psbt(&node);
+    let updated: UtxoUpdatePsbt = node.client.utxo_update_psbt(&psbt).unwrap();
+    let updated_psbt = updated.into_model().unwrap().0;
+
+    let json: DecodePsbt = node.client.decode_psbt(&updated_psbt.to_string()).unwrap();
+
+    assert!(json.inputs.iter().all(|i| i.witness_utxo.is_some() ^ i.non_witness_utxo.is_some()));
+}
+
+#[test]
+#[cfg(not(feature = "v19_and_below"))]
+fn decode_psbt_input_final_witness_after_signing() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+
+    let psbt = build_psbt(&node);
+    let processed: WalletProcessPsbt = node.client.wallet_process_psbt(&psbt).unwrap();
+    assert!(processed.complete);
+
+    let json: DecodePsbt = node.client.decode_psbt(&processed.psbt).unwrap();
+
+    assert!(json.inputs.iter().all(|i| i.final_script_witness.is_some()));
+}
+
+#[test]
+#[cfg(not(feature = "v22_and_below"))]
+fn decode_psbt_input_bip32_derivs_for_unfinalized_psbt() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+
+    let psbt = build_psbt(&node);
+
+    let processed: WalletProcessPsbt = node
+        .client
+        .call(
+            "walletprocesspsbt",
+            &[
+                bitcoind::serde_json::json!(psbt.to_string()),
+                bitcoind::serde_json::json!(true),
+                bitcoind::serde_json::json!("DEFAULT"),
+                bitcoind::serde_json::json!(true),
+                bitcoind::serde_json::json!(false),
+            ],
+        )
+        .unwrap();
+
+    let json: DecodePsbt = node.client.decode_psbt(&processed.psbt).unwrap();
+
+    assert!(json.inputs.iter().all(|i| i.bip32_derivs.is_some()));
+}
+
+#[test]
+#[cfg(not(feature = "v21_and_below"))]
+fn decode_script_multisig_has_segwit_and_p2sh_segwit() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+
+    let pk1: PublicKey =
+        "02ff12471208c14bd580709cb2358d98975247d8765f92bc25eab3b2763ed605f8".parse().unwrap();
+    let pk2: PublicKey =
+        "02fe6f0a5a297eb38c391581c4413e084773ea23954d93f7753db7dc0adc188b2f".parse().unwrap();
+    let multisig: CreateMultisig = node.client.create_multisig(1, vec![pk1, pk2]).unwrap();
+
+    let json: DecodeScript = node.client.decode_script(&multisig.redeem_script).unwrap();
+
+    let segwit = json.segwit.as_ref().unwrap();
+    assert!(segwit.p2sh_segwit.is_some());
+}
+
+#[test]
+#[cfg(not(feature = "v22_and_below"))]
+fn decode_script_multisig_has_descriptor() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+
+    let pk1: PublicKey =
+        "02ff12471208c14bd580709cb2358d98975247d8765f92bc25eab3b2763ed605f8".parse().unwrap();
+    let pk2: PublicKey =
+        "02fe6f0a5a297eb38c391581c4413e084773ea23954d93f7753db7dc0adc188b2f".parse().unwrap();
+    let multisig: CreateMultisig = node.client.create_multisig(1, vec![pk1, pk2]).unwrap();
+
+    let json: DecodeScript = node.client.decode_script(&multisig.redeem_script).unwrap();
+
+    assert!(json.descriptor.is_some());
+}
+
+#[test]
+fn get_raw_transaction_verbose_mined_has_time_fields() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &["-txindex"]);
+    node.fund_wallet();
+    let (_, tx) = node.create_mined_transaction();
+
+    let json: GetRawTransactionVerbose =
+        node.client.get_raw_transaction_verbose(tx.compute_txid()).unwrap();
+
+    assert!(json.transaction_time.is_some());
+    assert!(json.block_time.is_some());
+}
+
+#[test]
+fn get_raw_transaction_verbose_with_blockhash_is_in_active_chain() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &["-txindex"]);
+    node.fund_wallet();
+    let (_, tx) = node.create_mined_transaction();
+    let txid = tx.compute_txid();
+
+    let best = node.client.best_block_hash().unwrap();
+
+    let json: GetRawTransactionVerbose = node
+        .client
+        .call(
+            "getrawtransaction",
+            &[
+                bitcoind::serde_json::json!(txid.to_string()),
+                bitcoind::serde_json::json!(true),
+                bitcoind::serde_json::json!(best.to_string()),
+            ],
+        )
+        .unwrap();
+
+    assert_eq!(json.in_active_chain, Some(true));
+}
+
+#[cfg(not(feature = "v17"))]
+fn build_inputs_outputs(node: &BitcoinD) -> (Vec<Input>, Vec<Output>) {
+    let (_, tx) = node.create_mined_transaction();
+    let txid = tx.compute_txid();
+
+    let million = Amount::from_sat(1_000_000);
+    let (vout, value) = {
+        let v0 = node.client.get_tx_out(txid, 0).unwrap().into_model().unwrap();
+        if v0.tx_out.value == million {
+            (0u64, v0.tx_out.value)
+        } else {
+            let v1 = node.client.get_tx_out(txid, 1).unwrap().into_model().unwrap();
+            (1u64, v1.tx_out.value)
+        }
+    };
+
+    let spend = Amount::from_sat(100_000);
+    let fee = Amount::from_sat(1_000);
+    let change = value - spend - fee;
+
+    let inputs = vec![Input { txid, vout, sequence: None }];
+    let spend_addr = node.client.new_address().unwrap();
+    let change_addr =
+        node.client.get_raw_change_address().unwrap().into_model().unwrap().0.assume_checked();
+    let outputs = vec![Output::new(spend_addr, spend), Output::new(change_addr, change)];
+
+    (inputs, outputs)
+}
+
+#[cfg(not(feature = "v17"))]
+fn build_psbt(node: &BitcoinD) -> bitcoin::Psbt {
+    let (inputs, outputs) = build_inputs_outputs(node);
+    let json: CreatePsbt = node.client.create_psbt(&inputs, &outputs).unwrap();
+    json.into_model().unwrap().0
+}
+
+#[cfg(not(feature = "v20_and_below"))]
+fn build_and_sign_unbroadcast_tx(node: &BitcoinD) -> bitcoin::Transaction {
+    let (inputs, outputs) = build_inputs_outputs(node);
+    let json: CreateRawTransaction = node.client.create_raw_transaction(&inputs, &outputs).unwrap();
+    let raw = json.transaction().unwrap();
+
+    let signed: SignRawTransactionWithWallet =
+        node.client.sign_raw_transaction_with_wallet(&raw).unwrap();
+    signed.into_model().unwrap().tx
+}

--- a/integration_test/tests/util_core.rs
+++ b/integration_test/tests/util_core.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Tests derived from Bitcoin Core's rpc_validateaddress.py and rpc_getdescriptorinfo.py
+
+use bitcoind::vtype::*;
+use bitcoind::AddressType;
+use integration_test::{BitcoinD, BitcoinDExt as _, Wallet};
+
+#[test]
+fn validate_address_witness_fields_present_for_bech32() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+
+    let addr = node.client.new_address_with_type(AddressType::Bech32).unwrap();
+    let json: ValidateAddress = node.client.validate_address(&addr).unwrap();
+
+    assert!(json.is_witness);
+    assert!(json.witness_version.is_some());
+    assert!(json.witness_program.is_some());
+}
+
+#[test]
+#[cfg(not(feature = "v28_and_below"))]
+fn get_descriptor_info_multipath_returns_expansion() {
+    let node = BitcoinD::with_wallet(Wallet::None, &[]);
+
+    let multipath = "wpkh([26b4ed16/84h/1h/0h]tpubDDe7JUw2CGU1rYZxupmNrhDXuE1fv25gs4je3BBuWCFwTW9QHGgyh5cjAEugd14ysJXTVshPvnUVABfD66HZKCS9gp5AYFd5K2WN2oVFp8t/<0;1>/*)#grvmsm8m";
+
+    let json: GetDescriptorInfo = node.client.get_descriptor_info(multipath).unwrap();
+
+    assert!(json.multipath_expansion.is_some());
+}
+
+#[test]
+fn sign_and_verify_message_round_trip() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+
+    let addr = node.client.new_address_with_type(bitcoind::AddressType::Legacy).unwrap();
+    let message = "corepc round-trip test";
+
+    let json: SignMessage = node.client.sign_message(&addr, message).unwrap();
+    let sig = json.into_model().unwrap().0;
+
+    let verified: VerifyMessage = node.client.verify_message(&addr, &sig, message).unwrap();
+    assert!(verified.0);
+}

--- a/integration_test/tests/wallet_core.rs
+++ b/integration_test/tests/wallet_core.rs
@@ -1,0 +1,344 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Tests derived from Bitcoin Core's wallet_basic.py, wallet_coinbase_category.py,
+//! wallet_address_types.py, wallet_gethdkeys.py, wallet_listtransactions.py,
+//! wallet_bumpfee.py, wallet_listdescriptors.py, wallet_listsinceblock.py,
+//! wallet_groups.py, and wallet_listreceivedby.py
+
+use bitcoin::Amount;
+use bitcoind::vtype::*;
+use bitcoind::AddressType;
+use integration_test::{BitcoinD, BitcoinDExt as _, Wallet};
+
+#[test]
+#[cfg(not(feature = "v19_and_below"))]
+fn get_transaction_block_fields_present_after_mining() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+
+    let addr = node.client.new_address().unwrap();
+    let txid =
+        node.client.send_to_address(&addr, Amount::from_sat(500_000)).unwrap().txid().unwrap();
+    node.mine_a_block();
+
+    let json: GetTransaction = node.client.get_transaction(txid).unwrap();
+
+    assert!(json.block_hash.is_some());
+    assert!(json.block_height.is_some());
+    assert!(json.block_index.is_some());
+    assert!(json.block_time.is_some());
+}
+
+#[test]
+#[cfg(not(feature = "v25_and_below"))]
+fn get_wallet_info_has_birthtime() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+
+    let json: GetWalletInfo = node.client.get_wallet_info().unwrap();
+
+    assert!(json.birthtime.is_some());
+}
+
+#[test]
+fn get_transaction_send_has_fee_and_details() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+    let addr = node.client.new_address().unwrap();
+    let txid =
+        node.client.send_to_address(&addr, Amount::from_sat(500_000)).unwrap().txid().unwrap();
+    node.mine_a_block();
+
+    let json: GetTransaction = node.client.get_transaction(txid).unwrap();
+
+    assert!(json.fee.is_some());
+    assert!(!json.details.is_empty());
+}
+
+#[test]
+#[cfg(not(feature = "v23_and_below"))]
+fn list_transactions_send_entry_has_address_and_block() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+    let target = node.client.new_address().unwrap();
+    node.client.send_to_address(&target, Amount::from_sat(123_456)).unwrap();
+    node.mine_a_block();
+
+    let json: ListTransactions = node.client.list_transactions().unwrap();
+
+    let send = json.0.iter().rev().find(|t| t.address.is_some() && t.fee.is_some()).unwrap();
+    assert!(send.block_hash.is_some());
+    assert!(send.block_height.is_some());
+}
+
+#[test]
+fn list_received_by_address_contains_sent_txid() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+
+    let target = node.client.new_address().unwrap();
+    let txid =
+        node.client.send_to_address(&target, Amount::from_sat(321_000)).unwrap().txid().unwrap();
+    node.mine_a_block();
+
+    let json: ListReceivedByAddress = node.client.list_received_by_address().unwrap();
+
+    let entry = json.0.iter().find(|e| e.address == target.to_string()).unwrap();
+    assert!(entry.txids.iter().any(|t| *t == txid.to_string()));
+}
+
+#[test]
+#[cfg(not(feature = "v17"))]
+fn list_unspent_utxos_have_descriptor() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+
+    let json: ListUnspent = node.client.list_unspent().unwrap();
+
+    assert!(json.0.iter().all(|u| u.descriptor.is_some()));
+}
+
+#[test]
+fn list_since_block_has_coinbase_with_generated_true() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+
+    let json: ListSinceBlock = node.client.list_since_block().unwrap();
+
+    assert!(json.transactions.iter().any(|t| t.generated == Some(true)));
+}
+
+#[test]
+fn get_address_info_bech32_has_witness_fields() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    let addr = node.client.new_address_with_type(AddressType::Bech32).unwrap();
+
+    let json: GetAddressInfo = node.client.get_address_info(&addr).unwrap();
+
+    assert!(json.is_witness);
+    assert!(json.witness_version.is_some());
+    assert!(json.witness_program.is_some());
+}
+
+#[test]
+#[cfg(not(feature = "v27_and_below"))]
+fn get_hd_keys_returns_xpriv_when_private() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+
+    let json: GetHdKeys =
+        node.client.call("gethdkeys", &[bitcoind::serde_json::json!({"private": true})]).unwrap();
+
+    assert!(!json.0.is_empty());
+    assert!(json.0[0].xpriv.is_some());
+}
+
+#[test]
+#[cfg(not(feature = "v23_and_below"))]
+fn list_transactions_labeled_address_has_label() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+
+    let label = "corepc-test";
+    let addr = node.client.new_address_with_label(label).unwrap().assume_checked();
+    node.client.send_to_address(&addr, Amount::from_sat(10_000)).unwrap();
+    node.mine_a_block();
+
+    let json: ListTransactions = node.client.list_transactions().unwrap();
+
+    let entry = json
+        .0
+        .iter()
+        .find(|t| t.address.as_deref() == Some(addr.to_string().as_str()) && t.label.is_some());
+    assert!(entry.is_some(), "receive entry with label should exist");
+    assert_eq!(entry.unwrap().label.as_deref(), Some(label));
+}
+
+#[test]
+fn bump_fee_original_fee_rename_and_cross_field() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+    let addr = node.client.new_address().unwrap();
+    let old_txid =
+        node.client.send_to_address_rbf(&addr, Amount::from_sat(50_000)).unwrap().txid().unwrap();
+
+    let json: BumpFee = node.client.bump_fee(old_txid).unwrap();
+
+    assert!(json.original_fee > 0.0);
+    assert!(json.fee >= json.original_fee);
+    assert_ne!(json.txid, old_txid.to_string());
+}
+
+#[test]
+#[cfg(not(feature = "v25_and_below"))]
+fn get_wallet_info_has_last_processed_block() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+
+    let json: GetWalletInfo = node.client.get_wallet_info().unwrap();
+
+    assert!(json.last_processed_block.is_some());
+}
+
+#[test]
+#[cfg(not(feature = "v25_and_below"))]
+fn get_balances_has_last_processed_block() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+
+    let json: GetBalances = node.client.get_balances().unwrap();
+
+    assert!(json.last_processed_block.is_some());
+}
+
+#[test]
+#[cfg(not(feature = "v24_and_below"))]
+fn list_descriptors_ranged_has_range_and_next_index() {
+    let node = BitcoinD::with_wallet(Wallet::None, &[]);
+    let wallet_name = "desc_wallet_range";
+
+    #[cfg(feature = "v22_and_below")]
+    node.client.create_descriptor_wallet(wallet_name).unwrap();
+    #[cfg(not(feature = "v22_and_below"))]
+    node.client.create_wallet(wallet_name).unwrap();
+
+    let json: ListDescriptors = node.client.list_descriptors().unwrap();
+
+    let ranged = json.descriptors.iter().find(|d| d.range.is_some()).unwrap();
+    assert!(ranged.next_index.is_some());
+    let [start, end] = ranged.range.unwrap();
+    assert!(end >= start);
+}
+
+#[test]
+#[cfg(not(feature = "v21_and_below"))]
+fn list_descriptors_active_has_internal_field() {
+    let node = BitcoinD::with_wallet(Wallet::None, &[]);
+    let wallet_name = "desc_wallet_internal";
+
+    #[cfg(feature = "v22_and_below")]
+    node.client.create_descriptor_wallet(wallet_name).unwrap();
+    #[cfg(not(feature = "v22_and_below"))]
+    node.client.create_wallet(wallet_name).unwrap();
+
+    let json: ListDescriptors = node.client.list_descriptors().unwrap();
+
+    assert!(json.descriptors.iter().any(|d| d.active && d.internal.is_some()));
+}
+
+#[test]
+#[cfg(not(feature = "v27_and_below"))]
+fn get_address_info_has_parent_descriptor() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    let addr = node.client.new_address().unwrap();
+
+    let json: GetAddressInfo = node.client.get_address_info(&addr).unwrap();
+
+    assert!(json.parent_descriptor.is_some());
+}
+
+#[test]
+fn get_transaction_send_detail_has_negative_fee() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+    let dest = node.client.new_address().unwrap();
+    let txid =
+        node.client.send_to_address(&dest, Amount::from_sat(50_000)).unwrap().txid().unwrap();
+    node.mine_a_block();
+
+    let json: GetTransaction = node.client.get_transaction(txid).unwrap();
+
+    let send = json.details.iter().find(|d| d.category == TransactionCategory::Send).unwrap();
+    assert!(send.fee.is_some());
+    assert!(send.fee.unwrap() < 0.0);
+}
+
+#[test]
+#[cfg(not(feature = "v23_and_below"))]
+fn get_transaction_received_detail_has_parent_descs() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+    let dest = node.client.new_address().unwrap();
+    let txid =
+        node.client.send_to_address(&dest, Amount::from_sat(50_000)).unwrap().txid().unwrap();
+    node.mine_a_block();
+
+    let json: GetTransaction = node.client.get_transaction(txid).unwrap();
+
+    let receive = json.details.iter().find(|d| d.category == TransactionCategory::Receive).unwrap();
+    assert!(receive.parent_descriptors.is_some());
+}
+
+#[test]
+fn list_since_block_last_block_is_best() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+    node.mine_a_block();
+
+    let best = node.client.best_block_hash().unwrap();
+    let json: ListSinceBlock = node.client.list_since_block().unwrap();
+
+    assert_eq!(json.last_block, best.to_string());
+}
+
+#[test]
+fn list_address_groupings_labeled_uses_three_variant() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+
+    let label = "groupings-label";
+    let addr = node.client.new_address_with_label(label).unwrap().assume_checked();
+    let addr_s = addr.to_string();
+    node.client.send_to_address(&addr, Amount::from_sat(25_000)).unwrap();
+    node.mine_a_block();
+
+    let json: ListAddressGroupings = node.client.list_address_groupings().unwrap();
+
+    let entry = json
+        .0
+        .iter()
+        .flat_map(|group| group.iter())
+        .find(|item| match item {
+            ListAddressGroupingsItem::Two(a, _) => a == &addr_s,
+            ListAddressGroupingsItem::Three(a, _, _) => a == &addr_s,
+        })
+        .unwrap();
+    match entry {
+        ListAddressGroupingsItem::Three(_, _, l) => assert_eq!(l, label),
+        ListAddressGroupingsItem::Two(_, _) => {
+            panic!("labeled address must deserialize as Three variant, got Two")
+        }
+    }
+}
+
+#[test]
+fn list_received_by_address_aggregates_amount_across_txids() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+
+    let target = node.client.new_address().unwrap();
+    node.client.send_to_address(&target, Amount::from_sat(100_000)).unwrap();
+    node.mine_a_block();
+    node.client.send_to_address(&target, Amount::from_sat(200_000)).unwrap();
+    node.mine_a_block();
+
+    let json: ListReceivedByAddress = node.client.list_received_by_address().unwrap();
+
+    let entry = json.0.iter().find(|e| e.address == target.to_string()).unwrap();
+
+    assert_eq!(entry.txids.len(), 2);
+    assert_eq!(entry.amount, 0.003);
+}
+
+#[test]
+fn list_transactions_yields_both_send_and_receive() {
+    let node = BitcoinD::with_wallet(Wallet::Default, &[]);
+    node.fund_wallet();
+    let addr = node.client.new_address().unwrap();
+
+    node.client.send_to_address(&addr, Amount::from_sat(15_000)).unwrap();
+    node.mine_a_block();
+
+    let json: ListTransactions = node.client.list_transactions().unwrap();
+
+    assert!(json.0.iter().any(|t| t.category == TransactionCategory::Receive));
+    assert!(json.0.iter().any(|t| t.category == TransactionCategory::Send));
+}


### PR DESCRIPTION
Closes #58.

This PR adds 79 tests corresponding to invariants picked after analyzing Bitcoin Core tests from `test/functional` folder. Identical test copies from core proved unproductive, extensive, and tested much more than necessary for corepc, so invariants (not tests) needed to be filtered. By putting these tests in `tests/`, there is no additional effort on `Cargo.toml`.

The criteria:
- Not a test of Core's behavior.
- Only the client layer is tested (meaning the tests apply to the state before the into_model conversion).
- If a particular assertion failed, that means corepc has a bug.
- The tests are complementary and do not repeat or collide with existing corepc integration tests.

Main targets:
- Optional fields to prevent absence failures that the into_model conversions failed to catch.
- Round trips not exercised or already tested.
- Optional argument paths.
- Fragile serde renames.
- Consistency across fields (such as  `banned_until == ban_created + ban_duration`).
- Nested structs.
- Tests that prove the mutual sanity of RPCs, compressing simple RPC tests into one (such as getblockhash tip matches best block, get_deployment_info + get_deployment_info_tip).

All test check corepc honor a particular invariant. Previously untested fields are tested. Many tests contain `is_some()` because exact value assertions are not necessary, as long as the result parses into a particular type. Comprehensiveness was not a target because we test only what Core has. Flags are checked to be covering only the versions it should.

How LLM was used: I read through Core tests to see what we were missing. Started developing a philosophy for assertions to pick. Realized that copying tests directly wouldn't work, so we would need to pick invariants (some are hard to reproduce, need Core's particulars, or test no meaningful corepc behavior). Asked Claude Opus 4.7 to convert the entire Bitcoin Core surface, and started iterating on it, covering gaps where needed, shaving off useless assertions, and sharpening the philosophy of tests.

I have found various errors (such as rediscovering the inconsistency in numeric types) in RPCs/docs, saving them to investigate and open issues later.