### PR TITLE
pin memmap2 version above RUSTSEC-2026-0186 fix

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -573,9 +573,9 @@ checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 
 [[package]]
 name = "honggfuzz"
-version = "0.5.58"
+version = "0.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e8319f3cc8fe416e7aa1ab95dcc04fd49f35397a47d0b2f0f225f6dba346a07"
+checksum = "4d6510a410acedd7a7683b3a45dafdc5ccf3c72d6addaa373497005964fc4e23"
 dependencies = [
  "lazy_static",
  "memmap2",
@@ -661,6 +661,7 @@ version = "0.0.1"
 dependencies = [
  "honggfuzz",
  "jsonrpc",
+ "memmap2",
  "serde",
  "serde_json",
 ]
@@ -708,9 +709,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memmap2"
-version = "0.9.9"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -573,9 +573,9 @@ checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 
 [[package]]
 name = "honggfuzz"
-version = "0.5.58"
+version = "0.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e8319f3cc8fe416e7aa1ab95dcc04fd49f35397a47d0b2f0f225f6dba346a07"
+checksum = "4d6510a410acedd7a7683b3a45dafdc5ccf3c72d6addaa373497005964fc4e23"
 dependencies = [
  "lazy_static",
  "memmap2",
@@ -661,6 +661,7 @@ version = "0.0.1"
 dependencies = [
  "honggfuzz",
  "jsonrpc",
+ "memmap2",
  "serde",
  "serde_json",
 ]
@@ -708,9 +709,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memmap2"
-version = "0.9.9"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -16,6 +16,9 @@ jsonrpc = { path = "../jsonrpc", features = ["bitreq_http"] }
 serde = { version = "1.0.103", features = [ "derive" ] }
 serde_json = "1.0"
 
+[target.'cfg(fuzzing_debug)'.dependencies]
+memmap2 = "0.9.11"
+
 [lints.rust]
 unexpected_cfgs = { level = "deny", check-cfg = ['cfg(fuzzing)', 'cfg(jsonrpc_fuzz)'] }
 

--- a/fuzz/generate-files.sh
+++ b/fuzz/generate-files.sh
@@ -23,13 +23,13 @@ cargo-fuzz = true
 
 [dependencies]
 honggfuzz = { version = "0.5.55", default-features = false }
-jsonrpc = { path = "..", features = ["bitreq_http"] }
+jsonrpc = { path = "../jsonrpc", features = ["bitreq_http"] }
 
 serde = { version = "1.0.103", features = [ "derive" ] }
 serde_json = "1.0"
 
 [lints.rust]
-unexpected_cfgs = { level = "deny", check-cfg = ['cfg(fuzzing)'] }
+unexpected_cfgs = { level = "deny", check-cfg = ['cfg(fuzzing)', 'cfg(jsonrpc_fuzz)'] }
 EOF
 
 for targetFile in $(listTargetFiles); do
@@ -80,7 +80,7 @@ $(for name in $(listTargetNames); do echo "          $name,"; done)
           key: cache-\${{ matrix.target }}-\${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: '1.65.0'
+          toolchain: '1.75.0'
       - name: fuzz
         run: |
           if [[ "\${{ matrix.fuzz_target }}" =~ ^bitcoin ]]; then

--- a/fuzz/generate-files.sh
+++ b/fuzz/generate-files.sh
@@ -28,6 +28,9 @@ jsonrpc = { path = "../jsonrpc", features = ["bitreq_http"] }
 serde = { version = "1.0.103", features = [ "derive" ] }
 serde_json = "1.0"
 
+[target.'cfg(fuzzing_debug)'.dependencies]
+memmap2 = "0.9.11"
+
 [lints.rust]
 unexpected_cfgs = { level = "deny", check-cfg = ['cfg(fuzzing)', 'cfg(jsonrpc_fuzz)'] }
 EOF


### PR DESCRIPTION
Pin memmap2 to a safe minimum (>= 0.9.11) for fuzzing builds so the minimum lockfile generation is not the vulnerable 0.9.9 version.

Update the lockfiles.

Closes #645 