### PR TITLE
Run `verify --tests` in CI

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -160,7 +160,19 @@ jobs:
       - name: "Run integration tests"
         env:
           BITCOIND_DOWNLOAD_DIR: ${{ github.workspace }}/.cache/corepc/bitcoind
-        run: cd integration_test && cargo test --features=${{ matrix.version }},download
+        run: |
+          set -o pipefail
+          test_output="${{ runner.temp }}/integration-test-${{ matrix.version }}.out"
+          cd integration_test
+          cargo test --features=${{ matrix.version }},download 2>&1 | tee "$test_output"
+      - name: "Verify integration test coverage"
+        run: |
+          test_output="${{ runner.temp }}/integration-test-${{ matrix.version }}.out"
+          verify_version="${{ matrix.version }}"
+          verify_version="${verify_version#0_}"
+          verify_version="${verify_version%%_*}"
+          cd verify
+          cargo run -- --tests "$test_output" "$verify_version"
 
   # The jobs below copied from electrsd repo during import. Not too
   # much further thought given to it.

--- a/integration_test/tests/raw_transactions.rs
+++ b/integration_test/tests/raw_transactions.rs
@@ -717,10 +717,26 @@ fn raw_transactions__get_private_broadcast_info__modelled() {
 
 #[test]
 #[cfg(not(feature = "v30_and_below"))]
-fn raw_transactions__abort_private_broadcast() {
-    let node = BitcoinD::with_wallet(Wallet::None, &[]);
+fn raw_transactions__abort_private_broadcast__modelled() {
+    let node =
+        BitcoinD::with_wallet(Wallet::Default, &["-privatebroadcast=1", "-proxy=127.0.0.1:1"]);
+    node.fund_wallet();
 
-    // Aborting a transaction that is not in the private broadcast queue returns an error in regtest.
-    let txid = "0000000000000000000000000000000000000000000000000000000000000001";
-    assert!(node.client.abort_private_broadcast(txid).is_err());
+    // Create a signed transaction and send it via private broadcast.
+    let tx = create_a_raw_transaction(&node);
+    let signed = node
+        .client
+        .sign_raw_transaction_with_wallet(&tx)
+        .expect("signrawtransactionwithwallet")
+        .into_model()
+        .expect("SignRawTransaction into model")
+        .tx;
+    let send = node.client.send_raw_transaction(&signed).expect("sendrawtransaction");
+
+    let json: AbortPrivateBroadcast =
+        node.client.abort_private_broadcast(&send.0).expect("abortprivatebroadcast");
+    let model: Result<mtype::AbortPrivateBroadcast, encode::FromHexError> = json.into_model();
+    let abort = model.unwrap();
+
+    assert_eq!(abort.removed_transactions, &[signed]);
 }

--- a/types/src/v26/mod.rs
+++ b/types/src/v26/mod.rs
@@ -134,7 +134,7 @@
 //! | joinpsbts                          | version + model |                                        |
 //! | sendrawtransaction                 | version + model |                                        |
 //! | signrawtransactionwithkey          | version + model | UNTESTED                               |
-//! | submitpackage                      | version + model |                                        |
+//! | submitpackage                      | version + model | UNTESTED                               |
 //! | testmempoolaccept                  | version + model |                                        |
 //! | utxoupdatepsbt                     | version + model |                                        |
 //!


### PR DESCRIPTION
Fix the two problems highlighted when adding `verify --tests` to CI:
`submitpackage` is untested for v26 - Add `UNTESTED` label to the types table.
`abortprivatebroadcast` test did not check the model - Fix the test.

Add `verify --tests` to CI:
For every version `integration_tests` capture the output and run `verify --tests` with the output generated. Run in the same job as the tests since they are needed to generate the file.

Closes #639