### PR TITLE
Prepare stack of releases

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -281,7 +281,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "corepc-client"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bitcoin",
  "corepc-types",

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -293,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-types"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "bitcoin",
  "serde",

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -150,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoind"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -317,7 +317,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "electrsd"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -281,7 +281,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "corepc-client"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bitcoin",
  "corepc-types",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -293,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "corepc-types"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "bitcoin",
  "serde",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -150,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = "bitcoind"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",
@@ -317,7 +317,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "electrsd"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "bitcoin_hashes",

--- a/bitcoind/CHANGELOG.md
+++ b/bitcoind/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.41.0 - 2026-06-18
+
+- Improve bitcoind multithreading [#632](https://github.com/rust-bitcoin/corepc/pull/632)
+- Make `latest` feature enable Core 31 [#615](https://github.com/rust-bitcoin/corepc/pull/615)
+- Upgrade to latest version of `corepc-types` and `corepc-client`
+
 # 0.40.0 - 2026-05-26
 
 - Add initial support for Bitcoin Core v31 [#598](https://github.com/rust-bitcoin/corepc/pull/598)

--- a/bitcoind/Cargo.toml
+++ b/bitcoind/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoind"
-version = "0.40.0"
+version = "0.41.0"
 authors = ["Riccardo Casatta <riccardo@casatta.it>", "Tobin C. Harding <me@tobin.cc>"]
 license = "MIT"
 repository = "https://github.com/rust-bitcoin/corepc"

--- a/bitcoind/Cargo.toml
+++ b/bitcoind/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["tests", "contrib"]
 
 [dependencies]
 anyhow = { version = "1.0.66", default-features = false, features = ["std"] }
-corepc-client = { version = "0.15.0", path = "../client", features = ["client-sync"] }
+corepc-client = { version = "0.16.0", path = "../client", features = ["client-sync"] }
 log = { version = "0.4", default-features = false }
 serde_json = { version = "1.0.117", default-features = false }
 tempfile = { version = "3", default-features = false }

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.16.0 - 2026-06-18
+
+- Upgrade to latest `corepc-types 0.15.0`
+- Fix all the issues with `verify --tests` [#634](https://github.com/rust-bitcoin/corepc/pull/634)
+
 # 0.15.0 - 2026-05-26
 
 - Add initial support for Bitcoin Core v31 [#598](https://github.com/rust-bitcoin/corepc/pull/598)

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-client"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["Tobin C. Harding <me@tobin.cc>", "Jamil Lambert <Jamil.Lambert@proton.me>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/corepc"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -29,7 +29,7 @@ bitcoin = { version = "0.32.0", default-features = false, features = ["std", "se
 log = "0.4"
 serde = { version = "1.0.103", default-features = false, features = [ "derive", "alloc" ] }
 serde_json = { version = "1.0.117" }
-types = { package = "corepc-types", version = "0.14.0", path = "../types", default-features = false, features = ["std"] }
+types = { package = "corepc-types", version = "0.15.0", path = "../types", default-features = false, features = ["std"] }
 
 jsonrpc = { version = "0.20.0", path = "../jsonrpc", features = ["bitreq_http"], optional = true }
 

--- a/electrsd/CHANGELOG.md
+++ b/electrsd/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.41.0 - 2026-06-18
+
+- Fix timeout for old versions [#617](https://github.com/rust-bitcoin/corepc/pull/617)
+- Upgrade to latest version of `corepc-types`, `corepc-client`, and `bitcoind`
+
 # 0.40.0 - 2026-05-26
 
 With this release we now set the default feature to `electrs_0_10_6`.

--- a/electrsd/Cargo.toml
+++ b/electrsd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "electrsd"
-version = "0.40.0"
+version = "0.41.0"
 authors = ["Riccardo Casatta <riccardo@casatta.it>"]
 description = "Utility to run a regtest electrs process, useful in integration testing environment"
 repository = "https://github.com/rust-bitcoin/corepc"
@@ -12,7 +12,7 @@ categories = ["cryptography::cryptocurrencies", "development-tools::testing"]
 exclude = ["tests", "contrib"]
 
 [dependencies]
-bitcoind = { version = "0.40.0", path = "../bitcoind" }
+bitcoind = { version = "0.41.0", path = "../bitcoind" }
 corepc-client = { version = "0.16.0", path = "../client" }
 electrum-client = { version = "0.25.0", default-features = false }
 log = { version = "0.4" }

--- a/electrsd/Cargo.toml
+++ b/electrsd/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["tests", "contrib"]
 
 [dependencies]
 bitcoind = { version = "0.40.0", path = "../bitcoind" }
-corepc-client = { version = "0.15.0", path = "../client" }
+corepc-client = { version = "0.16.0", path = "../client" }
 electrum-client = { version = "0.25.0", default-features = false }
 log = { version = "0.4" }
 

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -63,6 +63,6 @@ env_logger = "0.9.0"
 bitcoind = { package = "bitcoind", version = "0.40.0", path = "../bitcoind", default-features = false }
 rand = "0.8.5"
 # Just so we can enable the feature.
-types = { package = "corepc-types", version = "0.14.0", path = "../types", features = ["serde-deny-unknown-fields"] }
+types = { package = "corepc-types", version = "0.15.0", path = "../types", features = ["serde-deny-unknown-fields"] }
 
 [dev-dependencies]

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -60,7 +60,7 @@ TODO = []                       # This is a dirty hack while writing the tests.
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false, features = ["std", "serde"] }
 env_logger = "0.9.0"
-bitcoind = { package = "bitcoind", version = "0.40.0", path = "../bitcoind", default-features = false }
+bitcoind = { package = "bitcoind", version = "0.41.0", path = "../bitcoind", default-features = false }
 rand = "0.8.5"
 # Just so we can enable the feature.
 types = { package = "corepc-types", version = "0.15.0", path = "../types", features = ["serde-deny-unknown-fields"] }

--- a/types/CHANGELOG.md
+++ b/types/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.15.0 - 2026-06-18
+
+- Finish off support for Bitcoin Core v31.0 [#615](https://github.com/rust-bitcoin/corepc/pull/615)
+- Follow-ups for Bitcoin Core v31.0 support [#635](https://github.com/rust-bitcoin/corepc/pull/635)
+
 # 0.14.0 - 2026-05-26
 
 - Add initial support for Bitcoin Core v31 [#598](https://github.com/rust-bitcoin/corepc/pull/598)

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "corepc-types"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Tobin C. Harding <me@tobin.cc>", "Jamil Lambert <Jamil.Lambert@proton.me>"]
 license = "CC0-1.0"
 repository = "https://github.com/rust-bitcoin/corepc"


### PR DESCRIPTION
We want to release the v31 stuff from types. Doing so requires release of the client, bitcoind, and electrsd as well.
