### PR TITLE
Add migration banner to all readme files

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,3 +1,11 @@
+> [!IMPORTANT]
+> **This repository has moved.** Active development is now on rust-bitcoin Forgejo:
+>
+> ### [git.rust-bitcoin.org/rust-bitcoin/corepc](https://git.rust-bitcoin.org/rust-bitcoin/corepc)
+>
+> This GitHub repository is **no longer maintained here**.
+> Please open all issues and pull requests on the new site.
+
 # corepc workflow notes
 
 Because there are so many integration test jobs (one for each version

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+> [!IMPORTANT]
+> **This repository has moved.** Active development is now on rust-bitcoin Forgejo:
+>
+> ### [git.rust-bitcoin.org/rust-bitcoin/corepc](https://git.rust-bitcoin.org/rust-bitcoin/corepc)
+>
+> This GitHub repository is **no longer maintained here**.
+> Please open all issues and pull requests on the new site.
+
 # Bitcoin Core JSON-RPC support
 
 There are two primary purposes of this repository:

--- a/bitcoind/README.md
+++ b/bitcoind/README.md
@@ -1,3 +1,11 @@
+> [!IMPORTANT]
+> **This repository has moved.** Active development is now on rust-bitcoin Forgejo:
+>
+> ### [git.rust-bitcoin.org/rust-bitcoin/corepc](https://git.rust-bitcoin.org/rust-bitcoin/corepc)
+>
+> This GitHub repository is **no longer maintained here**.
+> Please open all issues and pull requests on the new site.
+
 # Bitcoind
 
 Utility to run a regtest bitcoind process, useful in integration testing environment.

--- a/bitreq/README.md
+++ b/bitreq/README.md
@@ -1,3 +1,11 @@
+> [!IMPORTANT]
+> **This repository has moved.** Active development is now on rust-bitcoin Forgejo:
+>
+> ### [git.rust-bitcoin.org/rust-bitcoin/corepc](https://git.rust-bitcoin.org/rust-bitcoin/corepc)
+>
+> This GitHub repository is **no longer maintained here**.
+> Please open all issues and pull requests on the new site.
+
 # bitreq - forked from minreq
 [![Crates.io](https://img.shields.io/crates/d/bitreq.svg)](https://crates.io/crates/bitreq)
 [![Documentation](https://docs.rs/bitreq/badge.svg)](https://docs.rs/bitreq)

--- a/bitreq/fuzz/README.md
+++ b/bitreq/fuzz/README.md
@@ -1,3 +1,11 @@
+> [!IMPORTANT]
+> **This repository has moved.** Active development is now on rust-bitcoin Forgejo:
+>
+> ### [git.rust-bitcoin.org/rust-bitcoin/corepc](https://git.rust-bitcoin.org/rust-bitcoin/corepc)
+>
+> This GitHub repository is **no longer maintained here**.
+> Please open all issues and pull requests on the new site.
+
 # Fuzzing bitreq
 
 This directory contains fuzzing infrastructure for the `bitreq` crate, specifically targeting the `Url` parser.

--- a/client/README.md
+++ b/client/README.md
@@ -1,3 +1,11 @@
+> [!IMPORTANT]
+> **This repository has moved.** Active development is now on rust-bitcoin Forgejo:
+>
+> ### [git.rust-bitcoin.org/rust-bitcoin/corepc](https://git.rust-bitcoin.org/rust-bitcoin/corepc)
+>
+> This GitHub repository is **no longer maintained here**.
+> Please open all issues and pull requests on the new site.
+
 # corepc-client
 
 Rust client for the Bitcoin Core daemon's JSON-RPC API.

--- a/electrsd/README.md
+++ b/electrsd/README.md
@@ -1,3 +1,11 @@
+> [!IMPORTANT]
+> **This repository has moved.** Active development is now on rust-bitcoin Forgejo:
+>
+> ### [git.rust-bitcoin.org/rust-bitcoin/corepc](https://git.rust-bitcoin.org/rust-bitcoin/corepc)
+>
+> This GitHub repository is **no longer maintained here**.
+> Please open all issues and pull requests on the new site.
+
 [![MIT license](https://img.shields.io/github/license/RCasatta/electrsd)](https://github.com/RCasatta/electrsd/blob/master/LICENSE)
 [![Crates](https://img.shields.io/crates/v/electrsd.svg)](https://crates.io/crates/electrsd)
 

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,3 +1,11 @@
+> [!IMPORTANT]
+> **This repository has moved.** Active development is now on rust-bitcoin Forgejo:
+>
+> ### [git.rust-bitcoin.org/rust-bitcoin/corepc](https://git.rust-bitcoin.org/rust-bitcoin/corepc)
+>
+> This GitHub repository is **no longer maintained here**.
+> Please open all issues and pull requests on the new site.
+
 # Note to devs
 
 If you are considering adding fuzzing for the other crates take a look

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -1,3 +1,11 @@
+> [!IMPORTANT]
+> **This repository has moved.** Active development is now on rust-bitcoin Forgejo:
+>
+> ### [git.rust-bitcoin.org/rust-bitcoin/corepc](https://git.rust-bitcoin.org/rust-bitcoin/corepc)
+>
+> This GitHub repository is **no longer maintained here**.
+> Please open all issues and pull requests on the new site.
+
 # Integration testing
 
 This crate is used to run tests against all the supported versions of

--- a/jsonrpc/README.md
+++ b/jsonrpc/README.md
@@ -1,3 +1,11 @@
+> [!IMPORTANT]
+> **This repository has moved.** Active development is now on rust-bitcoin Forgejo:
+>
+> ### [git.rust-bitcoin.org/rust-bitcoin/corepc](https://git.rust-bitcoin.org/rust-bitcoin/corepc)
+>
+> This GitHub repository is **no longer maintained here**.
+> Please open all issues and pull requests on the new site.
+
 [![Status](https://travis-ci.org/apoelstra/rust-jsonrpc.png?branch=master)](https://travis-ci.org/apoelstra/rust-jsonrpc)
 
 # Rust Version compatibility

--- a/types/README.md
+++ b/types/README.md
@@ -1,3 +1,11 @@
+> [!IMPORTANT]
+> **This repository has moved.** Active development is now on rust-bitcoin Forgejo:
+>
+> ### [git.rust-bitcoin.org/rust-bitcoin/corepc](https://git.rust-bitcoin.org/rust-bitcoin/corepc)
+>
+> This GitHub repository is **no longer maintained here**.
+> Please open all issues and pull requests on the new site.
+
 # Bitcoin Core JSON-RPC types
 
 This crate provides data types returned by Bitcoin Core's JSON-RPC API. Each type is specific to the

--- a/types/src/psbt/README.md
+++ b/types/src/psbt/README.md
@@ -1,3 +1,11 @@
+> [!IMPORTANT]
+> **This repository has moved.** Active development is now on rust-bitcoin Forgejo:
+>
+> ### [git.rust-bitcoin.org/rust-bitcoin/corepc](https://git.rust-bitcoin.org/rust-bitcoin/corepc)
+>
+> This GitHub repository is **no longer maintained here**.
+> Please open all issues and pull requests on the new site.
+
 # PSBT
 
 A bunch of types and conversion code for supporting PSBTs (and

--- a/verify/README.md
+++ b/verify/README.md
@@ -1,3 +1,11 @@
+> [!IMPORTANT]
+> **This repository has moved.** Active development is now on rust-bitcoin Forgejo:
+>
+> ### [git.rust-bitcoin.org/rust-bitcoin/corepc](https://git.rust-bitcoin.org/rust-bitcoin/corepc)
+>
+> This GitHub repository is **no longer maintained here**.
+> Please open all issues and pull requests on the new site.
+
 # Verify
 
 TL;DR: `cargo run -- --help`


### PR DESCRIPTION
Now development has moved to forgejo add a banner to all readme files that this GitHub version is no longer maintained.

It renders like this:
<img width="2282" height="650" alt="image" src="https://github.com/user-attachments/assets/76097f3c-f77f-417d-9503-3c93153d7df6" />
