### PR TITLE
verify: fix help text

### DIFF
--- a/verify/src/main.rs
+++ b/verify/src/main.rs
@@ -41,13 +41,13 @@ fn main() -> Result<()> {
         arg!([version] "Verify specific version of Core (use \"all\" for all versions)")
             .required(true),
         arg!(-t --tests <TEST_OUTPUT> "Optionally check claimed status of tests").required(false),
-        arg!(-q --quiet ... "Run tests in quiet mode").required(false),
+        arg!(-q --quiet "Run tests in quiet mode").required(false),
     ]);
 
-    let matches = cmd.clone().get_matches();
+    let matches = cmd.get_matches();
     let version = matches.get_one::<String>("version").unwrap();
     let test_output = matches.get_one::<String>("tests");
-    let quiet = matches.get_one::<u8>("quiet") == Some(&1);
+    let quiet = matches.get_flag("quiet");
 
     if version == "all" {
         verify_all_versions(test_output, quiet)?;


### PR DESCRIPTION
`quiet` had `...` after it. Remove them.

Clap v4 has API changes that required the below changes:
- Remove unnecessary `cmd.clone()` now that `get_matches()` consumes the command.
- Replace deprecated `get_one::<u8>("quiet")` with boolean `get_flag("quiet")` for the quiet flag.

Closes #631