### PR TITLE
integration_test: Add explicit types everywhere

### DIFF
--- a/integration_test/tests/generating.rs
+++ b/integration_test/tests/generating.rs
@@ -110,7 +110,7 @@ fn generating__invalidate_block() {
         node.client.get_best_block_hash().expect("getbestblockhash").into_model().unwrap().0;
     assert_ne!(old_best_block, new_best_block);
 
-    node.client.invalidate_block(new_best_block).expect("invalidateblock");
+    let _: () = node.client.invalidate_block(new_best_block).expect("invalidateblock");
 
     let json: GetBestBlockHash = node.client.get_best_block_hash().expect("getbestblockhash");
     let model: Result<mtype::GetBestBlockHash, hex::HexToArrayError> = json.into_model();

--- a/integration_test/tests/hidden.rs
+++ b/integration_test/tests/hidden.rs
@@ -252,7 +252,7 @@ fn hidden__reconsider_block() {
         "height should decrease by 1 after invalidating the tip block"
     );
 
-    node.client.reconsider_block(tip_before).expect("reconsiderblock");
+    let _: () = node.client.reconsider_block(tip_before).expect("reconsiderblock");
 
     let tip_after_reconsider =
         node.client.best_block_hash().expect("bestblockhash after reconsider");

--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -837,9 +837,10 @@ fn wallet__list_wallets__modelled() {
     node.client.create_wallet(wallet_2).expect("createwallet w2");
 
     let json: ListWallets = node.client.list_wallets().expect("listwallets");
+    let model: mtype::ListWallets = json.into_model();
 
-    assert!(json.0.iter().any(|w| w == wallet_1));
-    assert!(json.0.iter().any(|w| w == wallet_2));
+    assert!(model.0.iter().any(|w| w == wallet_1));
+    assert!(model.0.iter().any(|w| w == wallet_2));
 }
 
 #[test]
@@ -1182,7 +1183,8 @@ fn create_load_unload_wallet() {
     let node = BitcoinD::with_wallet(Wallet::None, &[]);
 
     let wallet = format!("wallet-{}", rand::random::<u32>()).to_string();
-    node.client.create_wallet(&wallet).expect("failed to create wallet");
+    let json: CreateWallet = node.client.create_wallet(&wallet).expect("createwallet");
+    let _: mtype::CreateWallet = json.into_model();
 
     // Upto version 20 Core returns null for `unloadwallet`.
     #[cfg(feature = "v20_and_below")]
@@ -1195,7 +1197,8 @@ fn create_load_unload_wallet() {
         let _: mtype::UnloadWallet = json.into_model();
     }
 
-    let _: LoadWallet = node.client.load_wallet(&wallet).expect("loadwallet");
+    let json: LoadWallet = node.client.load_wallet(&wallet).expect("loadwallet");
+    let _: mtype::LoadWallet = json.into_model();
 }
 
 #[test]


### PR DESCRIPTION
- adding explicit re-exported types in tests excluding suffixed by _core

Fixes #612