### PR TITLE
Prepare stack of releases

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -180,7 +180,7 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitreq"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "base64 0.22.1",
  "log",

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -150,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoind"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -645,7 +645,7 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jsonrpc"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "base64 0.22.1",
  "bitreq",

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -293,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-types"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "bitcoin",
  "serde",

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -281,7 +281,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "corepc-client"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "bitcoin",
  "corepc-types",

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -317,7 +317,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "electrsd"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -180,7 +180,7 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitreq"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "base64 0.22.1",
  "log",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -150,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoind"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -645,7 +645,7 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jsonrpc"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "base64 0.22.1",
  "bitreq",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -293,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-types"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "bitcoin",
  "serde",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -281,7 +281,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "corepc-client"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "bitcoin",
  "corepc-types",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -317,7 +317,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "electrsd"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",

--- a/bitcoind/CHANGELOG.md
+++ b/bitcoind/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.40.0 - 2026-05-26
+
+- Add initial support for Bitcoin Core v31 [#598](https://github.com/rust-bitcoin/corepc/pull/598)
+- Upgrade to latest version of `corepc-types` and `corepc-client`
+
+In this release we remove support for Bitcoin Core `v27.0`, `v27.1`,
+`v28.0`, and `v28.1`. We still support the latest point release of
+these two versions: `v27.2` and `v28.2`.
+
 # 0.39.0 - 2026-05-12
 
 - Update to use latest `corepc-client v0.14.0`.

--- a/bitcoind/Cargo.toml
+++ b/bitcoind/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoind"
-version = "0.39.0"
+version = "0.40.0"
 authors = ["Riccardo Casatta <riccardo@casatta.it>", "Tobin C. Harding <me@tobin.cc>"]
 license = "MIT"
 repository = "https://github.com/rust-bitcoin/corepc"

--- a/bitcoind/Cargo.toml
+++ b/bitcoind/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["tests", "contrib"]
 
 [dependencies]
 anyhow = { version = "1.0.66", default-features = false, features = ["std"] }
-corepc-client = { version = "0.14.0", path = "../client", features = ["client-sync"] }
+corepc-client = { version = "0.15.0", path = "../client", features = ["client-sync"] }
 log = { version = "0.4", default-features = false }
 serde_json = { version = "1.0.117", default-features = false }
 tempfile = { version = "3", default-features = false }

--- a/bitreq/CHANGELOG.md
+++ b/bitreq/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.6 - 2026-05-26
+
+* Gate `webpki_roots` import on `webpki-roots` [#597](https://github.com/rust-bitcoin/corepc/pull/597)
+
 # 0.3.5 - 2026-04-20
 
 * Fix `tokio-rustls` feature gating for async rustls support [#563](https://github.com/rust-bitcoin/corepc/pull/563)

--- a/bitreq/Cargo.toml
+++ b/bitreq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitreq"
-version = "0.3.5"
+version = "0.3.6"
 authors = ["Jens Pitkanen <jens@neon.moe>", "Tobin C. Harding <me@tobin.cc>", "Matt Corallo", "Elias Rohrer <dev@tnull.de>"]
 description = "Simple, minimal-dependency HTTP client"
 documentation = "https://docs.rs/bitreq"

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.15.0 - 2026-05-26
+
+- Add initial support for Bitcoin Core v31 [#598](https://github.com/rust-bitcoin/corepc/pull/598)
+- Upgrade to latest `corepc-types` version
+- Change `fee_delta` to `SignedAmount` [#605](https://github.com/rust-bitcoin/corepc/pull/605)
+
 # 0.14.0 - 2026-05-12
 
 - Update to use latest `corepc-types v0.13.0`.

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-client"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Tobin C. Harding <me@tobin.cc>", "Jamil Lambert <Jamil.Lambert@proton.me>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/corepc"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -29,7 +29,7 @@ bitcoin = { version = "0.32.0", default-features = false, features = ["std", "se
 log = "0.4"
 serde = { version = "1.0.103", default-features = false, features = [ "derive", "alloc" ] }
 serde_json = { version = "1.0.117" }
-types = { package = "corepc-types", version = "0.13.0", path = "../types", default-features = false, features = ["std"] }
+types = { package = "corepc-types", version = "0.14.0", path = "../types", default-features = false, features = ["std"] }
 
 jsonrpc = { version = "0.20.0", path = "../jsonrpc", features = ["bitreq_http"], optional = true }
 

--- a/electrsd/CHANGELOG.md
+++ b/electrsd/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.40.0 - 2026-05-26
+
+With this release we now set the default feature to `electrs_0_10_6`.
+
+- Include in workspace and CI [#570](https://github.com/rust-bitcoin/corepc/pull/570)
+- Upgrade to latest version of `corepc-types`, `corepc-client`, and `bitcoind`
+
 # 0.39.0 - 2026-05-12
 
 - Update to use latest `bitcoind v0.39.0` and `corepc-client v0.14.0`.

--- a/electrsd/Cargo.toml
+++ b/electrsd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "electrsd"
-version = "0.39.0"
+version = "0.40.0"
 authors = ["Riccardo Casatta <riccardo@casatta.it>"]
 description = "Utility to run a regtest electrs process, useful in integration testing environment"
 repository = "https://github.com/rust-bitcoin/corepc"

--- a/electrsd/Cargo.toml
+++ b/electrsd/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["cryptography::cryptocurrencies", "development-tools::testing"]
 exclude = ["tests", "contrib"]
 
 [dependencies]
-bitcoind = { version = "0.39.0", path = "../bitcoind" }
+bitcoind = { version = "0.40.0", path = "../bitcoind" }
 corepc-client = { version = "0.15.0", path = "../client" }
 electrum-client = { version = "0.24.0", default-features = false }
 log = { version = "0.4" }

--- a/electrsd/Cargo.toml
+++ b/electrsd/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["tests", "contrib"]
 
 [dependencies]
 bitcoind = { version = "0.39.0", path = "../bitcoind" }
-corepc-client = { version = "0.14.0", path = "../client" }
+corepc-client = { version = "0.15.0", path = "../client" }
 electrum-client = { version = "0.24.0", default-features = false }
 log = { version = "0.4" }
 

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -60,7 +60,7 @@ TODO = []                       # This is a dirty hack while writing the tests.
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false, features = ["std", "serde"] }
 env_logger = "0.9.0"
-bitcoind = { package = "bitcoind", version = "0.39.0", path = "../bitcoind", default-features = false }
+bitcoind = { package = "bitcoind", version = "0.40.0", path = "../bitcoind", default-features = false }
 rand = "0.8.5"
 # Just so we can enable the feature.
 types = { package = "corepc-types", version = "0.14.0", path = "../types", features = ["serde-deny-unknown-fields"] }

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -63,6 +63,6 @@ env_logger = "0.9.0"
 bitcoind = { package = "bitcoind", version = "0.39.0", path = "../bitcoind", default-features = false }
 rand = "0.8.5"
 # Just so we can enable the feature.
-types = { package = "corepc-types", version = "0.13.0", path = "../types", features = ["serde-deny-unknown-fields"] }
+types = { package = "corepc-types", version = "0.14.0", path = "../types", features = ["serde-deny-unknown-fields"] }
 
 [dev-dependencies]

--- a/jsonrpc/CHANGELOG.md
+++ b/jsonrpc/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.20.1 - 2026-05-26
+
+* Set host header to URL hostname instead of resolved IP [#578](https://github.com/rust-bitcoin/corepc/pull/578)
+
 # 0.20.0 - 2026-04-20
 
 * Add async support [#558](https://github.com/rust-bitcoin/corepc/pull/558)

--- a/jsonrpc/Cargo.toml
+++ b/jsonrpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsonrpc"
-version = "0.20.0"
+version = "0.20.1"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/corepc/"

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.14.0 - 2026-05-26
+
+- Add initial support for Bitcoin Core v31 [#598](https://github.com/rust-bitcoin/corepc/pull/598)
+- Change `fee_delta` to `SignedAmount` [#605](https://github.com/rust-bitcoin/corepc/pull/605)
+
 # 0.13.0 - 2026-05-12
 
 - Change `model::GetBlockchainInfo::prune_target_size` from `u32` to `u64` [#547](https://github.com/rust-bitcoin/corepc/pull/547)

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-types"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Tobin C. Harding <me@tobin.cc>", "Jamil Lambert <Jamil.Lambert@proton.me>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/corepc"


### PR DESCRIPTION
Cut a release of every released crate in the repo. Note `bitreq` and `jsonrpc` are 'point' releases (minor releases really).