### PR TITLE
Fix duplicate rustsec issue creation

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -17,6 +17,8 @@ jobs:
       checks: write
     strategy:
       fail-fast: false
+      # Run one at a time, otherwise parallel jobs create the same advisory issue twice.
+      max-parallel: 1
       matrix:
         lockfile: [Cargo.lock, Cargo-minimal.lock, Cargo-recent.lock]
     steps:


### PR DESCRIPTION
When the audit runs on all 3 lockfiles at the same time a problem in multiple lockfiles can result in multiple issues being created for the same RustSec ID.

Run the jobs one at a time so that issues created are seen by the next jobs and no duplicate issue is created.