### PR TITLE
Gate out core tests from v31

### DIFF
--- a/integration_test/tests/blockchain_core.rs
+++ b/integration_test/tests/blockchain_core.rs
@@ -4,6 +4,7 @@
 //! rpc_txoutproof.py, rpc_scantxoutset.py, rpc_gettxspendingprevout.py,
 //! rpc_dumptxoutset.py and rpc_getblockstats.py
 
+#[cfg(feature = "v30_and_below")]
 use bitcoind::mtype;
 use bitcoind::vtype::*;
 use integration_test::{BitcoinD, BitcoinDExt as _, Wallet};
@@ -21,6 +22,7 @@ fn get_blockchain_info_pruned_node_has_prune_fields() {
 }
 
 #[test]
+#[cfg(feature = "v30_and_below")]
 fn get_chain_tx_stats_default_window_has_optional_fields() {
     let node = BitcoinD::with_wallet(Wallet::Default, &[]);
     let addr = node.client.new_address().unwrap();
@@ -37,6 +39,7 @@ fn get_chain_tx_stats_default_window_has_optional_fields() {
 }
 
 #[test]
+#[cfg(feature = "v30_and_below")]
 fn get_chain_tx_stats_pinned_to_block1_has_no_window_fields() {
     let node = BitcoinD::with_wallet(Wallet::Default, &[]);
     let addr = node.client.new_address().unwrap();
@@ -145,6 +148,7 @@ fn get_block_hash_at_tip_matches_best() {
 }
 
 #[test]
+#[cfg(feature = "v30_and_below")]
 fn get_block_verbose_one_tx_count_matches_n_tx() {
     let node = BitcoinD::with_wallet(Wallet::Default, &[]);
     node.fund_wallet();
@@ -173,6 +177,7 @@ fn get_chain_tips_active_tip_matches_best() {
 }
 
 #[test]
+#[cfg(feature = "v30_and_below")]
 fn get_mempool_entry_height_and_no_parents() {
     let node = BitcoinD::with_wallet(Wallet::Default, &[]);
     node.fund_wallet();
@@ -216,6 +221,7 @@ fn scan_tx_out_set_best_block_matches_tip() {
 
 #[test]
 #[cfg(not(feature = "v22_and_below"))]
+#[cfg(feature = "v30_and_below")]
 fn get_deployment_info_genesis_vs_tip() {
     let node = BitcoinD::with_wallet(Wallet::Default, &[]);
     node.fund_wallet();
@@ -249,6 +255,7 @@ fn get_tx_spending_prevout_for_unspent_output() {
 
 #[test]
 #[cfg(not(feature = "v28_and_below"))]
+#[cfg(feature = "v30_and_below")]
 fn get_block_verbose_two_non_coinbase_has_fee() {
     let node = BitcoinD::with_wallet(Wallet::Default, &[]);
     node.fund_wallet();
@@ -264,6 +271,7 @@ fn get_block_verbose_two_non_coinbase_has_fee() {
 
 #[test]
 #[cfg(not(feature = "v28_and_below"))]
+#[cfg(feature = "v30_and_below")]
 fn get_block_verbose_three_non_coinbase_has_prevouts() {
     let node = BitcoinD::with_wallet(Wallet::Default, &[]);
     node.fund_wallet();
@@ -279,6 +287,7 @@ fn get_block_verbose_three_non_coinbase_has_prevouts() {
 }
 
 #[test]
+#[cfg(feature = "v30_and_below")]
 fn get_mempool_entry_spent_by_contains_child() {
     let node = BitcoinD::with_wallet(Wallet::Default, &[]);
     node.fund_wallet();
@@ -304,6 +313,7 @@ fn get_raw_mempool_sequence_includes_tx() {
 }
 
 #[test]
+#[cfg(feature = "v30_and_below")]
 fn get_mempool_ancestors_verbose_keyed_by_parent_txid() {
     let node = BitcoinD::with_wallet(Wallet::Default, &[]);
     node.fund_wallet();
@@ -317,6 +327,7 @@ fn get_mempool_ancestors_verbose_keyed_by_parent_txid() {
 }
 
 #[test]
+#[cfg(feature = "v30_and_below")]
 fn get_block_verbose_one_stripped_size_le_size() {
     let node = BitcoinD::with_wallet(Wallet::Default, &[]);
     node.fund_wallet();
@@ -330,6 +341,7 @@ fn get_block_verbose_one_stripped_size_le_size() {
 }
 
 #[test]
+#[cfg(feature = "v30_and_below")]
 fn get_block_verbose_one_next_block_hash_some_for_non_tip() {
     let node = BitcoinD::with_wallet(Wallet::Default, &[]);
     node.fund_wallet();
@@ -400,6 +412,7 @@ fn get_block_stats_v25_actual_utxo_fields() {
     assert!(json.utxo_size_increase_actual.is_some());
 }
 
+#[cfg(feature = "v30_and_below")]
 fn create_child_spending_parent(node: &BitcoinD, parent: bitcoin::Txid) -> bitcoin::Txid {
     use bitcoind::{Input, Output};
     let inputs = vec![Input { txid: parent, vout: 0, sequence: None }];

--- a/integration_test/tests/mining_core.rs
+++ b/integration_test/tests/mining_core.rs
@@ -5,6 +5,7 @@
 #[cfg(not(feature = "v25_and_below"))]
 use bitcoin::SignedAmount;
 use bitcoind::vtype::*;
+#[cfg(feature = "v30_and_below")]
 use bitcoind::{TemplateRequest, TemplateRules};
 use integration_test::{BitcoinD, BitcoinDExt as _, Wallet};
 
@@ -52,6 +53,7 @@ fn generate_block_with_empty_tx_list() {
 }
 
 #[test]
+#[cfg(feature = "v30_and_below")]
 fn get_block_template_has_optional_fields() {
     let (node1, _node2, _node3) = integration_test::three_node_network();
     node1.fund_wallet();
@@ -72,6 +74,7 @@ fn get_block_template_has_optional_fields() {
 }
 
 #[test]
+#[cfg(feature = "v30_and_below")]
 fn get_block_template_includes_mempool_tx() {
     let (node1, _node2, _node3) = integration_test::three_node_network();
     node1.fund_wallet();

--- a/integration_test/tests/network_core.rs
+++ b/integration_test/tests/network_core.rs
@@ -10,6 +10,7 @@ use integration_test::{BitcoinD, BitcoinDExt as _, Wallet};
 
 #[test]
 #[cfg(not(feature = "v20_and_below"))]
+#[cfg(feature = "v30_and_below")]
 fn get_peer_info_has_connection_type() {
     let (node1, _node2, _node3) = integration_test::three_node_network();
 
@@ -30,6 +31,7 @@ fn get_net_totals_time_millis_is_non_zero() {
 
 #[test]
 #[cfg(not(feature = "v20_and_below"))]
+#[cfg(feature = "v30_and_below")]
 fn get_peer_info_bytes_per_msg_non_empty() {
     let (node1, _node2, _node3) = integration_test::three_node_network();
 
@@ -42,6 +44,7 @@ fn get_peer_info_bytes_per_msg_non_empty() {
 
 #[test]
 #[cfg(not(feature = "v22_and_below"))]
+#[cfg(feature = "v30_and_below")]
 fn get_peer_info_synced_blocks_le_headers() {
     let (node1, _node2, _node3) = integration_test::three_node_network();
 
@@ -66,6 +69,7 @@ fn get_network_info_local_services_names_non_empty() {
 
 #[test]
 #[cfg(not(feature = "v20_and_below"))]
+#[cfg(feature = "v30_and_below")]
 fn get_network_info_connections_sum_matches_total() {
     let (node1, _node2, _node3) = integration_test::three_node_network();
 

--- a/integration_test/tests/wallet_core.rs
+++ b/integration_test/tests/wallet_core.rs
@@ -31,6 +31,7 @@ fn get_transaction_block_fields_present_after_mining() {
 
 #[test]
 #[cfg(not(feature = "v25_and_below"))]
+#[cfg(feature = "v30_and_below")]
 fn get_wallet_info_has_birthtime() {
     let node = BitcoinD::with_wallet(Wallet::Default, &[]);
 
@@ -169,6 +170,7 @@ fn bump_fee_original_fee_rename_and_cross_field() {
 
 #[test]
 #[cfg(not(feature = "v25_and_below"))]
+#[cfg(feature = "v30_and_below")]
 fn get_wallet_info_has_last_processed_block() {
     let node = BitcoinD::with_wallet(Wallet::Default, &[]);
     node.fund_wallet();


### PR DESCRIPTION
v31 does not have all of the RPC changes implemented yet which causes the newly added tests to fail.

Gate out the tests so they are not run in v31.

Closes #609