### PR TITLE
Bump anyhow dep version to 1.0.103 to fix RUSTSEC-2026-0190

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arrayvec"

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arrayvec"

--- a/bitcoind/Cargo.toml
+++ b/bitcoind/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.75.0"
 exclude = ["tests", "contrib"]
 
 [dependencies]
-anyhow = { version = "1.0.66", default-features = false, features = ["std"] }
+anyhow = { version = "1.0.103", default-features = false, features = ["std"] }
 corepc-client = { version = "0.16.0", path = "../client", features = ["client-sync"] }
 log = { version = "0.4", default-features = false }
 serde_json = { version = "1.0.117", default-features = false }
@@ -24,7 +24,7 @@ which = { version = "3.1.1", default-features = false }
 env_logger = { version = "0.9.3", default-features = false }
 
 [build-dependencies]
-anyhow = { version = "1.0.66", optional = true }
+anyhow = { version = "1.0.103", optional = true }
 bitcoin_hashes = { version = ">= 0.13, <= 0.14", optional = true }
 flate2 = { version = "1.0", optional = true }
 bitreq = { version = "0.3.5", path = "../bitreq", features = ["https"], optional = true }

--- a/electrsd/Cargo.toml
+++ b/electrsd/Cargo.toml
@@ -24,7 +24,7 @@ nix = { version = "0.25.0" }
 env_logger = { version = "0.10" }
 
 [build-dependencies]
-anyhow = { version = "1.0.66", default-features = false, features = ["std"], optional = true }
+anyhow = { version = "1.0.103", default-features = false, features = ["std"], optional = true }
 bitcoin_hashes = { version = "0.14", optional = true }
 zip = { version = "0.6", default-features = false, optional = true, features = [
   "bzip2",

--- a/verify/Cargo.toml
+++ b/verify/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.93"
+anyhow = "1.0.103"
 clap = { version = "4.5.23", features = ["cargo"] }
 regex = "1"
 syn = { version = "2.0", default-features = false, features = ["full", "parsing"] }


### PR DESCRIPTION
There is a RUSTSEC-2026-0186: Unchecked pointer offset advisory for anyhow versions < 1.0.103.

Bump the anyhow dependency to 1.0.103.

Update the lockfiles.

Closes #649