### PR TITLE
bitreq: Bump vesion to 0.3.7

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -180,7 +180,7 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitreq"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "base64 0.22.1",
  "log",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -180,7 +180,7 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitreq"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "base64 0.22.1",
  "log",

--- a/bitreq/CHANGELOG.md
+++ b/bitreq/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.7 - 2026-05-28
+
+* Some pipeline fixes in `bitreq` [#584](https://github.com/rust-bitcoin/corepc/pull/584)
+
 # 0.3.6 - 2026-05-26
 
 * Gate `webpki_roots` import on `webpki-roots` [#597](https://github.com/rust-bitcoin/corepc/pull/597)

--- a/bitreq/Cargo.toml
+++ b/bitreq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitreq"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["Jens Pitkanen <jens@neon.moe>", "Tobin C. Harding <me@tobin.cc>", "Matt Corallo", "Elias Rohrer <dev@tnull.de>"]
 description = "Simple, minimal-dependency HTTP client"
 documentation = "https://docs.rs/bitreq"


### PR DESCRIPTION
Do a quick point release for stuff just merged in #584

In preparation, add a changelog entry, bump the version number, and update the lock files.