### PR TITLE
verify: enable running from any directory

### DIFF
--- a/verify/src/lib.rs
+++ b/verify/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod method;
 pub mod model;
+pub mod paths;
 pub mod reexports;
 pub mod ssot;
 pub mod versioned;

--- a/verify/src/main.rs
+++ b/verify/src/main.rs
@@ -18,8 +18,6 @@ use verify::method::{Method, Return};
 use verify::versioned::{self, Status};
 use verify::{method, model, reexports, ssot, Version};
 
-// TODO: Enable running from any directory, currently errors if run from `src/`.
-
 const VERSIONS: [Version; 15] = [
     Version::V17,
     Version::V18,

--- a/verify/src/model.rs
+++ b/verify/src/model.rs
@@ -4,15 +4,10 @@
 //!
 //! The "model files" are the files in `types/src/model/`.
 
-use std::path::PathBuf;
-
 use anyhow::Result;
 
 use crate::method::{self, Return};
-use crate::Version;
-
-/// Path to the model module file.
-fn path() -> PathBuf { PathBuf::from("../types/src/model/mod.rs") }
+use crate::{paths, Version};
 
 /// Returns `true` if this method requires a type to exist.
 pub fn requires_type(version: Version, method_name: &str) -> Result<bool> {
@@ -40,7 +35,7 @@ pub fn type_exists(version: Version, method_name: &str) -> Result<bool> {
     };
 
     if let Some(Return::Type(s)) = method.ret {
-        return crate::grep_for_re_export(&path(), s);
+        return crate::grep_for_re_export(&paths::model_mod(), s);
     }
     Ok(false)
 }

--- a/verify/src/paths.rs
+++ b/verify/src/paths.rs
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: CC0-1.0
+
+//! Paths to files used by the verify tool.
+
+use std::path::PathBuf;
+
+use crate::Version;
+
+/// Returns the path to the `verify` crate root directory.
+fn crate_dir() -> PathBuf { PathBuf::from(env!("CARGO_MANIFEST_DIR")) }
+
+/// Returns the path to `types/src`.
+pub fn types_src_dir() -> PathBuf { crate_dir().join("../types/src") }
+
+/// Path to the RPC SSOT file.
+pub fn ssot(version: Version) -> PathBuf { crate_dir().join(format!("rpc-api-{}.txt", version)) }
+
+/// Path to the version specific module file.
+pub fn versioned_mod(version: Version) -> PathBuf {
+    types_src_dir().join(format!("{}/mod.rs", version))
+}
+
+/// Path to the model module file.
+pub fn model_mod() -> PathBuf { types_src_dir().join("model/mod.rs") }

--- a/verify/src/reexports.rs
+++ b/verify/src/reexports.rs
@@ -10,7 +10,7 @@ use anyhow::{anyhow, Context, Result};
 use syn::{Fields, GenericArgument, Item, PathArguments, Type, UseTree, Visibility};
 use walkdir::WalkDir;
 
-use crate::Version;
+use crate::{paths, Version};
 
 type VersionedDeps = HashMap<String, BTreeMap<String, BTreeSet<String>>>;
 type ParsedTypeFiles = (Vec<(String, PathBuf)>, HashSet<String>);
@@ -32,8 +32,7 @@ struct UseEntry {
 
 /// Checks that every type is re-exported for the requested version.
 pub fn check_type_reexports(version: Version) -> Result<()> {
-    let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let src_dir = crate_dir.join("../types/src");
+    let src_dir = paths::types_src_dir();
     let all_versions = collect_version_dirs(&src_dir)?;
     let (files, known_names) = collect_type_files_and_names(&src_dir, &all_versions)?;
     let definitions = collect_type_definitions(&files, &known_names)?;

--- a/verify/src/ssot.rs
+++ b/verify/src/ssot.rs
@@ -10,19 +10,15 @@
 
 use std::fs::File;
 use std::io::{self, BufRead};
-use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use regex::Regex;
 
-use crate::Version;
-
-/// Path to the RPC SSOT file.
-pub fn path(version: Version) -> PathBuf { PathBuf::from(format!("./rpc-api-{}.txt", version)) }
+use crate::{paths, Version};
 
 /// Parses the Bitcoin Core docs (from SSOT file) and gets all the method names.
 pub fn all_methods(version: Version) -> Result<Vec<String>> {
-    let path = path(version);
+    let path = paths::ssot(version);
     let file = File::open(&path)
         .with_context(|| format!("Failed to grep for method names in {}", path.display()))?;
     let reader = io::BufReader::new(file);

--- a/verify/src/versioned.rs
+++ b/verify/src/versioned.rs
@@ -7,19 +7,13 @@
 use std::fmt;
 use std::fs::File;
 use std::io::{self, BufRead};
-use std::path::PathBuf;
 use std::str::FromStr;
 
 use anyhow::{Context, Result};
 use regex::Regex;
 
 use crate::method::{self, Return};
-use crate::Version;
-
-/// Path to the version specific module file.
-pub fn path(version: Version) -> PathBuf {
-    PathBuf::from(format!("../types/src/{}/mod.rs", version))
-}
+use crate::{paths, Version};
 
 /// Parses module rustdocs and gets all the method names.
 pub fn all_methods(version: Version) -> Result<Vec<String>> {
@@ -29,7 +23,7 @@ pub fn all_methods(version: Version) -> Result<Vec<String>> {
 
 /// Parses module rustdocs and grabs each method and its current status.
 pub fn methods_and_status(version: Version) -> Result<Vec<Method>> {
-    let path = path(version);
+    let path = paths::versioned_mod(version);
     let file = File::open(&path)
         .with_context(|| format!("Failed to grep rustdocs in {}", path.display()))?;
     let reader = io::BufReader::new(file);
@@ -80,7 +74,7 @@ pub fn requires_type(version: Version, method_name: &str) -> Result<bool> {
 
 /// Checks that a type exists in version specific module.
 pub fn type_exists(version: Version, method_name: &str) -> Result<bool> {
-    let path = path(version);
+    let path = paths::versioned_mod(version);
     let method = match method::Method::from_name(version, method_name) {
         Some(m) => m,
         None =>
@@ -111,7 +105,7 @@ pub enum ReturnsDoc {
 pub fn returns_map(version: Version) -> Result<std::collections::BTreeMap<String, ReturnsDoc>> {
     use std::collections::BTreeMap;
 
-    let path = path(version);
+    let path = paths::versioned_mod(version);
     let file = File::open(&path)
         .with_context(|| format!("Failed to grep rustdocs in {}", path.display()))?;
     let reader = io::BufReader::new(file);


### PR DESCRIPTION
Fixes: #627 

Use absolute paths from the crate root (from `CARGO_MANIFEST_DIR`) instead of relative to the current working directory.