### PR TITLE
WIP: Demonstrate usage of the bitcoin-units compat layer

### DIFF
--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -67,12 +67,10 @@ dependencies = [
 
 [[package]]
 name = "base58ck"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+version = "0.1.101"
+source = "git+https://github.com/tcharding/rust-bitcoin?branch=push-pwqxwuswpnsz#29160328b998377dde67adf353a417b4851212c9"
 dependencies = [
- "bitcoin-internals",
- "bitcoin_hashes",
+ "bitcoin_hashes 0.14.101",
 ]
 
 [[package]]
@@ -95,31 +93,54 @@ checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "bitcoin"
-version = "0.32.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf33434c870e98ecc8608588ccc990c5daba9ba9ad39733dc85fba22c211504"
+version = "0.32.101"
+source = "git+https://github.com/tcharding/rust-bitcoin?branch=push-pwqxwuswpnsz#29160328b998377dde67adf353a417b4851212c9"
 dependencies = [
  "base58ck",
  "base64 0.21.7",
  "bech32",
- "bitcoin-internals",
- "bitcoin-io",
- "bitcoin-units",
- "bitcoin_hashes",
- "hex-conservative",
+ "bitcoin-consensus-encoding 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin-io 0.1.101",
+ "bitcoin-units 0.1.101",
+ "bitcoin-units 1.0.0",
+ "bitcoin_hashes 0.14.101",
+ "hex-conservative 0.2.2",
  "hex_lit",
  "secp256k1",
  "serde",
 ]
 
 [[package]]
-name = "bitcoin-internals"
-version = "0.3.0"
+name = "bitcoin-consensus-encoding"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
+checksum = "207311705279250ba465076a1bac4b1ac982855fff73fc5f67e22158ac58cdc9"
 dependencies = [
+ "bitcoin-internals 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex-conservative 1.2.0",
  "serde",
 ]
+
+[[package]]
+name = "bitcoin-consensus-encoding"
+version = "1.1.0"
+source = "git+https://github.com/tcharding/rust-bitcoin?branch=push-puzmtlnlttlr#583a64812eb6ca17a262a7beffbfab0470cb061a"
+dependencies = [
+ "bitcoin-internals 0.6.0 (git+https://github.com/tcharding/rust-bitcoin?branch=push-puzmtlnlttlr)",
+ "hex-conservative 1.2.0",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d573f4cf32996a8dce612e4348cece65a241f1882ed594047c9ba348e8869fa5"
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.6.0"
+source = "git+https://github.com/tcharding/rust-bitcoin?branch=push-puzmtlnlttlr#583a64812eb6ca17a262a7beffbfab0470cb061a"
 
 [[package]]
 name = "bitcoin-io"
@@ -128,12 +149,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "340e09e8399c7bd8912f495af6aa58bea0c9214773417ffaa8f6460f93aaee56"
 
 [[package]]
-name = "bitcoin-units"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb54da0b28892f3c52203a7191534033e051b6f4b52bc15480681b57b7e036f5"
+name = "bitcoin-io"
+version = "0.1.101"
+source = "git+https://github.com/tcharding/rust-bitcoin?branch=push-pwqxwuswpnsz#29160328b998377dde67adf353a417b4851212c9"
 dependencies = [
- "bitcoin-internals",
+ "bitcoin-consensus-encoding 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bitcoin-units"
+version = "0.1.101"
+source = "git+https://github.com/tcharding/rust-bitcoin?branch=push-pwqxwuswpnsz#29160328b998377dde67adf353a417b4851212c9"
+dependencies = [
+ "bitcoin-consensus-encoding 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin-units 1.0.0",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin-units"
+version = "1.0.0"
+source = "git+https://github.com/tcharding/rust-bitcoin?branch=push-puzmtlnlttlr#583a64812eb6ca17a262a7beffbfab0470cb061a"
+dependencies = [
+ "bitcoin-consensus-encoding 1.1.0 (git+https://github.com/tcharding/rust-bitcoin?branch=push-puzmtlnlttlr)",
+ "bitcoin-internals 0.6.0 (git+https://github.com/tcharding/rust-bitcoin?branch=push-puzmtlnlttlr)",
  "serde",
 ]
 
@@ -143,8 +182,17 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
 dependencies = [
- "bitcoin-io",
- "hex-conservative",
+ "bitcoin-io 0.1.2",
+ "hex-conservative 0.2.2",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.101"
+source = "git+https://github.com/tcharding/rust-bitcoin?branch=push-pwqxwuswpnsz#29160328b998377dde67adf353a417b4851212c9"
+dependencies = [
+ "bitcoin-io 0.1.101",
+ "hex-conservative 0.2.2",
  "serde",
 ]
 
@@ -153,7 +201,7 @@ name = "bitcoind"
 version = "0.41.0"
 dependencies = [
  "anyhow",
- "bitcoin_hashes",
+ "bitcoin_hashes 0.14.0",
  "bitreq",
  "corepc-client",
  "env_logger 0.9.3",
@@ -320,7 +368,7 @@ name = "electrsd"
 version = "0.41.0"
 dependencies = [
  "anyhow",
- "bitcoin_hashes",
+ "bitcoin_hashes 0.14.0",
  "bitcoind",
  "bitreq",
  "corepc-client",
@@ -558,9 +606,18 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex-conservative"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "hex-conservative"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35431185f361ccf3ffc58254628af5f1f5d5f28531da2e02e5d6c82bbc282a10"
 dependencies = [
  "arrayvec",
 ]
@@ -1109,7 +1166,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e0cc0f1cf93f4969faf3ea1c7d8a9faed25918d96affa959720823dfe86d4f3"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.14.0",
  "secp256k1-sys",
  "serde",
 ]

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -67,12 +67,10 @@ dependencies = [
 
 [[package]]
 name = "base58ck"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+version = "0.1.101"
+source = "git+https://github.com/tcharding/rust-bitcoin?branch=push-pwqxwuswpnsz#29160328b998377dde67adf353a417b4851212c9"
 dependencies = [
- "bitcoin-internals",
- "bitcoin_hashes",
+ "bitcoin_hashes 0.14.101",
 ]
 
 [[package]]
@@ -95,31 +93,54 @@ checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "bitcoin"
-version = "0.32.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf33434c870e98ecc8608588ccc990c5daba9ba9ad39733dc85fba22c211504"
+version = "0.32.101"
+source = "git+https://github.com/tcharding/rust-bitcoin?branch=push-pwqxwuswpnsz#29160328b998377dde67adf353a417b4851212c9"
 dependencies = [
  "base58ck",
  "base64 0.21.7",
  "bech32",
- "bitcoin-internals",
- "bitcoin-io",
- "bitcoin-units",
- "bitcoin_hashes",
- "hex-conservative",
+ "bitcoin-consensus-encoding 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin-io 0.1.101",
+ "bitcoin-units 0.1.101",
+ "bitcoin-units 1.0.0",
+ "bitcoin_hashes 0.14.101",
+ "hex-conservative 0.2.2",
  "hex_lit",
  "secp256k1",
  "serde",
 ]
 
 [[package]]
-name = "bitcoin-internals"
-version = "0.3.0"
+name = "bitcoin-consensus-encoding"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
+checksum = "207311705279250ba465076a1bac4b1ac982855fff73fc5f67e22158ac58cdc9"
 dependencies = [
+ "bitcoin-internals 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex-conservative 1.2.0",
  "serde",
 ]
+
+[[package]]
+name = "bitcoin-consensus-encoding"
+version = "1.1.0"
+source = "git+https://github.com/tcharding/rust-bitcoin?branch=push-puzmtlnlttlr#583a64812eb6ca17a262a7beffbfab0470cb061a"
+dependencies = [
+ "bitcoin-internals 0.6.0 (git+https://github.com/tcharding/rust-bitcoin?branch=push-puzmtlnlttlr)",
+ "hex-conservative 1.2.0",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d573f4cf32996a8dce612e4348cece65a241f1882ed594047c9ba348e8869fa5"
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.6.0"
+source = "git+https://github.com/tcharding/rust-bitcoin?branch=push-puzmtlnlttlr#583a64812eb6ca17a262a7beffbfab0470cb061a"
 
 [[package]]
 name = "bitcoin-io"
@@ -128,12 +149,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "340e09e8399c7bd8912f495af6aa58bea0c9214773417ffaa8f6460f93aaee56"
 
 [[package]]
-name = "bitcoin-units"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb54da0b28892f3c52203a7191534033e051b6f4b52bc15480681b57b7e036f5"
+name = "bitcoin-io"
+version = "0.1.101"
+source = "git+https://github.com/tcharding/rust-bitcoin?branch=push-pwqxwuswpnsz#29160328b998377dde67adf353a417b4851212c9"
 dependencies = [
- "bitcoin-internals",
+ "bitcoin-consensus-encoding 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bitcoin-units"
+version = "0.1.101"
+source = "git+https://github.com/tcharding/rust-bitcoin?branch=push-pwqxwuswpnsz#29160328b998377dde67adf353a417b4851212c9"
+dependencies = [
+ "bitcoin-consensus-encoding 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin-units 1.0.0",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin-units"
+version = "1.0.0"
+source = "git+https://github.com/tcharding/rust-bitcoin?branch=push-puzmtlnlttlr#583a64812eb6ca17a262a7beffbfab0470cb061a"
+dependencies = [
+ "bitcoin-consensus-encoding 1.1.0 (git+https://github.com/tcharding/rust-bitcoin?branch=push-puzmtlnlttlr)",
+ "bitcoin-internals 0.6.0 (git+https://github.com/tcharding/rust-bitcoin?branch=push-puzmtlnlttlr)",
  "serde",
 ]
 
@@ -143,8 +182,17 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
 dependencies = [
- "bitcoin-io",
- "hex-conservative",
+ "bitcoin-io 0.1.2",
+ "hex-conservative 0.2.2",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.101"
+source = "git+https://github.com/tcharding/rust-bitcoin?branch=push-pwqxwuswpnsz#29160328b998377dde67adf353a417b4851212c9"
+dependencies = [
+ "bitcoin-io 0.1.101",
+ "hex-conservative 0.2.2",
  "serde",
 ]
 
@@ -153,7 +201,7 @@ name = "bitcoind"
 version = "0.41.0"
 dependencies = [
  "anyhow",
- "bitcoin_hashes",
+ "bitcoin_hashes 0.14.0",
  "bitreq",
  "corepc-client",
  "env_logger 0.9.3",
@@ -320,7 +368,7 @@ name = "electrsd"
 version = "0.41.0"
 dependencies = [
  "anyhow",
- "bitcoin_hashes",
+ "bitcoin_hashes 0.14.0",
  "bitcoind",
  "bitreq",
  "corepc-client",
@@ -558,9 +606,18 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex-conservative"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "hex-conservative"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35431185f361ccf3ffc58254628af5f1f5d5f28531da2e02e5d6c82bbc282a10"
 dependencies = [
  "arrayvec",
 ]
@@ -1109,7 +1166,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e0cc0f1cf93f4969faf3ea1c7d8a9faed25918d96affa959720823dfe86d4f3"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.14.0",
  "secp256k1-sys",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,7 @@ versions = [
     "0_18_1",
     "0_17_2",
 ]
+
+[patch.crates-io]
+# The compat layer branch: https://github.com/rust-bitcoin/rust-bitcoin/pull/6259
+bitcoin = { git = "https://github.com/tcharding/rust-bitcoin", branch = "push-pwqxwuswpnsz" }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -25,7 +25,7 @@ allowed_duplicates = ["base64"]
 client-sync = ["jsonrpc"]
 
 [dependencies]
-bitcoin = { version = "0.32.0", default-features = false, features = ["std", "serde"] }
+bitcoin = { version = "0.32.101", default-features = false, features = ["std", "serde", "compat"] }
 log = "0.4"
 serde = { version = "1.0.103", default-features = false, features = [ "derive", "alloc" ] }
 serde_json = { version = "1.0.117" }

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -58,7 +58,7 @@ v17 = ["v18_and_below"]
 TODO = []                       # This is a dirty hack while writing the tests.
 
 [dependencies]
-bitcoin = { version = "0.32.0", default-features = false, features = ["std", "serde"] }
+bitcoin = { version = "0.32.101", default-features = false, features = ["std", "serde", "compat"] }
 env_logger = "0.9.0"
 bitcoind = { package = "bitcoind", version = "0.41.0", path = "../bitcoind", default-features = false }
 rand = "0.8.5"
@@ -66,3 +66,6 @@ rand = "0.8.5"
 types = { package = "corepc-types", version = "0.15.0", path = "../types", features = ["serde-deny-unknown-fields"] }
 
 [dev-dependencies]
+
+[patch.crates-io]
+bitcoin = { git = "https://github.com/tcharding/rust-bitcoin", branch = "push-pwqxwuswpnsz" }

--- a/integration_test/tests/blockchain.rs
+++ b/integration_test/tests/blockchain.rs
@@ -127,7 +127,7 @@ fn blockchain__load_tx_out_set__modelled() {
 
     assert_eq!(model.base_height, snapshot_height as u32);
     assert_eq!(model.tip_hash, hash_at_height);
-    assert_eq!(model.coins_loaded, bitcoin::Amount::from_btc(110.0).unwrap());
+    assert_eq!(model.coins_loaded, bitcoin::compat::Amount::from_btc(110.0).unwrap());
 }
 
 #[test]

--- a/integration_test/tests/wallet.rs
+++ b/integration_test/tests/wallet.rs
@@ -359,7 +359,7 @@ fn wallet__get_received_by_address__modelled() {
     let model: Result<mtype::GetReceivedByAddress, amount::ParseAmountError> = json.into_model();
     let received_by_address = model.unwrap();
 
-    assert_eq!(received_by_address.0, amount);
+    assert_eq!(received_by_address.0, amount.to_stable().unwrap());
 }
 
 #[test]
@@ -379,7 +379,7 @@ fn wallet__get_received_by_label__modelled() {
         node.client.get_received_by_label(label).expect("getreceivedbylabel");
     let model: Result<mtype::GetReceivedByLabel, amount::ParseAmountError> = json.into_model();
     let received = model.unwrap();
-    assert_eq!(received.0, amount);
+    assert_eq!(received.0, amount.to_stable().unwrap());
 }
 
 #[test]
@@ -1021,7 +1021,7 @@ fn wallet__set_tx_fee() {
     #[cfg(not(feature = "v29_and_below"))]
     let node = BitcoinD::with_wallet(Wallet::Default, &["-deprecatedrpc=settxfee"]);
 
-    let fee_rate = FeeRate::from_sat_per_vb(2).expect("2 sat/vb is valid");
+    let fee_rate = FeeRate::from_sat_per_vb_u32(2);
 
     let json: SetTxFee = node.client.set_tx_fee(fee_rate).expect("settxfee");
     assert!(json.0);

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -18,7 +18,7 @@ std = ["bitcoin/std"]
 serde-deny-unknown-fields = []
 
 [dependencies]
-bitcoin = { version = "0.32.0", default-features = false, features = ["serde", "base64", "secp-recovery"] }
+bitcoin = { version = "0.32.101", default-features = false, features = ["serde", "base64", "secp-recovery", "compat"] }
 serde = { version = "1.0.103", default-features = false, features = [ "derive", "alloc" ] }
 serde_json = { version = "1.0.117" }
 

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -40,6 +40,7 @@ use core::fmt;
 
 use bitcoin::address::{self, Address, NetworkUnchecked};
 use bitcoin::amount::ParseAmountError;
+use bitcoin::compat::{Amount as StableAmount, Sequence as StableSequence};
 use bitcoin::hex::{self, FromHex as _};
 use bitcoin::{Amount, FeeRate, ScriptBuf, Witness};
 use serde::{Deserialize, Serialize};
@@ -97,9 +98,21 @@ impl std::error::Error for NumericError {}
 /// Converts `fee_rate` in BTC/kB to `FeeRate`.
 fn btc_per_kb(btc_per_kb: f64) -> Result<Option<FeeRate>, ParseAmountError> {
     // TODO: After upgrade to bitcoin `v0.33` use `FeeRate::from_sat_per_kvb()`.
-    let per_kb = Amount::from_btc(btc_per_kb)?;
+    let per_kb = bitcoin::Amount::from_btc(btc_per_kb)?;
     Ok(FeeRate::from_sat_per_vb(per_kb.to_sat()).and_then(|fee_rate| fee_rate.checked_div(1000)))
 }
+
+fn stable_amount(amount: Amount) -> StableAmount {
+    amount.to_stable().expect("Bitcoin Core amounts are within MAX_MONEY")
+}
+
+fn stable_amount_from_sat(sats: u64) -> StableAmount { stable_amount(Amount::from_sat(sats)) }
+
+fn stable_amount_from_btc(btc: f64) -> Result<StableAmount, ParseAmountError> {
+    Ok(stable_amount(Amount::from_btc(btc)?))
+}
+
+fn stable_sequence(sequence: bitcoin::Sequence) -> StableSequence { sequence.to_stable() }
 
 // TODO: Remove this function if a new `Witness` constructor gets added.
 // https://github.com/rust-bitcoin/rust-bitcoin/issues/4350

--- a/types/src/model/blockchain.rs
+++ b/types/src/model/blockchain.rs
@@ -8,11 +8,12 @@
 use alloc::collections::BTreeMap;
 
 use bitcoin::address::NetworkUnchecked;
+use bitcoin::compat::{Amount, Sequence};
 use bitcoin::hashes::sha256;
 use bitcoin::{
-    absolute, block, transaction, Address, Amount, Block, BlockHash, CompactTarget, FeeRate,
-    Network, OutPoint, ScriptBuf, Sequence, Target, Transaction, TxMerkleNode, TxOut, Txid, Weight,
-    Witness, Work, Wtxid,
+    absolute, block, transaction, Address, Block, BlockHash, CompactTarget, FeeRate, Network,
+    OutPoint, ScriptBuf, Target, Transaction, TxMerkleNode, TxOut, Txid, Weight, Witness, Work,
+    Wtxid,
 };
 use serde::{Deserialize, Serialize};
 
@@ -22,6 +23,7 @@ use super::{GetRawTransactionVerbose, ScriptPubKey};
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct DumpTxOutSet {
     /// The number of coins written in the snapshot.
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub coins_written: Amount,
     /// The hash of the base of the snapshot.
     pub base_hash: BlockHash,
@@ -139,6 +141,7 @@ pub struct GetBlockVerboseTwoTransaction {
     /// The transaction data (same as `getrawtransaction` verbose output).
     pub transaction: GetRawTransactionVerbose,
     /// The transaction fee in BTC (omitted if block undo data is not available).
+    #[serde(default, with = "bitcoin::compat::amount::serde::as_btc::opt")]
     pub fee: Option<Amount>,
 }
 
@@ -210,6 +213,7 @@ pub struct GetBlockVerboseThreeTransaction {
     /// The prevout data aligned with the transaction input order.
     pub prevouts: Vec<Option<GetBlockVerboseThreePrevout>>,
     /// The transaction fee in BTC, omitted if block undo data is not available.
+    #[serde(default, with = "bitcoin::compat::amount::serde::as_btc::opt")]
     pub fee: Option<Amount>,
 }
 
@@ -222,6 +226,7 @@ pub struct GetBlockVerboseThreePrevout {
     /// The height of the prevout.
     pub height: u32,
     /// The value in BTC.
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub value: Amount,
     /// The script pubkey.
     pub script_pubkey: ScriptPubKey,
@@ -411,6 +416,7 @@ pub struct GetBlockHeaderVerbose {
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct GetBlockStats {
     /// Average fee in the block.
+    #[serde(default, with = "bitcoin::compat::amount::serde::as_btc::opt")]
     pub average_fee: Option<Amount>,
     /// Average feerate.
     pub average_fee_rate: Option<FeeRate>,
@@ -425,18 +431,21 @@ pub struct GetBlockStats {
     /// The number of inputs (excluding coinbase).
     pub inputs: Option<u32>,
     /// Maximum fee in the block.
+    #[serde(default, with = "bitcoin::compat::amount::serde::as_btc::opt")]
     pub max_fee: Option<Amount>,
     /// Maximum feerate (in satoshis per virtual byte).
     pub max_fee_rate: Option<FeeRate>,
     /// Maximum transaction size.
     pub max_tx_size: Option<u32>,
     /// Truncated median fee in the block.
+    #[serde(default, with = "bitcoin::compat::amount::serde::as_btc::opt")]
     pub median_fee: Option<Amount>,
     /// The block median time past.
     pub median_time: Option<u32>,
     /// Truncated median transaction size
     pub median_tx_size: Option<u32>,
     /// Minimum fee in the block.
+    #[serde(default, with = "bitcoin::compat::amount::serde::as_btc::opt")]
     pub minimum_fee: Option<Amount>,
     /// Minimum feerate (in satoshis per virtual byte).
     pub minimum_fee_rate: Option<FeeRate>,
@@ -445,6 +454,7 @@ pub struct GetBlockStats {
     /// The number of outputs.
     pub outputs: Option<u32>,
     /// The block subsidy.
+    #[serde(default, with = "bitcoin::compat::amount::serde::as_btc::opt")]
     pub subsidy: Option<Amount>,
     /// Total size of all segwit transactions.
     pub segwit_total_size: Option<u32>,
@@ -455,12 +465,14 @@ pub struct GetBlockStats {
     /// The block time.
     pub time: Option<u32>,
     /// Total amount in all outputs (excluding coinbase and thus reward [ie subsidy + totalfee]).
+    #[serde(default, with = "bitcoin::compat::amount::serde::as_btc::opt")]
     pub total_out: Option<Amount>,
     /// Total size of all non-coinbase transactions.
     pub total_size: Option<u32>,
     /// Total weight of all non-coinbase transactions divided by segwit scale factor (4).
     pub total_weight: Option<Weight>,
     /// The fee total.
+    #[serde(default, with = "bitcoin::compat::amount::serde::as_btc::opt")]
     pub total_fee: Option<Amount>,
     /// The number of transactions (excluding coinbase).
     pub txs: Option<u32>,
@@ -648,6 +660,7 @@ pub enum ActivityEntry {
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct SpendActivity {
     /// The total amount of the spent output.
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub amount: Amount,
     /// The blockhash (omitted if unconfirmed).
     pub block_hash: Option<BlockHash>,
@@ -669,6 +682,7 @@ pub struct SpendActivity {
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct ReceiveActivity {
     /// The total amount in BTC of the new output.
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub amount: Amount,
     /// The block that this receive is in (omitted if unconfirmed).
     pub block_hash: Option<BlockHash>,
@@ -705,6 +719,7 @@ pub struct GetMempoolCluster {
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct Chunk {
     /// Fees of the transactions in this chunk.
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub chunk_fee: Amount,
     /// Sigops-adjusted weight of all transactions in this chunk.
     pub chunk_weight: u64,
@@ -778,16 +793,21 @@ pub struct MempoolEntry {
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct MempoolEntryFees {
     /// Transaction fee in BTC.
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub base: Amount,
     /// Transaction fee with fee deltas used for mining priority.
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub modified: Amount,
     /// Modified fees (see above) of in-mempool ancestors (including this one).
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub ancestor: Amount,
     /// Modified fees (see above) of in-mempool descendants (including this one).
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub descendant: Amount,
     /// Transaction fees of chunk.
     ///
     /// This was introduced with Bitcoin Core v31 and will hence be `None` for previous versions.
+    #[serde(default, with = "bitcoin::compat::amount::serde::as_btc::opt")]
     pub chunk: Option<Amount>,
 }
 
@@ -861,6 +881,7 @@ pub struct FeerateDiagramEntry {
     /// Cumulative sigops-adjusted weight.
     pub weight: u64,
     /// Cumulative fee.
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub fee: Amount,
 }
 
@@ -904,10 +925,12 @@ pub struct GetTxOutSetInfo {
     /// The estimated size of the chainstate on disk (not available when coinstatsindex is used).
     pub disk_size: Option<u32>,
     /// The total amount.
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub total_amount: Amount,
     /// The serialized hash (only present if 'muhash' hash_type is chosen).
     pub muhash: Option<String>, // FIXME: What sort of hash is this?
     /// The total amount of coins permanently excluded from the UTXO set (only available if coinstatsindex is used).
+    #[serde(default, with = "bitcoin::compat::amount::serde::as_btc::opt")]
     pub total_unspendable_amount: Option<Amount>,
     /// Info on amounts in the block at this block height (only available if coinstatsindex is used).
     pub block_info: Option<GetTxOutSetInfoBlockInfo>,
@@ -917,12 +940,16 @@ pub struct GetTxOutSetInfo {
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct GetTxOutSetInfoBlockInfo {
     /// Total amount of all prevouts spent in this block.
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub prevout_spent: Amount,
     /// Coinbase subsidy amount of this block.
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub coinbase: Amount,
     /// Total amount of new outputs created by this block.
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub new_outputs_ex_coinbase: Amount,
     /// Total amount of unspendable outputs created in this block.
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub unspendable: Amount,
     /// Detailed view of unspendable categories.
     pub unspendables: GetTxOutSetInfoUnspendables,
@@ -932,12 +959,16 @@ pub struct GetTxOutSetInfoBlockInfo {
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct GetTxOutSetInfoUnspendables {
     /// The unspendable amount of the Genesis block subsidy.
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub genesis_block: Amount,
     /// Transactions overridden by duplicates (no longer possible with BIP30).
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub bip30: Amount,
     /// Amounts sent to scripts that are unspendable (for example OP_RETURN outputs).
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub scripts: Amount,
     /// Fee rewards that miners did not claim in their coinbase transaction.
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub unclaimed_rewards: Amount,
 }
 
@@ -964,6 +995,7 @@ pub struct GetTxSpendingPrevoutItem {
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct LoadTxOutSet {
     /// The number of coins loaded from the snapshot.
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub coins_loaded: Amount,
     /// The hash of the base of the snapshot.
     pub tip_hash: BlockHash,
@@ -1031,6 +1063,7 @@ pub struct ScanTxOutSetStart {
     /// The unspents.
     pub unspents: Vec<ScanTxOutSetUnspent>,
     /// The total amount of all found unspent outputs in BTC.
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub total_amount: Amount,
 }
 
@@ -1046,6 +1079,7 @@ pub struct ScanTxOutSetUnspent {
     /// A specialized descriptor for the matched output script. For v18 onwards.
     pub descriptor: Option<String>,
     /// The total amount in BTC of the unspent output.
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub amount: Amount,
     /// Whether this is a coinbase output. For v25 onwards.
     pub coinbase: Option<bool>,

--- a/types/src/model/raw_transactions.rs
+++ b/types/src/model/raw_transactions.rs
@@ -8,8 +8,9 @@
 use alloc::collections::BTreeMap;
 
 use bitcoin::address::{Address, NetworkUnchecked};
+use bitcoin::compat::{Amount, Sequence};
 use bitcoin::hashes::{hash160, sha256};
-use bitcoin::{Amount, BlockHash, FeeRate, Psbt, ScriptBuf, Sequence, Transaction, Txid, Wtxid};
+use bitcoin::{BlockHash, FeeRate, Psbt, ScriptBuf, Transaction, Txid, Wtxid};
 use serde::{Deserialize, Serialize};
 
 /// Models the result of JSON-RPC method `abortprivatebroadcast`.
@@ -31,6 +32,7 @@ pub struct AnalyzePsbt {
     /// Shown only if all UTXO slots in the PSBT have been filled.
     pub estimated_fee_rate: Option<FeeRate>,
     /// The transaction fee paid. Shown only if all UTXO slots in the PSBT have been filled.
+    #[serde(default, with = "bitcoin::compat::amount::serde::as_btc::opt")]
     pub fee: Option<Amount>,
     /// Role of the next person that this psbt needs to go to.
     pub next: String,
@@ -88,6 +90,7 @@ pub struct DecodePsbt {
     /// The decoded PSBT.
     pub psbt: Psbt,
     /// The transaction fee paid if all UTXOs slots in the PSBT have been filled.
+    #[serde(default, with = "bitcoin::compat::amount::serde::as_btc::opt")]
     pub fee: Option<Amount>,
 }
 
@@ -144,6 +147,7 @@ pub struct FundRawTransaction {
     /// The resulting raw transaction.
     pub tx: Transaction,
     /// Fee the resulting transaction pays.
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub fee: Amount,
     /// The position of the added change output, or -1.
     pub change_position: i64,
@@ -251,6 +255,7 @@ pub struct SubmitPackageTxResult {
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct SubmitPackageTxResultFees {
     /// Transaction fee.
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub base_fee: Amount,
     /// The effective feerate.
     ///
@@ -292,6 +297,7 @@ pub struct MempoolAcceptance {
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct MempoolAcceptanceFees {
     /// Transaction fee in BTC.
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub base: Amount,
     /// The effective feerate in BTC per KvB. May differ from the base feerate if, for example, there
     /// are modified fees from `prioritisetransaction` or a package feerate was used.

--- a/types/src/model/wallet.rs
+++ b/types/src/model/wallet.rs
@@ -9,10 +9,11 @@ use alloc::collections::BTreeMap;
 
 use bitcoin::address::NetworkUnchecked;
 use bitcoin::bip32::{Xpriv, Xpub};
+use bitcoin::compat::Amount;
 use bitcoin::hashes::hash160;
 use bitcoin::{
-    bip32, sign_message, Address, Amount, BlockHash, FeeRate, PrivateKey, Psbt, PublicKey,
-    ScriptBuf, SignedAmount, Transaction, Txid, WitnessProgram, WitnessVersion,
+    bip32, sign_message, Address, BlockHash, FeeRate, PrivateKey, Psbt, PublicKey, ScriptBuf,
+    SignedAmount, Transaction, Txid, WitnessProgram, WitnessVersion,
 };
 use serde::{Deserialize, Serialize};
 
@@ -73,8 +74,10 @@ pub struct BumpFee {
     /// The id of the new transaction.
     pub txid: Txid,
     /// Fee of the replaced transaction.
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub original_fee: Amount,
     /// Fee of the new transaction.
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub fee: Amount,
     /// Errors encountered during processing (may be empty).
     pub errors: Vec<String>,
@@ -240,7 +243,7 @@ pub struct GetAddressInfoEmbedded {
 
 /// Models the result of JSON-RPC method `getbalance`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-pub struct GetBalance(pub Amount);
+pub struct GetBalance(#[serde(with = "bitcoin::compat::amount::serde::as_btc")] pub Amount);
 
 /// Models the result of JSON-RPC method `getbalances`.
 ///
@@ -260,14 +263,18 @@ pub struct GetBalances {
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct GetBalancesMine {
     /// Trusted balance (outputs created by the wallet or confirmed outputs).
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub trusted: Amount,
     /// Untrusted pending balance (outputs created by others that are in the mempool).
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub untrusted_pending: Amount,
     /// Balance from immature coinbase outputs.
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub immature: Amount,
     /// Balance from coins sent to addresses that were previously spent from (potentially privacy violating).
     ///
     /// Only present if `avoid_reuse` is set.
+    #[serde(default, with = "bitcoin::compat::amount::serde::as_btc::opt")]
     pub used: Option<Amount>,
 }
 
@@ -275,10 +282,13 @@ pub struct GetBalancesMine {
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct GetBalancesWatchOnly {
     /// Trusted balance (outputs created by the wallet or confirmed outputs).
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub trusted: Amount,
     /// Untrusted pending balance (outputs created by others that are in the mempool).
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub untrusted_pending: Amount,
     /// Balance from immature coinbase outputs.
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub immature: Amount,
 }
 
@@ -318,11 +328,13 @@ pub struct GetRawChangeAddress(pub Address<NetworkUnchecked>);
 
 /// Models the result of JSON-RPC method `getreceivedbyaddress`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-pub struct GetReceivedByAddress(pub Amount);
+pub struct GetReceivedByAddress(
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")] pub Amount,
+);
 
 /// Models the result of JSON-RPC method `getreceivedbylabel`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-pub struct GetReceivedByLabel(pub Amount);
+pub struct GetReceivedByLabel(#[serde(with = "bitcoin::compat::amount::serde::as_btc")] pub Amount);
 
 /// Models the result of JSON-RPC method `gettransaction`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
@@ -427,7 +439,9 @@ pub struct LastProcessedBlock {
 
 /// Models the result of JSON-RPC method `getunconfirmedbalance`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-pub struct GetUnconfirmedBalance(pub Amount);
+pub struct GetUnconfirmedBalance(
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")] pub Amount,
+);
 
 /// Models the result of JSON-RPC method `getwalletinfo`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
@@ -439,10 +453,13 @@ pub struct GetWalletInfo {
     /// Database format. v21 and later only.
     pub format: Option<String>,
     /// The total confirmed balance of the wallet in BTC. v17 to v29 only.
+    #[serde(default, with = "bitcoin::compat::amount::serde::as_btc::opt")]
     pub balance: Option<Amount>,
     /// The total unconfirmed balance of the wallet in BTC. v17 to v29 only.
+    #[serde(default, with = "bitcoin::compat::amount::serde::as_btc::opt")]
     pub unconfirmed_balance: Option<Amount>,
     /// The total immature balance of the wallet in BTC. v17 to v29 only.
+    #[serde(default, with = "bitcoin::compat::amount::serde::as_btc::opt")]
     pub immature_balance: Option<Amount>,
     /// The total number of transactions in the wallet.
     pub tx_count: u32,
@@ -505,6 +522,7 @@ pub struct ListAddressGroupingsItem {
     /// The bitcoin address.
     pub address: Address<NetworkUnchecked>,
     /// The amount.
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub amount: Amount,
     /// The label.
     pub label: Option<String>,
@@ -535,6 +553,7 @@ pub struct ListReceivedByAddressItem {
     /// The receiving address.
     pub address: Address<NetworkUnchecked>,
     /// The total amount received by the address.
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub amount: Amount,
     /// The number of confirmations of the most recent transaction included.
     pub confirmations: i64, // Docs do not indicate what negative value means?
@@ -554,6 +573,7 @@ pub struct ListReceivedByLabelItem {
     /// Only returned if imported addresses were involved in transaction.
     pub involves_watch_only: Option<bool>,
     /// The total amount received by addresses with this label.
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub amount: Amount,
     /// The number of confirmations of the most recent transaction included.
     pub confirmations: u32,
@@ -682,6 +702,7 @@ pub struct ListUnspentItem {
     /// The script key.
     pub script_pubkey: ScriptBuf,
     /// The transaction amount.
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub amount: Amount,
     /// The number of confirmations.
     pub confirmations: u32, // Docs do not indicate what negative value means?
@@ -721,8 +742,10 @@ pub struct PsbtBumpFee {
     /// The base64-encoded unsigned PSBT of the new transaction.
     pub psbt: Psbt,
     /// The fee of the replaced transaction.
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub original_fee: Amount,
     /// The fee of the new transaction.
+    #[serde(with = "bitcoin::compat::amount::serde::as_btc")]
     pub fee: Amount,
     /// Errors encountered during processing (may be empty).
     pub errors: Vec<String>,

--- a/types/src/psbt/mod.rs
+++ b/types/src/psbt/mod.rs
@@ -6,8 +6,8 @@ use std::collections::{BTreeMap, HashMap};
 
 use bitcoin::hex::{self, FromHex as _};
 use bitcoin::{
-    absolute, bip32, ecdsa, psbt, secp256k1, transaction, Amount, OutPoint, PublicKey, ScriptBuf,
-    Sequence, Transaction, TxIn, TxOut, Txid, Witness,
+    absolute, bip32, ecdsa, psbt, secp256k1, transaction, OutPoint, PublicKey, ScriptBuf,
+    Transaction, TxIn, TxOut, Txid, Witness,
 };
 use serde::{Deserialize, Serialize};
 
@@ -129,7 +129,7 @@ impl RawTransactionInput {
         Ok(TxIn {
             previous_output,
             script_sig,
-            sequence: Sequence::from_consensus(self.sequence),
+            sequence: bitcoin::Sequence::from_consensus(self.sequence),
             witness,
         })
     }
@@ -155,7 +155,7 @@ impl RawTransactionOutput {
     pub fn to_output(&self) -> Result<TxOut, RawTransactionOutputError> {
         use RawTransactionOutputError as E;
 
-        let value = Amount::from_btc(self.value).map_err(E::Value)?;
+        let value = bitcoin::Amount::from_btc(self.value).map_err(E::Value)?;
         let script_pubkey = self.script_pubkey.script_buf().map_err(E::ScriptPubKey)?;
 
         Ok(TxOut { value, script_pubkey })
@@ -179,7 +179,7 @@ impl WitnessUtxo {
     pub fn to_tx_out(&self) -> Result<TxOut, WitnessUtxoError> {
         use WitnessUtxoError as E;
 
-        let value = Amount::from_btc(self.amount).map_err(E::Amount)?;
+        let value = bitcoin::Amount::from_btc(self.amount).map_err(E::Amount)?;
         let script_pubkey = self.script_pubkey.script_buf().map_err(E::ScriptPubKey)?;
 
         Ok(TxOut { value, script_pubkey })

--- a/types/src/v17/blockchain/into.rs
+++ b/types/src/v17/blockchain/into.rs
@@ -3,8 +3,8 @@
 use bitcoin::consensus::encode;
 use bitcoin::hex::FromHex;
 use bitcoin::{
-    block, hex, Amount, Block, BlockHash, CompactTarget, FeeRate, Network, ScriptBuf, TxMerkleNode,
-    TxOut, Txid, Weight, Work, Wtxid,
+    block, hex, Block, BlockHash, CompactTarget, FeeRate, Network, ScriptBuf, TxMerkleNode, TxOut,
+    Txid, Weight, Work, Wtxid,
 };
 
 // TODO: Use explicit imports?
@@ -237,7 +237,7 @@ impl GetBlockStats {
         let total_weight = self.total_weight.and_then(Weight::from_vb);
 
         Ok(model::GetBlockStats {
-            average_fee: self.average_fee.map(Amount::from_sat),
+            average_fee: self.average_fee.map(crate::stable_amount_from_sat),
             average_fee_rate,
             average_tx_size: self
                 .average_tx_size
@@ -247,23 +247,23 @@ impl GetBlockStats {
             fee_rate_percentiles,
             height: self.height.map(|v| crate::to_u32(v, "height")).transpose()?,
             inputs: self.inputs.map(|v| crate::to_u32(v, "inputs")).transpose()?,
-            max_fee: self.max_fee.map(Amount::from_sat),
+            max_fee: self.max_fee.map(crate::stable_amount_from_sat),
             max_fee_rate,
             max_tx_size: self.max_tx_size.map(|v| crate::to_u32(v, "max_tx_size")).transpose()?,
-            median_fee: self.median_fee.map(Amount::from_sat),
+            median_fee: self.median_fee.map(crate::stable_amount_from_sat),
             median_time: self.median_time.map(|v| crate::to_u32(v, "median_time")).transpose()?,
             median_tx_size: self
                 .median_tx_size
                 .map(|v| crate::to_u32(v, "median_tx_size"))
                 .transpose()?,
-            minimum_fee: self.minimum_fee.map(Amount::from_sat),
+            minimum_fee: self.minimum_fee.map(crate::stable_amount_from_sat),
             minimum_fee_rate,
             minimum_tx_size: self
                 .minimum_tx_size
                 .map(|v| crate::to_u32(v, "minimum_tx_size"))
                 .transpose()?,
             outputs: self.outputs.map(|v| crate::to_u32(v, "outputs")).transpose()?,
-            subsidy: self.subsidy.map(Amount::from_sat),
+            subsidy: self.subsidy.map(crate::stable_amount_from_sat),
             segwit_total_size: self
                 .segwit_total_size
                 .map(|v| crate::to_u32(v, "segwit_total_size"))
@@ -271,10 +271,10 @@ impl GetBlockStats {
             segwit_total_weight,
             segwit_txs: self.segwit_txs.map(|v| crate::to_u32(v, "segwit_txs")).transpose()?,
             time: self.time.map(|v| crate::to_u32(v, "time")).transpose()?,
-            total_out: self.total_out.map(Amount::from_sat),
+            total_out: self.total_out.map(crate::stable_amount_from_sat),
             total_size: self.total_size.map(|v| crate::to_u32(v, "total_size")).transpose()?,
             total_weight,
-            total_fee: self.total_fee.map(Amount::from_sat),
+            total_fee: self.total_fee.map(crate::stable_amount_from_sat),
             txs: self.txs.map(|v| crate::to_u32(v, "txs")).transpose()?,
             utxo_increase: self.utxo_increase,
             utxo_size_increase: self.utxo_size_increase,
@@ -459,10 +459,10 @@ impl MempoolEntryFees {
         use MempoolEntryFeesError as E;
 
         Ok(model::MempoolEntryFees {
-            base: Amount::from_btc(self.base).map_err(E::Base)?,
-            modified: Amount::from_btc(self.modified).map_err(E::Modified)?,
-            ancestor: Amount::from_btc(self.ancestor).map_err(E::Ancestor)?,
-            descendant: Amount::from_btc(self.descendant).map_err(E::Descendant)?,
+            base: crate::stable_amount_from_btc(self.base).map_err(E::Base)?,
+            modified: crate::stable_amount_from_btc(self.modified).map_err(E::Modified)?,
+            ancestor: crate::stable_amount_from_btc(self.ancestor).map_err(E::Ancestor)?,
+            descendant: crate::stable_amount_from_btc(self.descendant).map_err(E::Descendant)?,
             chunk: None,
         })
     }
@@ -529,7 +529,7 @@ impl GetTxOut {
 
         let best_block = self.best_block.parse::<BlockHash>().map_err(E::BestBlock)?;
         let tx_out = TxOut {
-            value: Amount::from_btc(self.value).map_err(E::Value)?,
+            value: bitcoin::Amount::from_btc(self.value).map_err(E::Value)?,
             script_pubkey: self.script_pubkey.script_buf().map_err(E::ScriptBuf)?,
         };
 
@@ -557,7 +557,8 @@ impl GetTxOutSetInfo {
         let bogo_size = crate::to_u32(self.bogo_size, "bogo_size")?;
         let hash_serialized_2 = Some(self.hash_serialized_2); // TODO: Convert this to a hash type.
         let disk_size = Some(crate::to_u32(self.disk_size, "disk_size")?);
-        let total_amount = Amount::from_btc(self.total_amount).map_err(E::TotalAmount)?;
+        let total_amount =
+            crate::stable_amount_from_btc(self.total_amount).map_err(E::TotalAmount)?;
 
         Ok(model::GetTxOutSetInfo {
             height,
@@ -584,7 +585,8 @@ impl ScanTxOutSetStart {
         let unspents =
             self.unspents.into_iter().map(|u| u.into_model()).collect::<Result<Vec<_>, _>>()?;
 
-        let total_amount = Amount::from_btc(self.total_amount).map_err(E::TotalAmount)?;
+        let total_amount =
+            crate::stable_amount_from_btc(self.total_amount).map_err(E::TotalAmount)?;
 
         Ok(model::ScanTxOutSetStart {
             success: self.success,
@@ -603,7 +605,7 @@ impl ScanTxOutSetUnspent {
         use ScanTxOutSetError as E;
 
         let txid = self.txid.parse::<Txid>().map_err(E::Txid)?;
-        let amount = Amount::from_btc(self.amount).map_err(E::Amount)?;
+        let amount = crate::stable_amount_from_btc(self.amount).map_err(E::Amount)?;
         let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubKey)?;
 
         Ok(model::ScanTxOutSetUnspent {

--- a/types/src/v17/mining/into.rs
+++ b/types/src/v17/mining/into.rs
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: CC0-1.0
 
 use bitcoin::hex::FromHex as _;
-use bitcoin::{
-    block, consensus, BlockHash, CompactTarget, SignedAmount, Transaction, Txid, Weight, Wtxid,
-};
+use bitcoin::{block, consensus, BlockHash, CompactTarget, Transaction, Txid, Weight, Wtxid};
 
 use super::{
     BlockTemplateTransaction, BlockTemplateTransactionError, GetBlockTemplate,
@@ -27,7 +25,7 @@ impl GetBlockTemplate {
             .map(|t| t.into_model())
             .collect::<Result<Vec<_>, _>>()
             .map_err(E::Transactions)?;
-        let coinbase_value = SignedAmount::from_sat(self.coinbase_value);
+        let coinbase_value = bitcoin::SignedAmount::from_sat(self.coinbase_value);
         let target = Vec::from_hex(&self.target).map_err(E::Target)?;
         let sigop_limit = crate::to_u32(self.sigop_limit, "sigop_limit")?;
         let weight_limit = crate::to_u32(self.weight_limit, "weight_limit")?;
@@ -78,7 +76,7 @@ impl BlockTemplateTransaction {
             .iter()
             .map(|x| crate::to_u32(*x, "depend"))
             .collect::<Result<Vec<_>, _>>()?;
-        let fee = SignedAmount::from_sat(self.fee);
+        let fee = bitcoin::SignedAmount::from_sat(self.fee);
         let sigops = crate::to_u32(self.sigops, "sigops")?;
         let weight = Weight::from_wu(self.weight); // FIXME: Is this the correct unit?
 

--- a/types/src/v17/raw_transactions/into.rs
+++ b/types/src/v17/raw_transactions/into.rs
@@ -4,8 +4,7 @@ use std::collections::BTreeMap;
 
 use bitcoin::psbt::{self, Psbt, PsbtParseError, PsbtSighashType};
 use bitcoin::{
-    absolute, consensus, hex, transaction, Address, Amount, BlockHash, ScriptBuf, Sequence,
-    Transaction, Txid,
+    absolute, consensus, hex, transaction, Address, BlockHash, ScriptBuf, Transaction, Txid,
 };
 
 use super::{
@@ -124,7 +123,7 @@ impl DecodePsbt {
 
         let psbt =
             bitcoin::Psbt { unsigned_tx, version, xpub, proprietary, unknown, inputs, outputs };
-        let fee = self.fee.map(Amount::from_btc).transpose().map_err(E::Fee)?;
+        let fee = self.fee.map(crate::stable_amount_from_btc).transpose().map_err(E::Fee)?;
 
         Ok(model::DecodePsbt { psbt, fee })
     }
@@ -335,7 +334,7 @@ impl FundRawTransaction {
         use FundRawTransactionError as E;
 
         let tx: Transaction = consensus::encode::deserialize_hex(&self.hex).map_err(E::Hex)?;
-        let fee = Amount::from_btc(self.fee).map_err(E::Fee)?;
+        let fee = crate::stable_amount_from_btc(self.fee).map_err(E::Fee)?;
 
         Ok(model::FundRawTransaction { tx, fee, change_position: self.change_position })
     }
@@ -440,7 +439,7 @@ impl SignFail {
 
         let txid = self.txid.parse::<Txid>().map_err(E::Txid)?;
         let script_sig = ScriptBuf::from_hex(&self.script_sig).map_err(E::ScriptSig)?;
-        let sequence = Sequence::from_consensus(self.sequence);
+        let sequence = crate::stable_sequence(bitcoin::Sequence::from_consensus(self.sequence));
 
         Ok(model::SignFail { txid, vout: self.vout, script_sig, sequence, error: self.error })
     }

--- a/types/src/v17/wallet/into.rs
+++ b/types/src/v17/wallet/into.rs
@@ -8,8 +8,8 @@ use bitcoin::hex::FromHex;
 use bitcoin::key::{self, PrivateKey, PublicKey};
 use bitcoin::psbt::PsbtParseError;
 use bitcoin::{
-    address, bip32, sign_message, Address, Amount, BlockHash, Psbt, ScriptBuf, SignedAmount,
-    Transaction, Txid, WitnessProgram, WitnessVersion,
+    address, bip32, sign_message, Address, BlockHash, Psbt, ScriptBuf, Transaction, Txid,
+    WitnessProgram, WitnessVersion,
 };
 
 // TODO: Use explicit imports?
@@ -81,8 +81,9 @@ impl BumpFee {
         use BumpFeeError as E;
 
         let txid = self.txid.parse::<Txid>().map_err(E::Txid)?;
-        let original_fee = Amount::from_btc(self.original_fee).map_err(E::OriginalFee)?;
-        let fee = Amount::from_btc(self.fee).map_err(E::Fee)?;
+        let original_fee =
+            crate::stable_amount_from_btc(self.original_fee).map_err(E::OriginalFee)?;
+        let fee = crate::stable_amount_from_btc(self.fee).map_err(E::Fee)?;
 
         Ok(model::BumpFee { txid, original_fee, fee, errors: self.errors })
     }
@@ -285,7 +286,7 @@ impl GetAddressInfoEmbedded {
 impl GetBalance {
     /// Converts version specific type to a version nonspecific, more strongly typed type.
     pub fn into_model(self) -> Result<model::GetBalance, ParseAmountError> {
-        let amount = Amount::from_btc(self.0)?;
+        let amount = crate::stable_amount_from_btc(self.0)?;
         Ok(model::GetBalance(amount))
     }
 }
@@ -321,7 +322,7 @@ impl GetRawChangeAddress {
 impl GetReceivedByAddress {
     /// Converts version specific type to a version nonspecific, more strongly typed type.
     pub fn into_model(self) -> Result<model::GetReceivedByAddress, ParseAmountError> {
-        let amount = Amount::from_btc(self.0)?;
+        let amount = crate::stable_amount_from_btc(self.0)?;
         Ok(model::GetReceivedByAddress(amount))
     }
 }
@@ -331,8 +332,9 @@ impl GetTransaction {
     pub fn into_model(self) -> Result<model::GetTransaction, GetTransactionError> {
         use GetTransactionError as E;
 
-        let amount = SignedAmount::from_btc(self.amount).map_err(E::Amount)?;
-        let fee = self.fee.map(|fee| SignedAmount::from_btc(fee).map_err(E::Fee)).transpose()?;
+        let amount = bitcoin::SignedAmount::from_btc(self.amount).map_err(E::Amount)?;
+        let fee =
+            self.fee.map(|fee| bitcoin::SignedAmount::from_btc(fee).map_err(E::Fee)).transpose()?;
 
         let block_hash =
             self.block_hash.map(|s| s.parse::<BlockHash>().map_err(E::BlockHash)).transpose()?;
@@ -388,8 +390,9 @@ impl GetTransactionDetail {
         use GetTransactionDetailError as E;
 
         let address = self.address.parse::<Address<_>>().map_err(E::Address)?;
-        let amount = SignedAmount::from_btc(self.amount).map_err(E::Amount)?;
-        let fee = self.fee.map(|fee| SignedAmount::from_btc(fee).map_err(E::Fee)).transpose()?;
+        let amount = bitcoin::SignedAmount::from_btc(self.amount).map_err(E::Amount)?;
+        let fee =
+            self.fee.map(|fee| bitcoin::SignedAmount::from_btc(fee).map_err(E::Fee)).transpose()?;
 
         Ok(model::GetTransactionDetail {
             involves_watch_only: None, // v20 and later only.
@@ -409,7 +412,7 @@ impl GetTransactionDetail {
 impl GetUnconfirmedBalance {
     /// Converts version specific type to a version nonspecific, more strongly typed type.
     pub fn into_model(self) -> Result<model::GetUnconfirmedBalance, ParseAmountError> {
-        let amount = Amount::from_btc(self.0)?;
+        let amount = crate::stable_amount_from_btc(self.0)?;
         Ok(model::GetUnconfirmedBalance(amount))
     }
 }
@@ -420,11 +423,11 @@ impl GetWalletInfo {
         use GetWalletInfoError as E;
 
         let wallet_version = crate::to_u32(self.wallet_version, "wallet_version")?;
-        let balance = Amount::from_btc(self.balance).map_err(E::Balance)?;
-        let unconfirmed_balance =
-            Amount::from_btc(self.unconfirmed_balance).map_err(E::UnconfirmedBalance)?;
+        let balance = crate::stable_amount_from_btc(self.balance).map_err(E::Balance)?;
+        let unconfirmed_balance = crate::stable_amount_from_btc(self.unconfirmed_balance)
+            .map_err(E::UnconfirmedBalance)?;
         let immature_balance =
-            Amount::from_btc(self.immature_balance).map_err(E::ImmatureBalance)?;
+            crate::stable_amount_from_btc(self.immature_balance).map_err(E::ImmatureBalance)?;
         let tx_count = crate::to_u32(self.tx_count, "tx_count")?;
         let keypool_oldest = crate::to_u32(self.keypool_oldest, "keypoo_oldest")?;
         let keypool_size = crate::to_u32(self.keypool_size, "keypoo_size")?;
@@ -482,12 +485,12 @@ impl ListAddressGroupingsItem {
         match self {
             ListAddressGroupingsItem::Two(addr, amt) => {
                 let address = addr.parse::<Address<_>>().map_err(E::Address)?;
-                let amount = Amount::from_btc(amt).map_err(E::Amount)?;
+                let amount = crate::stable_amount_from_btc(amt).map_err(E::Amount)?;
                 Ok(model::ListAddressGroupingsItem { address, amount, label: None })
             }
             ListAddressGroupingsItem::Three(addr, amt, label) => {
                 let address = addr.parse::<Address<_>>().map_err(E::Address)?;
-                let amount = Amount::from_btc(amt).map_err(E::Amount)?;
+                let amount = crate::stable_amount_from_btc(amt).map_err(E::Amount)?;
                 Ok(model::ListAddressGroupingsItem { address, amount, label: Some(label) })
             }
         }
@@ -535,7 +538,7 @@ impl ListReceivedByAddressItem {
         use ListReceivedByAddressError as E;
 
         let address = self.address.parse::<Address<_>>().map_err(E::Address)?;
-        let amount = Amount::from_btc(self.amount).map_err(E::Amount)?;
+        let amount = crate::stable_amount_from_btc(self.amount).map_err(E::Amount)?;
         let txids = self
             .txids
             .iter()
@@ -586,13 +589,13 @@ impl TransactionItem {
 
         let address = self.address.parse::<Address<_>>().map_err(E::Address)?;
         let category = self.category.into_model();
-        let amount = SignedAmount::from_btc(self.amount).map_err(E::Amount)?;
+        let amount = bitcoin::SignedAmount::from_btc(self.amount).map_err(E::Amount)?;
         let vout = crate::to_u32(self.vout, "vout")?;
         let fee = self
             .fee
-            .map(|f| SignedAmount::from_btc(f).map_err(E::Fee))
+            .map(|f| bitcoin::SignedAmount::from_btc(f).map_err(E::Fee))
             .transpose()? // optional historically
-            .unwrap_or_else(|| SignedAmount::from_sat(0));
+            .unwrap_or_else(|| bitcoin::SignedAmount::from_sat(0));
         let block_hash = self.block_hash.parse::<BlockHash>().map_err(E::BlockHash)?;
         let block_index = crate::to_u32(self.block_index, "block_index")?;
         let txid = self.txid.map(|s| s.parse::<Txid>().map_err(E::Txid)).transpose()?;
@@ -660,7 +663,7 @@ impl ListUnspentItem {
         let address = self.address.parse::<Address<_>>().map_err(E::Address)?;
         let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubKey)?;
 
-        let amount = Amount::from_btc(self.amount).map_err(E::Amount)?;
+        let amount = crate::stable_amount_from_btc(self.amount).map_err(E::Amount)?;
         let confirmations = crate::to_u32(self.confirmations, "confirmations")?;
         let redeem_script = self
             .redeem_script
@@ -737,7 +740,7 @@ impl WalletCreateFundedPsbt {
         use WalletCreateFundedPsbtError as E;
 
         let psbt = self.psbt.parse::<Psbt>().map_err(E::Psbt)?;
-        let fee = SignedAmount::from_btc(self.fee).map_err(E::Fee)?;
+        let fee = bitcoin::SignedAmount::from_btc(self.fee).map_err(E::Fee)?;
         let change_position = crate::to_u32(self.change_position, "change_position")?;
         Ok(model::WalletCreateFundedPsbt { psbt, fee, change_position })
     }

--- a/types/src/v17/wallet/mod.rs
+++ b/types/src/v17/wallet/mod.rs
@@ -357,7 +357,7 @@ impl GetBalance {
     /// Converts json straight to a `bitcoin::Amount`.
     pub fn balance(self) -> Result<Amount, ParseAmountError> {
         let model = self.into_model()?;
-        Ok(model.0)
+        Ok(Amount::from_stable(model.0))
     }
 }
 

--- a/types/src/v18/blockchain/into.rs
+++ b/types/src/v18/blockchain/into.rs
@@ -2,7 +2,7 @@
 
 use alloc::collections::BTreeMap;
 
-use bitcoin::{hex, Amount, ScriptBuf, Txid, Wtxid};
+use bitcoin::{hex, ScriptBuf, Txid, Wtxid};
 
 use super::{
     GetMempoolAncestors, GetMempoolAncestorsVerbose, GetMempoolDescendants,
@@ -145,7 +145,8 @@ impl ScanTxOutSetStart {
         let unspents =
             self.unspents.into_iter().map(|u| u.into_model()).collect::<Result<Vec<_>, _>>()?;
 
-        let total_amount = Amount::from_btc(self.total_amount).map_err(E::TotalAmount)?;
+        let total_amount =
+            crate::stable_amount_from_btc(self.total_amount).map_err(E::TotalAmount)?;
 
         Ok(model::ScanTxOutSetStart {
             success: self.success,
@@ -164,7 +165,7 @@ impl ScanTxOutSetUnspent {
         use ScanTxOutSetError as E;
 
         let txid = self.txid.parse::<Txid>().map_err(E::Txid)?;
-        let amount = Amount::from_btc(self.amount).map_err(E::Amount)?;
+        let amount = crate::stable_amount_from_btc(self.amount).map_err(E::Amount)?;
         let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubKey)?;
 
         Ok(model::ScanTxOutSetUnspent {

--- a/types/src/v18/raw_transactions/into.rs
+++ b/types/src/v18/raw_transactions/into.rs
@@ -2,7 +2,6 @@
 
 use bitcoin::hashes::{hash160, sha256};
 use bitcoin::psbt::{Psbt, PsbtParseError};
-use bitcoin::Amount;
 
 use super::{
     AnalyzePsbt, AnalyzePsbtError, AnalyzePsbtInput, AnalyzePsbtInputMissing,
@@ -27,7 +26,7 @@ impl AnalyzePsbt {
             .transpose()
             .map_err(E::EstimatedFeeRate)?
             .flatten();
-        let fee = self.fee.map(Amount::from_btc).transpose().map_err(E::Fee)?;
+        let fee = self.fee.map(crate::stable_amount_from_btc).transpose().map_err(E::Fee)?;
 
         Ok(model::AnalyzePsbt {
             inputs,

--- a/types/src/v18/wallet/into.rs
+++ b/types/src/v18/wallet/into.rs
@@ -4,7 +4,7 @@ use bitcoin::amount::ParseAmountError;
 use bitcoin::hashes::hash160;
 use bitcoin::hex::FromHex;
 use bitcoin::key::PublicKey;
-use bitcoin::{bip32, Address, Amount, ScriptBuf, Txid, WitnessProgram, WitnessVersion};
+use bitcoin::{bip32, Address, ScriptBuf, Txid, WitnessProgram, WitnessVersion};
 
 use super::{
     GetAddressInfo, GetAddressInfoEmbedded, GetAddressInfoEmbeddedError, GetAddressInfoError,
@@ -160,7 +160,7 @@ impl GetAddressInfoEmbedded {
 impl GetReceivedByLabel {
     /// Converts version specific type to a version nonspecific, more strongly typed type.
     pub fn into_model(self) -> Result<model::GetReceivedByLabel, ParseAmountError> {
-        let amount = bitcoin::Amount::from_btc(self.0)?;
+        let amount = crate::stable_amount_from_btc(self.0)?;
         Ok(model::GetReceivedByLabel(amount))
     }
 }
@@ -171,11 +171,11 @@ impl GetWalletInfo {
         use GetWalletInfoError as E;
 
         let wallet_version = crate::to_u32(self.wallet_version, "wallet_version")?;
-        let balance = Amount::from_btc(self.balance).map_err(E::Balance)?;
-        let unconfirmed_balance =
-            Amount::from_btc(self.unconfirmed_balance).map_err(E::UnconfirmedBalance)?;
+        let balance = crate::stable_amount_from_btc(self.balance).map_err(E::Balance)?;
+        let unconfirmed_balance = crate::stable_amount_from_btc(self.unconfirmed_balance)
+            .map_err(E::UnconfirmedBalance)?;
         let immature_balance =
-            Amount::from_btc(self.immature_balance).map_err(E::ImmatureBalance)?;
+            crate::stable_amount_from_btc(self.immature_balance).map_err(E::ImmatureBalance)?;
         let tx_count = crate::to_u32(self.tx_count, "tx_count")?;
         let keypool_oldest = crate::to_u32(self.keypool_oldest, "keypoo_oldest")?;
         let keypool_size = crate::to_u32(self.keypool_size, "keypoo_size")?;
@@ -232,7 +232,7 @@ impl ListReceivedByAddressItem {
         use ListReceivedByAddressError as E;
 
         let address = self.address.parse::<Address<_>>().map_err(E::Address)?;
-        let amount = Amount::from_btc(self.amount).map_err(E::Amount)?;
+        let amount = crate::stable_amount_from_btc(self.amount).map_err(E::Amount)?;
         let txids = self
             .txids
             .iter()
@@ -269,7 +269,7 @@ impl ListReceivedByLabelItem {
     pub fn into_model(self) -> Result<model::ListReceivedByLabelItem, ListReceivedByLabelError> {
         use ListReceivedByLabelError as E;
 
-        let amount = Amount::from_btc(self.amount).map_err(E::Amount)?;
+        let amount = crate::stable_amount_from_btc(self.amount).map_err(E::Amount)?;
         let confirmations = crate::to_u32(self.confirmations, "confirmations")?;
 
         Ok(model::ListReceivedByLabelItem {
@@ -302,7 +302,7 @@ impl ListUnspentItem {
         let address = self.address.parse::<Address<_>>().map_err(E::Address)?;
         let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubKey)?;
 
-        let amount = Amount::from_btc(self.amount).map_err(E::Amount)?;
+        let amount = crate::stable_amount_from_btc(self.amount).map_err(E::Amount)?;
         let confirmations = crate::to_u32(self.confirmations, "confirmations")?;
         let redeem_script = self
             .redeem_script

--- a/types/src/v19/blockchain/into.rs
+++ b/types/src/v19/blockchain/into.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeMap;
 
 use bitcoin::hex::{self, FromHex as _};
-use bitcoin::{bip158, Amount, BlockHash, Network, Txid, Work, Wtxid};
+use bitcoin::{bip158, BlockHash, Network, Txid, Work, Wtxid};
 
 use super::error::{
     GetBlockFilterError, GetBlockchainInfoError, MapMempoolEntryError, MempoolEntryError,
@@ -204,10 +204,10 @@ impl MempoolEntryFees {
         use MempoolEntryFeesError as E;
 
         Ok(model::MempoolEntryFees {
-            base: Amount::from_btc(self.base).map_err(E::Base)?,
-            modified: Amount::from_btc(self.modified).map_err(E::Modified)?,
-            ancestor: Amount::from_btc(self.ancestor).map_err(E::MempoolEntry)?,
-            descendant: Amount::from_btc(self.descendant).map_err(E::Descendant)?,
+            base: crate::stable_amount_from_btc(self.base).map_err(E::Base)?,
+            modified: crate::stable_amount_from_btc(self.modified).map_err(E::Modified)?,
+            ancestor: crate::stable_amount_from_btc(self.ancestor).map_err(E::MempoolEntry)?,
+            descendant: crate::stable_amount_from_btc(self.descendant).map_err(E::Descendant)?,
             chunk: None,
         })
     }
@@ -277,7 +277,8 @@ impl ScanTxOutSetStart {
         let unspents =
             self.unspents.into_iter().map(|u| u.into_model()).collect::<Result<Vec<_>, _>>()?;
 
-        let total_amount = Amount::from_btc(self.total_amount).map_err(E::TotalAmount)?;
+        let total_amount =
+            crate::stable_amount_from_btc(self.total_amount).map_err(E::TotalAmount)?;
 
         Ok(model::ScanTxOutSetStart {
             success: self.success,

--- a/types/src/v19/wallet/into.rs
+++ b/types/src/v19/wallet/into.rs
@@ -2,7 +2,7 @@
 
 use bitcoin::amount::ParseAmountError;
 use bitcoin::consensus::encode;
-use bitcoin::{Amount, BlockHash, SignedAmount, Transaction, Txid};
+use bitcoin::{BlockHash, Transaction, Txid};
 
 use super::{
     GetBalances, GetBalancesError, GetBalancesMine, GetBalancesWatchOnly, GetTransaction,
@@ -30,10 +30,10 @@ impl GetBalances {
 impl GetBalancesMine {
     /// Converts version specific type to a version nonspecific, more strongly typed type.
     pub fn into_model(self) -> Result<model::GetBalancesMine, ParseAmountError> {
-        let trusted = Amount::from_btc(self.trusted)?;
-        let untrusted_pending = Amount::from_btc(self.untrusted_pending)?;
-        let immature = Amount::from_btc(self.immature)?;
-        let used = self.used.map(Amount::from_btc).transpose()?;
+        let trusted = crate::stable_amount_from_btc(self.trusted)?;
+        let untrusted_pending = crate::stable_amount_from_btc(self.untrusted_pending)?;
+        let immature = crate::stable_amount_from_btc(self.immature)?;
+        let used = self.used.map(crate::stable_amount_from_btc).transpose()?;
 
         Ok(model::GetBalancesMine { trusted, untrusted_pending, immature, used })
     }
@@ -42,9 +42,9 @@ impl GetBalancesMine {
 impl GetBalancesWatchOnly {
     /// Converts version specific type to a version nonspecific, more strongly typed type.
     pub fn into_model(self) -> Result<model::GetBalancesWatchOnly, ParseAmountError> {
-        let trusted = Amount::from_btc(self.trusted)?;
-        let untrusted_pending = Amount::from_btc(self.untrusted_pending)?;
-        let immature = Amount::from_btc(self.immature)?;
+        let trusted = crate::stable_amount_from_btc(self.trusted)?;
+        let untrusted_pending = crate::stable_amount_from_btc(self.untrusted_pending)?;
+        let immature = crate::stable_amount_from_btc(self.immature)?;
 
         Ok(model::GetBalancesWatchOnly { trusted, untrusted_pending, immature })
     }
@@ -55,8 +55,9 @@ impl GetTransaction {
     pub fn into_model(self) -> Result<model::GetTransaction, GetTransactionError> {
         use GetTransactionError as E;
 
-        let amount = SignedAmount::from_btc(self.amount).map_err(E::Amount)?;
-        let fee = self.fee.map(|fee| SignedAmount::from_btc(fee).map_err(E::Fee)).transpose()?;
+        let amount = bitcoin::SignedAmount::from_btc(self.amount).map_err(E::Amount)?;
+        let fee =
+            self.fee.map(|fee| bitcoin::SignedAmount::from_btc(fee).map_err(E::Fee)).transpose()?;
         let block_hash =
             self.block_hash.map(|s| s.parse::<BlockHash>().map_err(E::BlockHash)).transpose()?;
         let block_index =
@@ -114,11 +115,11 @@ impl GetWalletInfo {
         use GetWalletInfoError as E;
 
         let wallet_version = crate::to_u32(self.wallet_version, "wallet_version")?;
-        let balance = Amount::from_btc(self.balance).map_err(E::Balance)?;
-        let unconfirmed_balance =
-            Amount::from_btc(self.unconfirmed_balance).map_err(E::UnconfirmedBalance)?;
+        let balance = crate::stable_amount_from_btc(self.balance).map_err(E::Balance)?;
+        let unconfirmed_balance = crate::stable_amount_from_btc(self.unconfirmed_balance)
+            .map_err(E::UnconfirmedBalance)?;
         let immature_balance =
-            Amount::from_btc(self.immature_balance).map_err(E::ImmatureBalance)?;
+            crate::stable_amount_from_btc(self.immature_balance).map_err(E::ImmatureBalance)?;
         let tx_count = crate::to_u32(self.tx_count, "tx_count")?;
         let keypool_oldest = crate::to_u32(self.keypool_oldest, "keypoo_oldest")?;
         let keypool_size = crate::to_u32(self.keypool_size, "keypoo_size")?;

--- a/types/src/v20/wallet/into.rs
+++ b/types/src/v20/wallet/into.rs
@@ -4,8 +4,7 @@ use bitcoin::hashes::hash160;
 use bitcoin::hex::FromHex;
 use bitcoin::key::PublicKey;
 use bitcoin::{
-    bip32, Address, BlockHash, ScriptBuf, SignedAmount, Transaction, Txid, WitnessProgram,
-    WitnessVersion,
+    bip32, Address, BlockHash, ScriptBuf, Transaction, Txid, WitnessProgram, WitnessVersion,
 };
 
 use super::{
@@ -178,8 +177,9 @@ impl GetTransaction {
     pub fn into_model(self) -> Result<model::GetTransaction, GetTransactionError> {
         use GetTransactionError as E;
 
-        let amount = SignedAmount::from_btc(self.amount).map_err(E::Amount)?;
-        let fee = self.fee.map(|fee| SignedAmount::from_btc(fee).map_err(E::Fee)).transpose()?;
+        let amount = bitcoin::SignedAmount::from_btc(self.amount).map_err(E::Amount)?;
+        let fee =
+            self.fee.map(|fee| bitcoin::SignedAmount::from_btc(fee).map_err(E::Fee)).transpose()?;
         let block_hash =
             self.block_hash.map(|s| s.parse::<BlockHash>().map_err(E::BlockHash)).transpose()?;
         let block_index =
@@ -239,8 +239,9 @@ impl GetTransactionDetail {
         use GetTransactionDetailError as E;
 
         let address = self.address.parse::<Address<_>>().map_err(E::Address)?;
-        let amount = SignedAmount::from_btc(self.amount).map_err(E::Amount)?;
-        let fee = self.fee.map(|fee| SignedAmount::from_btc(fee).map_err(E::Fee)).transpose()?;
+        let amount = bitcoin::SignedAmount::from_btc(self.amount).map_err(E::Amount)?;
+        let fee =
+            self.fee.map(|fee| bitcoin::SignedAmount::from_btc(fee).map_err(E::Fee)).transpose()?;
 
         Ok(model::GetTransactionDetail {
             involves_watch_only: self.involves_watch_only,
@@ -287,13 +288,13 @@ impl TransactionItem {
 
         let address = self.address.parse::<Address<_>>().map_err(E::Address)?;
         let category = self.category.into_model();
-        let amount = SignedAmount::from_btc(self.amount).map_err(E::Amount)?;
+        let amount = bitcoin::SignedAmount::from_btc(self.amount).map_err(E::Amount)?;
         let vout = crate::to_u32(self.vout, "vout")?;
         let fee = self
             .fee
-            .map(|f| SignedAmount::from_btc(f).map_err(E::Fee))
+            .map(|f| bitcoin::SignedAmount::from_btc(f).map_err(E::Fee))
             .transpose()? // optional historically
-            .unwrap_or_else(|| SignedAmount::from_sat(0));
+            .unwrap_or_else(|| bitcoin::SignedAmount::from_sat(0));
         let block_hash = self.block_hash.parse::<BlockHash>().map_err(E::BlockHash)?;
         let block_height = crate::to_u32(self.block_height, "block_height")?;
         let block_index = crate::to_u32(self.block_index, "block_index")?;

--- a/types/src/v21/raw_transactions/into.rs
+++ b/types/src/v21/raw_transactions/into.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-use bitcoin::{Amount, Txid};
+use bitcoin::Txid;
 
 use super::{MempoolAcceptance, MempoolAcceptanceError, TestMempoolAccept, TestMempoolAcceptError};
 use crate::model;
@@ -23,7 +23,7 @@ impl MempoolAcceptance {
         let vsize = self.vsize.map(|s| crate::to_u32(s, "vsize")).transpose()?;
         let fees = match self.fees {
             Some(s) => {
-                let base = Amount::from_btc(s.base).map_err(E::Base)?;
+                let base = crate::stable_amount_from_btc(s.base).map_err(E::Base)?;
                 Some(model::MempoolAcceptanceFees {
                     base,
                     effective_fee_rate: None, // v25 and later only.

--- a/types/src/v21/wallet/into.rs
+++ b/types/src/v21/wallet/into.rs
@@ -21,8 +21,9 @@ impl PsbtBumpFee {
         use PsbtBumpFeeError as E;
 
         let psbt = self.psbt.parse().map_err(E::Psbt)?;
-        let original_fee = bitcoin::Amount::from_btc(self.original_fee).map_err(E::OriginalFee)?;
-        let fee = bitcoin::Amount::from_btc(self.fee).map_err(E::Fee)?;
+        let original_fee =
+            crate::stable_amount_from_btc(self.original_fee).map_err(E::OriginalFee)?;
+        let fee = crate::stable_amount_from_btc(self.fee).map_err(E::Fee)?;
         let errors = self.errors;
         Ok(model::PsbtBumpFee { psbt, original_fee, fee, errors })
     }
@@ -70,11 +71,11 @@ impl GetWalletInfo {
         use GetWalletInfoError as E;
 
         let wallet_version = crate::to_u32(self.wallet_version, "wallet_version")?;
-        let balance = bitcoin::Amount::from_btc(self.balance).map_err(E::Balance)?;
-        let unconfirmed_balance =
-            bitcoin::Amount::from_btc(self.unconfirmed_balance).map_err(E::UnconfirmedBalance)?;
+        let balance = crate::stable_amount_from_btc(self.balance).map_err(E::Balance)?;
+        let unconfirmed_balance = crate::stable_amount_from_btc(self.unconfirmed_balance)
+            .map_err(E::UnconfirmedBalance)?;
         let immature_balance =
-            bitcoin::Amount::from_btc(self.immature_balance).map_err(E::ImmatureBalance)?;
+            crate::stable_amount_from_btc(self.immature_balance).map_err(E::ImmatureBalance)?;
         let tx_count = crate::to_u32(self.tx_count, "tx_count")?;
         let keypool_oldest = crate::to_u32(self.keypool_oldest, "keypool_oldest")?;
         let keypool_size = crate::to_u32(self.keypool_size, "keypool_size")?;

--- a/types/src/v22/raw_transactions/into.rs
+++ b/types/src/v22/raw_transactions/into.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-use bitcoin::{Address, Amount, Txid, Wtxid};
+use bitcoin::{Address, Txid, Wtxid};
 
 use super::{
     DecodeScript, DecodeScriptError, MempoolAcceptance, MempoolAcceptanceError, TestMempoolAccept,
@@ -59,7 +59,7 @@ impl MempoolAcceptance {
         let vsize = self.vsize.map(|s| crate::to_u32(s, "vsize")).transpose()?;
         let fees = match self.fees {
             Some(s) => {
-                let base = Amount::from_btc(s.base).map_err(E::Base)?;
+                let base = crate::stable_amount_from_btc(s.base).map_err(E::Base)?;
                 Some(model::MempoolAcceptanceFees {
                     base,
                     effective_fee_rate: None, // v25 and later only.

--- a/types/src/v23/raw_transactions/into.rs
+++ b/types/src/v23/raw_transactions/into.rs
@@ -6,7 +6,7 @@ use bitcoin::bip32::{DerivationPath, Fingerprint, KeySource, Xpub};
 use bitcoin::hashes::{hash160, ripemd160, sha256, sha256d};
 use bitcoin::hex::{self, FromHex as _};
 use bitcoin::psbt::{self, raw, PsbtSighashType};
-use bitcoin::{Address, Amount};
+use bitcoin::Address;
 
 use super::{
     DecodePsbt, DecodePsbtError, DecodeScript, DecodeScriptError, GlobalXpub, GlobalXpubError,
@@ -67,7 +67,7 @@ impl DecodePsbt {
             inputs,
             outputs,
         };
-        let fee = self.fee.map(Amount::from_btc).transpose().map_err(E::Fee)?;
+        let fee = self.fee.map(crate::stable_amount_from_btc).transpose().map_err(E::Fee)?;
 
         Ok(model::DecodePsbt { psbt, fee })
     }

--- a/types/src/v23/wallet/into.rs
+++ b/types/src/v23/wallet/into.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: CC0-1.0
 
 use bitcoin::consensus::encode;
-use bitcoin::{Address, BlockHash, ScriptBuf, SignedAmount, Transaction, Txid};
+use bitcoin::{Address, BlockHash, ScriptBuf, Transaction, Txid};
 
 use super::{
     AddMultisigAddress, AddMultisigAddressError, GetTransaction, GetTransactionError,
@@ -32,8 +32,9 @@ impl GetTransaction {
     pub fn into_model(self) -> Result<model::GetTransaction, GetTransactionError> {
         use GetTransactionError as E;
 
-        let amount = SignedAmount::from_btc(self.amount).map_err(E::Amount)?;
-        let fee = self.fee.map(|fee| SignedAmount::from_btc(fee).map_err(E::Fee)).transpose()?;
+        let amount = bitcoin::SignedAmount::from_btc(self.amount).map_err(E::Amount)?;
+        let fee =
+            self.fee.map(|fee| bitcoin::SignedAmount::from_btc(fee).map_err(E::Fee)).transpose()?;
         let block_hash =
             self.block_hash.map(|s| s.parse::<BlockHash>().map_err(E::BlockHash)).transpose()?;
         let block_index =
@@ -99,11 +100,11 @@ impl GetWalletInfo {
         use GetWalletInfoError as E;
 
         let wallet_version = crate::to_u32(self.wallet_version, "wallet_version")?;
-        let balance = bitcoin::Amount::from_btc(self.balance).map_err(E::Balance)?;
-        let unconfirmed_balance =
-            bitcoin::Amount::from_btc(self.unconfirmed_balance).map_err(E::UnconfirmedBalance)?;
+        let balance = crate::stable_amount_from_btc(self.balance).map_err(E::Balance)?;
+        let unconfirmed_balance = crate::stable_amount_from_btc(self.unconfirmed_balance)
+            .map_err(E::UnconfirmedBalance)?;
         let immature_balance =
-            bitcoin::Amount::from_btc(self.immature_balance).map_err(E::ImmatureBalance)?;
+            crate::stable_amount_from_btc(self.immature_balance).map_err(E::ImmatureBalance)?;
         let tx_count = crate::to_u32(self.tx_count, "tx_count")?;
         let keypool_oldest =
             self.keypool_oldest.map(|v| crate::to_u32(v, "keypool_oldest")).transpose()?;
@@ -176,13 +177,13 @@ impl TransactionItem {
 
         let address = self.address.parse::<Address<_>>().map_err(E::Address)?;
         let category = self.category.into_model();
-        let amount = SignedAmount::from_btc(self.amount).map_err(E::Amount)?;
+        let amount = bitcoin::SignedAmount::from_btc(self.amount).map_err(E::Amount)?;
         let vout = crate::to_u32(self.vout, "vout")?;
         let fee = self
             .fee
-            .map(|f| SignedAmount::from_btc(f).map_err(E::Fee))
+            .map(|f| bitcoin::SignedAmount::from_btc(f).map_err(E::Fee))
             .transpose()? // optional historically
-            .unwrap_or_else(|| SignedAmount::from_sat(0));
+            .unwrap_or_else(|| bitcoin::SignedAmount::from_sat(0));
         let block_hash =
             self.block_hash.map(|h| h.parse::<BlockHash>().map_err(E::BlockHash)).transpose()?;
         let block_height =

--- a/types/src/v24/raw_transactions/into.rs
+++ b/types/src/v24/raw_transactions/into.rs
@@ -9,7 +9,7 @@ use bitcoin::psbt::{self, raw, PsbtSighashType};
 use bitcoin::taproot::{
     ControlBlock, LeafVersion, TapLeafHash, TapNodeHash, TapTree, TaprootBuilder,
 };
-use bitcoin::{Amount, ScriptBuf, XOnlyPublicKey};
+use bitcoin::{ScriptBuf, XOnlyPublicKey};
 
 use super::{
     taproot, ControlBlocksError, DecodePsbt, DecodePsbtError, GlobalXpub, GlobalXpubError,
@@ -72,7 +72,7 @@ impl DecodePsbt {
             inputs,
             outputs,
         };
-        let fee = self.fee.map(Amount::from_btc).transpose().map_err(E::Fee)?;
+        let fee = self.fee.map(crate::stable_amount_from_btc).transpose().map_err(E::Fee)?;
 
         Ok(model::DecodePsbt { psbt, fee })
     }

--- a/types/src/v24/wallet/into.rs
+++ b/types/src/v24/wallet/into.rs
@@ -2,7 +2,7 @@
 
 use bitcoin::amount::ParseAmountError;
 use bitcoin::consensus::encode;
-use bitcoin::{Address, Amount, BlockHash, ScriptBuf, SignedAmount, Transaction, Txid};
+use bitcoin::{Address, BlockHash, ScriptBuf, Transaction, Txid};
 
 use super::{
     GetTransaction, GetTransactionDetail, GetTransactionDetailError, GetTransactionError,
@@ -17,8 +17,9 @@ impl GetTransaction {
     pub fn into_model(self) -> Result<model::GetTransaction, GetTransactionError> {
         use GetTransactionError as E;
 
-        let amount = SignedAmount::from_btc(self.amount).map_err(E::Amount)?;
-        let fee = self.fee.map(|fee| SignedAmount::from_btc(fee).map_err(E::Fee)).transpose()?;
+        let amount = bitcoin::SignedAmount::from_btc(self.amount).map_err(E::Amount)?;
+        let fee =
+            self.fee.map(|fee| bitcoin::SignedAmount::from_btc(fee).map_err(E::Fee)).transpose()?;
         let block_hash =
             self.block_hash.map(|s| s.parse::<BlockHash>().map_err(E::BlockHash)).transpose()?;
         let block_index =
@@ -85,8 +86,9 @@ impl GetTransactionDetail {
         use GetTransactionDetailError as E;
 
         let address = self.address.parse::<Address<_>>().map_err(E::Address)?;
-        let amount = SignedAmount::from_btc(self.amount).map_err(E::Amount)?;
-        let fee = self.fee.map(|fee| SignedAmount::from_btc(fee).map_err(E::Fee)).transpose()?;
+        let amount = bitcoin::SignedAmount::from_btc(self.amount).map_err(E::Amount)?;
+        let fee =
+            self.fee.map(|fee| bitcoin::SignedAmount::from_btc(fee).map_err(E::Fee)).transpose()?;
 
         Ok(model::GetTransactionDetail {
             involves_watch_only: self.involves_watch_only,
@@ -132,13 +134,13 @@ impl TransactionItem {
         let address =
             self.address.map(|a| a.parse::<Address<_>>().map_err(E::Address)).transpose()?;
         let category = self.category.into_model();
-        let amount = SignedAmount::from_btc(self.amount).map_err(E::Amount)?;
+        let amount = bitcoin::SignedAmount::from_btc(self.amount).map_err(E::Amount)?;
         let vout = crate::to_u32(self.vout, "vout")?;
         let fee = self
             .fee
-            .map(|f| SignedAmount::from_btc(f).map_err(E::Fee))
+            .map(|f| bitcoin::SignedAmount::from_btc(f).map_err(E::Fee))
             .transpose()? // optional historically
-            .unwrap_or_else(|| SignedAmount::from_sat(0));
+            .unwrap_or_else(|| bitcoin::SignedAmount::from_sat(0));
         let block_hash =
             self.block_hash.map(|h| h.parse::<BlockHash>().map_err(E::BlockHash)).transpose()?;
         let block_height =
@@ -222,7 +224,7 @@ impl ListUnspentItem {
         let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubKey)?;
         let label = self.label.unwrap_or_default();
 
-        let amount = Amount::from_btc(self.amount).map_err(E::Amount)?;
+        let amount = crate::stable_amount_from_btc(self.amount).map_err(E::Amount)?;
         let confirmations = crate::to_u32(self.confirmations, "confirmations")?;
         let redeem_script = self
             .redeem_script
@@ -266,7 +268,7 @@ impl SendAll {
 impl SimulateRawTransaction {
     /// Converts version specific type to a version nonspecific, more strongly typed type.
     pub fn into_model(self) -> Result<model::SimulateRawTransaction, ParseAmountError> {
-        let balance_change = SignedAmount::from_btc(self.balance_change)?;
+        let balance_change = bitcoin::SignedAmount::from_btc(self.balance_change)?;
         Ok(model::SimulateRawTransaction { balance_change })
     }
 }

--- a/types/src/v25/blockchain/into.rs
+++ b/types/src/v25/blockchain/into.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-use bitcoin::{Amount, BlockHash, FeeRate, ScriptBuf, Txid, Weight};
+use bitcoin::{BlockHash, FeeRate, ScriptBuf, Txid, Weight};
 
 use super::error::ScanBlocksStartError;
 use super::{
@@ -29,7 +29,7 @@ impl GetBlockStats {
         let total_weight = self.total_weight.and_then(Weight::from_vb);
 
         Ok(model::GetBlockStats {
-            average_fee: self.average_fee.map(Amount::from_sat),
+            average_fee: self.average_fee.map(crate::stable_amount_from_sat),
             average_fee_rate,
             average_tx_size: self
                 .average_tx_size
@@ -39,23 +39,23 @@ impl GetBlockStats {
             fee_rate_percentiles,
             height: self.height.map(|v| crate::to_u32(v, "height")).transpose()?,
             inputs: self.inputs.map(|v| crate::to_u32(v, "inputs")).transpose()?,
-            max_fee: self.max_fee.map(Amount::from_sat),
+            max_fee: self.max_fee.map(crate::stable_amount_from_sat),
             max_fee_rate,
             max_tx_size: self.max_tx_size.map(|v| crate::to_u32(v, "max_tx_size")).transpose()?,
-            median_fee: self.median_fee.map(Amount::from_sat),
+            median_fee: self.median_fee.map(crate::stable_amount_from_sat),
             median_time: self.median_time.map(|v| crate::to_u32(v, "median_time")).transpose()?,
             median_tx_size: self
                 .median_tx_size
                 .map(|v| crate::to_u32(v, "median_tx_size"))
                 .transpose()?,
-            minimum_fee: self.minimum_fee.map(Amount::from_sat),
+            minimum_fee: self.minimum_fee.map(crate::stable_amount_from_sat),
             minimum_fee_rate,
             minimum_tx_size: self
                 .minimum_tx_size
                 .map(|v| crate::to_u32(v, "minimum_tx_size"))
                 .transpose()?,
             outputs: self.outputs.map(|v| crate::to_u32(v, "outputs")).transpose()?,
-            subsidy: self.subsidy.map(Amount::from_sat),
+            subsidy: self.subsidy.map(crate::stable_amount_from_sat),
             segwit_total_size: self
                 .segwit_total_size
                 .map(|v| crate::to_u32(v, "segwit_total_size"))
@@ -63,10 +63,10 @@ impl GetBlockStats {
             segwit_total_weight,
             segwit_txs: self.segwit_txs.map(|v| crate::to_u32(v, "segwit_txs")).transpose()?,
             time: self.time.map(|v| crate::to_u32(v, "time")).transpose()?,
-            total_out: self.total_out.map(Amount::from_sat),
+            total_out: self.total_out.map(crate::stable_amount_from_sat),
             total_size: self.total_size.map(|v| crate::to_u32(v, "total_size")).transpose()?,
             total_weight,
-            total_fee: self.total_fee.map(Amount::from_sat),
+            total_fee: self.total_fee.map(crate::stable_amount_from_sat),
             txs: self.txs.map(|v| crate::to_u32(v, "txs")).transpose()?,
             utxo_increase: self.utxo_increase,
             utxo_size_increase: self.utxo_size_increase,
@@ -106,7 +106,8 @@ impl ScanTxOutSetStart {
         let unspents =
             self.unspents.into_iter().map(|u| u.into_model()).collect::<Result<Vec<_>, _>>()?;
 
-        let total_amount = Amount::from_btc(self.total_amount).map_err(E::TotalAmount)?;
+        let total_amount =
+            crate::stable_amount_from_btc(self.total_amount).map_err(E::TotalAmount)?;
 
         Ok(model::ScanTxOutSetStart {
             success: self.success,
@@ -125,7 +126,7 @@ impl ScanTxOutSetUnspent {
         use ScanTxOutSetError as E;
 
         let txid = self.txid.parse::<Txid>().map_err(E::Txid)?;
-        let amount = Amount::from_btc(self.amount).map_err(E::Amount)?;
+        let amount = crate::stable_amount_from_btc(self.amount).map_err(E::Amount)?;
         let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubKey)?;
 
         Ok(model::ScanTxOutSetUnspent {

--- a/types/src/v25/raw_transactions/into.rs
+++ b/types/src/v25/raw_transactions/into.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-use bitcoin::{Amount, Txid, Wtxid};
+use bitcoin::{Txid, Wtxid};
 
 use super::{MempoolAcceptance, MempoolAcceptanceError, TestMempoolAccept, TestMempoolAcceptError};
 use crate::model;
@@ -43,7 +43,7 @@ impl MempoolAcceptance {
                     .flatten();
 
                 Ok::<_, MempoolAcceptanceError>(model::MempoolAcceptanceFees {
-                    base: Amount::from_btc(s.base).map_err(E::Base)?,
+                    base: crate::stable_amount_from_btc(s.base).map_err(E::Base)?,
                     effective_fee_rate,
                     effective_includes,
                 })

--- a/types/src/v26/blockchain/into.rs
+++ b/types/src/v26/blockchain/into.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: CC0-1.0
 
 use bitcoin::hashes::sha256;
-use bitcoin::{Amount, BlockHash};
+use bitcoin::BlockHash;
 
 use super::{
     DumpTxOutSet, DumpTxOutSetError, GetChainStates, GetChainStatesError, GetTxOutSetInfo,
@@ -47,7 +47,8 @@ impl DumpTxOutSet {
     pub fn into_model(self) -> Result<model::DumpTxOutSet, DumpTxOutSetError> {
         use DumpTxOutSetError as E;
 
-        let coins_written = Amount::from_btc(self.coins_written).map_err(E::CoinsWritten)?;
+        let coins_written =
+            crate::stable_amount_from_btc(self.coins_written).map_err(E::CoinsWritten)?;
         let base_hash = self.base_hash.parse::<BlockHash>().map_err(E::BaseHash)?;
         let base_height = crate::to_u32(self.base_height, "base_height")?;
         let tx_out_set_hash =
@@ -77,26 +78,33 @@ impl GetTxOutSetInfo {
         let tx_outs = crate::to_u32(self.tx_outs, "tx_outs")?;
         let bogo_size = crate::to_u32(self.bogo_size, "bogo_size")?;
         let disk_size = self.disk_size.map(|v| crate::to_u32(v, "disk_size")).transpose()?;
-        let total_amount = Amount::from_btc(self.total_amount).map_err(E::TotalAmount)?;
+        let total_amount =
+            crate::stable_amount_from_btc(self.total_amount).map_err(E::TotalAmount)?;
         let total_unspendable_amount = self
             .total_unspendable_amount
-            .map(|v| Amount::from_btc(v).map_err(E::TotalUnspendableAmount))
+            .map(|v| crate::stable_amount_from_btc(v).map_err(E::TotalUnspendableAmount))
             .transpose()?;
         let block_info = match self.block_info {
             Some(b) => {
-                let prevout_spent = Amount::from_btc(b.prevout_spent).map_err(E::PrevoutSpent)?;
-                let coinbase = Amount::from_btc(b.coinbase).map_err(E::Coinbase)?;
+                let prevout_spent =
+                    crate::stable_amount_from_btc(b.prevout_spent).map_err(E::PrevoutSpent)?;
+                let coinbase = crate::stable_amount_from_btc(b.coinbase).map_err(E::Coinbase)?;
                 let new_outputs_ex_coinbase =
-                    Amount::from_btc(b.new_outputs_ex_coinbase).map_err(E::NewOutputsExCoinbase)?;
-                let unspendable = Amount::from_btc(b.unspendable).map_err(E::Unspendable)?;
+                    crate::stable_amount_from_btc(b.new_outputs_ex_coinbase)
+                        .map_err(E::NewOutputsExCoinbase)?;
+                let unspendable =
+                    crate::stable_amount_from_btc(b.unspendable).map_err(E::Unspendable)?;
                 let unspendables = model::GetTxOutSetInfoUnspendables {
-                    genesis_block: Amount::from_btc(b.unspendables.genesis_block)
+                    genesis_block: crate::stable_amount_from_btc(b.unspendables.genesis_block)
                         .map_err(E::UnspendablesGenesisBlock)?,
-                    bip30: Amount::from_btc(b.unspendables.bip30).map_err(E::UnspendablesBip30)?,
-                    scripts: Amount::from_btc(b.unspendables.scripts)
+                    bip30: crate::stable_amount_from_btc(b.unspendables.bip30)
+                        .map_err(E::UnspendablesBip30)?,
+                    scripts: crate::stable_amount_from_btc(b.unspendables.scripts)
                         .map_err(E::UnspendablesScripts)?,
-                    unclaimed_rewards: Amount::from_btc(b.unspendables.unclaimed_rewards)
-                        .map_err(E::UnspendablesUnclaimedRewards)?,
+                    unclaimed_rewards: crate::stable_amount_from_btc(
+                        b.unspendables.unclaimed_rewards,
+                    )
+                    .map_err(E::UnspendablesUnclaimedRewards)?,
                 };
 
                 Some(model::GetTxOutSetInfoBlockInfo {
@@ -134,7 +142,8 @@ impl LoadTxOutSet {
 
         let tip_hash = self.tip_hash.parse::<BlockHash>().map_err(E::TipHash)?;
         let base_height = crate::to_u32(self.base_height, "base_height")?;
-        let coins_loaded = Amount::from_btc(self.coins_loaded).map_err(E::CoinsLoaded)?;
+        let coins_loaded =
+            crate::stable_amount_from_btc(self.coins_loaded).map_err(E::CoinsLoaded)?;
 
         Ok(model::LoadTxOutSet { coins_loaded, tip_hash, base_height, path: self.path })
     }

--- a/types/src/v26/mining.rs
+++ b/types/src/v26/mining.rs
@@ -6,7 +6,7 @@
 
 use std::collections::BTreeMap;
 
-use bitcoin::{hex, SignedAmount, Txid};
+use bitcoin::{hex, Txid};
 use serde::{Deserialize, Serialize};
 
 use crate::model;
@@ -49,7 +49,7 @@ impl PrioritisedTransaction {
     /// Converts version specific type to a version nonspecific, more strongly typed type.
     pub fn into_model(self) -> model::PrioritisedTransaction {
         model::PrioritisedTransaction {
-            fee_delta: SignedAmount::from_sat(self.fee_delta),
+            fee_delta: bitcoin::SignedAmount::from_sat(self.fee_delta),
             in_mempool: self.in_mempool,
             modified_fee: None,
         }

--- a/types/src/v26/raw_transactions/into.rs
+++ b/types/src/v26/raw_transactions/into.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-use bitcoin::{consensus, Amount, Psbt, Txid, Wtxid};
+use bitcoin::{consensus, Psbt, Txid, Wtxid};
 
 // TODO: Use explicit imports?
 use super::*;
@@ -68,7 +68,7 @@ impl SubmitPackageTxResultFees {
     ) -> Result<model::SubmitPackageTxResultFees, SubmitPackageTxResultFeesError> {
         use SubmitPackageTxResultFeesError as E;
 
-        let base_fee = Amount::from_btc(self.base_fee).map_err(E::BaseFee)?;
+        let base_fee = crate::stable_amount_from_btc(self.base_fee).map_err(E::BaseFee)?;
         let effective_fee_rate = self
             .effective_fee_rate
             .map(|f| crate::btc_per_kb(f).map_err(E::EffectiveFeeRate))

--- a/types/src/v26/wallet/into.rs
+++ b/types/src/v26/wallet/into.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: CC0-1.0
 
 use bitcoin::consensus::encode;
-use bitcoin::{BlockHash, Psbt, SignedAmount, Transaction, Txid};
+use bitcoin::{BlockHash, Psbt, Transaction, Txid};
 
 use super::{
     CreateWallet, GetBalances, GetBalancesError, GetTransaction, GetTransactionError,
@@ -46,8 +46,9 @@ impl GetTransaction {
     pub fn into_model(self) -> Result<model::GetTransaction, GetTransactionError> {
         use GetTransactionError as E;
 
-        let amount = SignedAmount::from_btc(self.amount).map_err(E::Amount)?;
-        let fee = self.fee.map(|fee| SignedAmount::from_btc(fee).map_err(E::Fee)).transpose()?;
+        let amount = bitcoin::SignedAmount::from_btc(self.amount).map_err(E::Amount)?;
+        let fee =
+            self.fee.map(|fee| bitcoin::SignedAmount::from_btc(fee).map_err(E::Fee)).transpose()?;
         let block_hash =
             self.block_hash.map(|s| s.parse::<BlockHash>().map_err(E::BlockHash)).transpose()?;
         let block_index =
@@ -119,11 +120,11 @@ impl GetWalletInfo {
         use GetWalletInfoError as E;
 
         let wallet_version = crate::to_u32(self.wallet_version, "wallet_version")?;
-        let balance = bitcoin::Amount::from_btc(self.balance).map_err(E::Balance)?;
-        let unconfirmed_balance =
-            bitcoin::Amount::from_btc(self.unconfirmed_balance).map_err(E::UnconfirmedBalance)?;
+        let balance = crate::stable_amount_from_btc(self.balance).map_err(E::Balance)?;
+        let unconfirmed_balance = crate::stable_amount_from_btc(self.unconfirmed_balance)
+            .map_err(E::UnconfirmedBalance)?;
         let immature_balance =
-            bitcoin::Amount::from_btc(self.immature_balance).map_err(E::ImmatureBalance)?;
+            crate::stable_amount_from_btc(self.immature_balance).map_err(E::ImmatureBalance)?;
         let tx_count = crate::to_u32(self.tx_count, "tx_count")?;
         let keypool_oldest =
             self.keypool_oldest.map(|v| crate::to_u32(v, "keypool_oldest")).transpose()?;

--- a/types/src/v27/mining.rs
+++ b/types/src/v27/mining.rs
@@ -6,7 +6,7 @@
 
 use std::collections::BTreeMap;
 
-use bitcoin::{hex, SignedAmount, Txid};
+use bitcoin::{hex, Txid};
 use serde::{Deserialize, Serialize};
 
 use crate::model;
@@ -51,9 +51,9 @@ impl PrioritisedTransaction {
     /// Converts version specific type to a version nonspecific, more strongly typed type.
     pub fn into_model(self) -> model::PrioritisedTransaction {
         model::PrioritisedTransaction {
-            fee_delta: SignedAmount::from_sat(self.fee_delta),
+            fee_delta: bitcoin::SignedAmount::from_sat(self.fee_delta),
             in_mempool: self.in_mempool,
-            modified_fee: self.modified_fee.map(SignedAmount::from_sat),
+            modified_fee: self.modified_fee.map(bitcoin::SignedAmount::from_sat),
         }
     }
 }

--- a/types/src/v28/blockchain/into.rs
+++ b/types/src/v28/blockchain/into.rs
@@ -2,7 +2,7 @@
 
 use alloc::collections::BTreeMap;
 
-use bitcoin::{Amount, BlockHash, Network, ScriptBuf, Txid, Work};
+use bitcoin::{BlockHash, Network, ScriptBuf, Txid, Work};
 
 use super::{
     GetBlockchainInfo, GetBlockchainInfoError, ScanTxOutSetError, ScanTxOutSetStart,
@@ -61,7 +61,8 @@ impl ScanTxOutSetStart {
         let unspents =
             self.unspents.into_iter().map(|u| u.into_model()).collect::<Result<Vec<_>, _>>()?;
 
-        let total_amount = Amount::from_btc(self.total_amount).map_err(E::TotalAmount)?;
+        let total_amount =
+            crate::stable_amount_from_btc(self.total_amount).map_err(E::TotalAmount)?;
 
         Ok(model::ScanTxOutSetStart {
             success: self.success,
@@ -80,7 +81,7 @@ impl ScanTxOutSetUnspent {
         use ScanTxOutSetError as E;
 
         let txid = self.txid.parse::<Txid>().map_err(E::Txid)?;
-        let amount = Amount::from_btc(self.amount).map_err(E::Amount)?;
+        let amount = crate::stable_amount_from_btc(self.amount).map_err(E::Amount)?;
         let script_pubkey = ScriptBuf::from_hex(&self.script_pubkey).map_err(E::ScriptPubKey)?;
         let block_hash = self.block_hash.parse::<BlockHash>().map_err(E::BlockHash)?;
 

--- a/types/src/v28/raw_transactions/into.rs
+++ b/types/src/v28/raw_transactions/into.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-use bitcoin::{Amount, Txid, Wtxid};
+use bitcoin::{Txid, Wtxid};
 
 // TODO: Use explicit imports?
 use super::*;
@@ -53,7 +53,7 @@ impl SubmitPackageTxResultFees {
     ) -> Result<model::SubmitPackageTxResultFees, SubmitPackageTxResultFeesError> {
         use SubmitPackageTxResultFeesError as E;
 
-        let base_fee = Amount::from_btc(self.base_fee).map_err(E::BaseFee)?;
+        let base_fee = crate::stable_amount_from_btc(self.base_fee).map_err(E::BaseFee)?;
         let effective_fee_rate = self
             .effective_fee_rate
             .map(|f| crate::btc_per_kb(f).map_err(E::EffectiveFeeRate))

--- a/types/src/v28/wallet/into.rs
+++ b/types/src/v28/wallet/into.rs
@@ -5,8 +5,7 @@ use bitcoin::hashes::hash160;
 use bitcoin::hex::FromHex;
 use bitcoin::key::PublicKey;
 use bitcoin::{
-    bip32, Address, BlockHash, ScriptBuf, SignedAmount, Transaction, Txid, WitnessProgram,
-    WitnessVersion,
+    bip32, Address, BlockHash, ScriptBuf, Transaction, Txid, WitnessProgram, WitnessVersion,
 };
 
 use super::{
@@ -188,8 +187,9 @@ impl GetTransaction {
     pub fn into_model(self) -> Result<model::GetTransaction, GetTransactionError> {
         use GetTransactionError as E;
 
-        let amount = SignedAmount::from_btc(self.amount).map_err(E::Amount)?;
-        let fee = self.fee.map(|fee| SignedAmount::from_btc(fee).map_err(E::Fee)).transpose()?;
+        let amount = bitcoin::SignedAmount::from_btc(self.amount).map_err(E::Amount)?;
+        let fee =
+            self.fee.map(|fee| bitcoin::SignedAmount::from_btc(fee).map_err(E::Fee)).transpose()?;
         let block_hash =
             self.block_hash.map(|s| s.parse::<BlockHash>().map_err(E::BlockHash)).transpose()?;
         let block_index =
@@ -284,13 +284,13 @@ impl TransactionItem {
         let address =
             self.address.map(|s| s.parse::<Address<_>>().map_err(E::Address)).transpose()?;
         let category = self.category.into_model();
-        let amount = SignedAmount::from_btc(self.amount).map_err(E::Amount)?;
+        let amount = bitcoin::SignedAmount::from_btc(self.amount).map_err(E::Amount)?;
         let vout = crate::to_u32(self.vout, "vout")?;
         let fee = self
             .fee
-            .map(|f| SignedAmount::from_btc(f).map_err(E::Fee))
+            .map(|f| bitcoin::SignedAmount::from_btc(f).map_err(E::Fee))
             .transpose()? // optional historically
-            .unwrap_or_else(|| SignedAmount::from_sat(0));
+            .unwrap_or_else(|| bitcoin::SignedAmount::from_sat(0));
         let block_hash =
             self.block_hash.map(|s| s.parse::<BlockHash>().map_err(E::BlockHash)).transpose()?;
         let block_height =

--- a/types/src/v29/blockchain/into.rs
+++ b/types/src/v29/blockchain/into.rs
@@ -5,8 +5,8 @@ use alloc::collections::BTreeMap;
 use bitcoin::consensus::encode;
 use bitcoin::hashes::hex::FromHex;
 use bitcoin::{
-    absolute, block, hex, transaction, Amount, BlockHash, CompactTarget, Network, ScriptBuf,
-    Target, Transaction, TxMerkleNode, Txid, Weight, Work,
+    absolute, block, hex, transaction, BlockHash, CompactTarget, Network, ScriptBuf, Target,
+    Transaction, TxMerkleNode, Txid, Weight, Work,
 };
 
 // TODO: Use explicit imports?
@@ -84,7 +84,8 @@ impl GetBlockVerboseTwo {
             .into_iter()
             .map(|entry| {
                 let transaction = entry.transaction.into_model().map_err(E::Transaction)?;
-                let fee = entry.fee.map(Amount::from_btc).transpose().map_err(E::Fee)?;
+                let fee =
+                    entry.fee.map(crate::stable_amount_from_btc).transpose().map_err(E::Fee)?;
                 Ok(model::GetBlockVerboseTwoTransaction { transaction, fee })
             })
             .collect::<Result<Vec<_>, E>>()?;
@@ -149,7 +150,8 @@ impl GetRawTransactionVerboseWithPrevout {
                 .map(|prevout| {
                     let height = crate::to_u32(prevout.height, "prevout.height")
                         .map_err(E::PrevoutHeight)?;
-                    let value = Amount::from_btc(prevout.value).map_err(E::PrevoutValue)?;
+                    let value =
+                        crate::stable_amount_from_btc(prevout.value).map_err(E::PrevoutValue)?;
                     let script_pubkey =
                         prevout.script_pubkey.into_model().map_err(E::PrevoutScriptPubKey)?;
                     Ok::<model::GetBlockVerboseThreePrevout, GetBlockVerboseThreeError>(
@@ -212,7 +214,8 @@ impl GetBlockVerboseThree {
             .into_iter()
             .map(|entry| {
                 let (transaction, prevouts) = entry.transaction.into_model_with_prevouts()?;
-                let fee = entry.fee.map(Amount::from_btc).transpose().map_err(E::Fee)?;
+                let fee =
+                    entry.fee.map(crate::stable_amount_from_btc).transpose().map_err(E::Fee)?;
                 Ok(model::GetBlockVerboseThreeTransaction { transaction, prevouts, fee })
             })
             .collect::<Result<Vec<_>, E>>()?;
@@ -405,7 +408,8 @@ impl GetDescriptorActivity {
             .map(|entry| -> Result<model::ActivityEntry, GetDescriptorActivityError> {
                 match entry {
                     ActivityEntry::Spend(spend) => {
-                        let amount = Amount::from_btc(spend.amount).map_err(E::Amount)?;
+                        let amount =
+                            crate::stable_amount_from_btc(spend.amount).map_err(E::Amount)?;
                         let block_hash = spend
                             .block_hash
                             .map(|s| s.parse::<BlockHash>())
@@ -430,7 +434,8 @@ impl GetDescriptorActivity {
                         }))
                     }
                     ActivityEntry::Receive(receive) => {
-                        let amount = Amount::from_btc(receive.amount).map_err(E::Amount)?;
+                        let amount =
+                            crate::stable_amount_from_btc(receive.amount).map_err(E::Amount)?;
                         let block_hash = receive
                             .block_hash
                             .map(|s| s.parse::<BlockHash>())

--- a/types/src/v29/raw_transactions/into.rs
+++ b/types/src/v29/raw_transactions/into.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-use bitcoin::{Amount, Txid, Wtxid};
+use bitcoin::{Txid, Wtxid};
 
 use super::{MempoolAcceptance, MempoolAcceptanceError, TestMempoolAccept, TestMempoolAcceptError};
 use crate::model;
@@ -43,7 +43,7 @@ impl MempoolAcceptance {
                     .flatten();
 
                 Ok::<_, MempoolAcceptanceError>(model::MempoolAcceptanceFees {
-                    base: Amount::from_btc(s.base).map_err(E::Base)?,
+                    base: crate::stable_amount_from_btc(s.base).map_err(E::Base)?,
                     effective_fee_rate,
                     effective_includes,
                 })

--- a/types/src/v30/raw_transactions/into.rs
+++ b/types/src/v30/raw_transactions/into.rs
@@ -9,7 +9,7 @@ use bitcoin::psbt::{self, raw, PsbtSighashType};
 use bitcoin::taproot::{
     ControlBlock, LeafVersion, TapLeafHash, TapNodeHash, TapTree, TaprootBuilder,
 };
-use bitcoin::{Amount, ScriptBuf, XOnlyPublicKey};
+use bitcoin::{ScriptBuf, XOnlyPublicKey};
 
 use super::{
     taproot, ControlBlocksError, DecodePsbt, DecodePsbtError, GlobalXpub, GlobalXpubError,
@@ -72,7 +72,7 @@ impl DecodePsbt {
             inputs,
             outputs,
         };
-        let fee = self.fee.map(Amount::from_btc).transpose().map_err(E::Fee)?;
+        let fee = self.fee.map(crate::stable_amount_from_btc).transpose().map_err(E::Fee)?;
 
         Ok(model::DecodePsbt { psbt, fee })
     }

--- a/types/src/v31/blockchain/into.rs
+++ b/types/src/v31/blockchain/into.rs
@@ -4,8 +4,8 @@ use alloc::collections::BTreeMap;
 
 use bitcoin::consensus::encode;
 use bitcoin::{
-    absolute, block, transaction, Amount, BlockHash, CompactTarget, OutPoint, ScriptBuf, Sequence,
-    Target, Transaction, TxMerkleNode, Txid, Weight, Work, Wtxid,
+    absolute, block, transaction, BlockHash, CompactTarget, OutPoint, ScriptBuf, Target,
+    Transaction, TxMerkleNode, Txid, Weight, Work, Wtxid,
 };
 
 use super::{
@@ -34,7 +34,7 @@ impl GetMempoolCluster {
                 .map(|txid| txid.parse::<Txid>())
                 .collect::<Result<Vec<_>, _>>()
                 .map_err(E::Txid)?;
-            let chunk_fee = Amount::from_btc(chunk.chunk_fee).map_err(E::ChunkFee)?;
+            let chunk_fee = crate::stable_amount_from_btc(chunk.chunk_fee).map_err(E::ChunkFee)?;
             chunks.push(model::Chunk { chunk_fee, chunk_weight: chunk.chunk_weight, txs })
         }
 
@@ -109,11 +109,11 @@ impl MempoolEntryFees {
     pub fn into_model(self) -> Result<model::MempoolEntryFees, MempoolEntryFeesError> {
         use MempoolEntryFeesError as E;
 
-        let base = Amount::from_btc(self.base).map_err(E::Base)?;
-        let modified = Amount::from_btc(self.modified).map_err(E::Modified)?;
-        let ancestor = Amount::from_btc(self.ancestor).map_err(E::Ancestor)?;
-        let descendant = Amount::from_btc(self.descendant).map_err(E::Descendant)?;
-        let chunk = Some(Amount::from_btc(self.chunk).map_err(E::Chunk)?);
+        let base = crate::stable_amount_from_btc(self.base).map_err(E::Base)?;
+        let modified = crate::stable_amount_from_btc(self.modified).map_err(E::Modified)?;
+        let ancestor = crate::stable_amount_from_btc(self.ancestor).map_err(E::Ancestor)?;
+        let descendant = crate::stable_amount_from_btc(self.descendant).map_err(E::Descendant)?;
+        let chunk = Some(crate::stable_amount_from_btc(self.chunk).map_err(E::Chunk)?);
 
         Ok(model::MempoolEntryFees { base, modified, ancestor, descendant, chunk })
     }
@@ -211,7 +211,7 @@ impl GetMempoolFeerateDiagram {
         let mut entries = vec![];
         for entry in self.0 {
             let weight = crate::to_u64(entry.weight, "weight")?;
-            let fee = Amount::from_btc(entry.fee).map_err(E::Fee)?;
+            let fee = crate::stable_amount_from_btc(entry.fee).map_err(E::Fee)?;
             entries.push(model::FeerateDiagramEntry { weight, fee });
         }
         Ok(model::GetMempoolFeerateDiagram(entries))
@@ -281,7 +281,7 @@ impl CoinbaseTransaction {
             .map_err(E::Witness)?;
         let version = transaction::Version::non_standard(self.version);
         let locktime = absolute::LockTime::from_consensus(self.locktime);
-        let sequence = Sequence::from_consensus(self.sequence);
+        let sequence = crate::stable_sequence(bitcoin::Sequence::from_consensus(self.sequence));
 
         Ok(model::CoinbaseTransaction { version, locktime, sequence, coinbase, witness })
     }
@@ -365,7 +365,8 @@ impl GetBlockVerboseTwo {
             .into_iter()
             .map(|entry| {
                 let transaction = entry.transaction.into_model().map_err(E::Transaction)?;
-                let fee = entry.fee.map(Amount::from_btc).transpose().map_err(E::Fee)?;
+                let fee =
+                    entry.fee.map(crate::stable_amount_from_btc).transpose().map_err(E::Fee)?;
                 Ok(model::GetBlockVerboseTwoTransaction { transaction, fee })
             })
             .collect::<Result<Vec<_>, E>>()?;
@@ -432,7 +433,8 @@ impl GetBlockVerboseThree {
             .map(|entry| {
                 let (transaction, prevouts) =
                     entry.transaction.into_model_with_prevouts().map_err(E::Transaction)?;
-                let fee = entry.fee.map(Amount::from_btc).transpose().map_err(E::Fee)?;
+                let fee =
+                    entry.fee.map(crate::stable_amount_from_btc).transpose().map_err(E::Fee)?;
                 Ok(model::GetBlockVerboseThreeTransaction { transaction, prevouts, fee })
             })
             .collect::<Result<Vec<_>, E>>()?;


### PR DESCRIPTION
Depend on the rust-bitcoin compat-layer branch and switch the model layer to stable Amount and Sequence types while preserving the client request helper ergonomics around native bitcoin primitives.

Assisted-by: GPT-5.4